### PR TITLE
feat: rename project from prism-dlmm to prism-liquidity-agent

### DIFF
--- a/.omo/boulder.json
+++ b/.omo/boulder.json
@@ -4,7 +4,7 @@
   "works": {
     "github-issues-from-dump-434f7fc3": {
       "work_id": "github-issues-from-dump-434f7fc3",
-      "active_plan": "/Users/irfandi/Coding/2026/prism-dlmm/.omo/plans/github-issues-from-dump.md",
+      "active_plan": "/Users/irfandi/Coding/2026/prism-liquidity-agent/.omo/plans/github-issues-from-dump.md",
       "plan_name": "github-issues-from-dump",
       "status": "completed",
       "started_at": "2026-06-02T08:40:30.154Z",
@@ -21,7 +21,7 @@
       "elapsed_ms": 198322
     }
   },
-  "active_plan": "/Users/irfandi/Coding/2026/prism-dlmm/.omo/plans/github-issues-from-dump.md",
+  "active_plan": "/Users/irfandi/Coding/2026/prism-liquidity-agent/.omo/plans/github-issues-from-dump.md",
   "started_at": "2026-06-02T08:40:30.154Z",
   "status": "completed",
   "updated_at": "2026-06-02T08:43:48.489Z",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Notes for OpenCode sessions working in `prism-dlmm`. Read this before touching the codebase — several things in `README.md`, `CLAUDE.md`, `ARCHITECTURE.md`, and `CONTRIBUTING.md` are stale or wrong.
+Notes for OpenCode sessions working in `prism-liquidity-agent`. Read this before touching the codebase — several things in `README.md`, `CLAUDE.md`, `ARCHITECTURE.md`, and `CONTRIBUTING.md` are stale or wrong.
 
 ## Stack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@
 ## Setup
 
 ```bash
-git clone https://github.com/irfndi/prism-dlmm
-cd prism-dlmm
+git clone https://github.com/irfndi/prism-liquidity-agent
+cd prism-liquidity-agent
 bun install
 bun run setup          # interactive .env wizard
 docker-compose up chromadb -d

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Runtime](https://img.shields.io/badge/runtime-Bun_1.4-black)
 ![Chain](https://img.shields.io/badge/chain-Solana-9945FF)
 
-An autonomous liquidity agent that watches Meteora DLMM pools, reasons over live on-chain data, and rebalances positions before they bleed.
+An autonomous liquidity agent that watches liquidity pools on Solana (currently Meteora DLMM), reasons over live on-chain data, and rebalances positions before they bleed.
 
 ## What it does
 
@@ -38,8 +38,8 @@ Before any decision, the agent scores each pool's volume on a 0-1 scale. Volume/
 ## Quickstart
 
 ```bash
-git clone https://github.com/irfndi/prism-dlmm
-cd prism-dlmm
+git clone https://github.com/irfndi/prism-liquidity-agent
+cd prism-liquidity-agent
 bun install
 bun run setup            # interactive .env wizard
 bun run dev              # paper trading by default

--- a/cli/support.ts
+++ b/cli/support.ts
@@ -11,7 +11,7 @@ export const issueCommand = new Command("issue")
 export const supportCommand = new Command("support")
   .description("Get support contact info")
   .action(() => {
-    console.log("Docs: https://github.com/irfndi/prism-dlmm/tree/main/docs");
-    console.log("Issues: https://github.com/irfndi/prism-dlmm/issues");
+    console.log("Docs: https://github.com/irfndi/prism-liquidity-agent/tree/main/docs");
+    console.log("Issues: https://github.com/irfndi/prism-liquidity-agent/issues");
     console.log("Telegram: @prism_dlmm_bot");
   });

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@prism-dlmm/cloudflare",
+  "name": "@prism-liquidity-agent/cloudflare",
   "version": "1.0.0",
   "description": "Cloudflare Workers for Prism DLMM platform",
   "type": "module",

--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -335,7 +335,7 @@ app.post("/v1/issue", async (c) => {
     return c.json({ error: "Title required" }, 400);
   }
 
-  const repo = GITHUB_REPO || "irfndi/prism-dlmm";
+  const repo = GITHUB_REPO || "irfndi/prism-liquidity-agent";
 
   try {
     // Create GitHub issue

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -173,7 +173,7 @@ File an issue to the Prism GitHub repo.
 
 ```bash
 prism issue "Getting timeout on pool fetch"
-# Output: Issue #42 created — https://github.com/irfndi/prism-dlmm/issues/42
+# Output: Issue #42 created — https://github.com/irfndi/prism-liquidity-agent/issues/42
 ```
 
 ### `prism support`
@@ -183,8 +183,8 @@ Get support contact info.
 ```bash
 prism support
 # Output:
-# Docs: https://github.com/irfndi/prism-dlmm/tree/main/docs
-# Issues: https://github.com/irfndi/prism-dlmm/issues
+# Docs: https://github.com/irfndi/prism-liquidity-agent/tree/main/docs
+# Issues: https://github.com/irfndi/prism-liquidity-agent/issues
 # Telegram: @prism_dlmm_bot
 ```
 

--- a/docs/cron-examples.md
+++ b/docs/cron-examples.md
@@ -11,13 +11,13 @@ Run Prism unattended on a schedule.
 crontab -e
 
 # Add line:
-*/10 * * * * cd /path/to/prism-dlmm && bun run dev >> /var/log/prism.log 2>&1
+*/10 * * * * cd /path/to/prism-liquidity-agent && bun run dev >> /var/log/prism.log 2>&1
 ```
 
 ### Every hour (conservative)
 
 ```bash
-0 * * * * cd /path/to/prism-dlmm && bun run dev >> /var/log/prism.log 2>&1
+0 * * * * cd /path/to/prism-liquidity-agent && bun run dev >> /var/log/prism.log 2>&1
 ```
 
 ### With log rotation
@@ -52,7 +52,7 @@ Create `~/Library/LaunchAgents/com.prism.dlmm.plist`:
         <string>dev</string>
     </array>
     <key>WorkingDirectory</key>
-    <string>/path/to/prism-dlmm</string>
+    <string>/path/to/prism-liquidity-agent</string>
     <key>StartInterval</key>
     <integer>600</integer>
     <key>StandardOutPath</key>
@@ -72,7 +72,7 @@ launchctl start com.prism.dlmm
 
 ## Systemd (Linux)
 
-Create `/etc/systemd/system/prism-dlmm.service`:
+Create `/etc/systemd/system/prism-liquidity-agent.service`:
 
 ```ini
 [Unit]
@@ -82,7 +82,7 @@ After=network.target
 [Service]
 Type=simple
 User=prism
-WorkingDirectory=/path/to/prism-dlmm
+WorkingDirectory=/path/to/prism-liquidity-agent
 ExecStart=/usr/local/bin/bun run dev
 Restart=always
 RestartSec=600
@@ -97,8 +97,8 @@ Enable and start:
 
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable prism-dlmm
-sudo systemctl start prism-dlmm
+sudo systemctl enable prism-liquidity-agent
+sudo systemctl start prism-liquidity-agent
 ```
 
 ## Docker (Optional)
@@ -112,8 +112,8 @@ CMD ["bun", "run", "dev"]
 ```
 
 ```bash
-docker build -t prism-dlmm .
-docker run -d --env-file .env -v $(pwd)/prism.db:/app/prism.db prism-dlmm
+docker build -t prism-liquidity-agent .
+docker run -d --env-file .env -v $(pwd)/prism.db:/app/prism.db prism-liquidity-agent
 ```
 
 ## Monitoring
@@ -128,5 +128,5 @@ ps aux | grep "bun run dev"
 launchctl list | grep com.prism.dlmm
 
 # Systemd
-sudo systemctl status prism-dlmm
+sudo systemctl status prism-liquidity-agent
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,8 +11,8 @@
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/irfndi/prism-dlmm.git
-cd prism-dlmm
+git clone https://github.com/irfndi/prism-liquidity-agent.git
+cd prism-liquidity-agent
 
 # 2. Install dependencies
 bun install
@@ -32,8 +32,8 @@ prism dev
 ### 1. Clone and Install
 
 ```bash
-git clone https://github.com/irfndi/prism-dlmm.git
-cd prism-dlmm
+git clone https://github.com/irfndi/prism-liquidity-agent.git
+cd prism-liquidity-agent
 bun install
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "prism-dlmm",
+  "name": "prism-liquidity-agent",
   "version": "1.0.0",
-  "description": "Autonomous DLMM rebalancing agent for Meteora pools on Solana",
+  "description": "Autonomous liquidity agent for Solana pools (currently Meteora DLMM)",
   "type": "module",
   "bin": {
     "prism": "./cli/index.ts"
@@ -54,7 +54,7 @@
     "defi",
     "rebalancing",
     "autonomous",
-    "mcp",
+    "liquidity",
     "effect-ts"
   ],
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "defi",
     "rebalancing",
     "autonomous",
-    "liquidity",
     "effect-ts"
   ],
   "license": "MIT"


### PR DESCRIPTION
Renames the project to reflect broader vision of supporting multiple liquidity models beyond Meteora DLMM.

## Changes
- Package name: prism-dlmm → prism-liquidity-agent
- Description updated to mention multi-liquidity support
- All documentation URLs updated
- CLI references updated
- Keywords updated (removed 'dlmm', added 'liquidity')

## What was NOT changed
- @meteora-ag/dlmm SDK dependency (external library)
- DLMMStrategy implementation name (will coexist with future strategies)
- Technical DLMM protocol references in docs

Closes #19