### PR TITLE
feat: address issues #28 and #29 — 3-layer docs, error reporting, update resilience

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,9 @@
+version: 1
+
+# GitGuardian configuration — see https://docs.gitguardian.com/ggshield-docs/reference/config
+# Used to suppress false-positive matches in test fixtures.
+
+paths-ignore:
+  # Test files contain synthetic high-entropy strings used to exercise the
+  # redaction logic in engine/error-reporter.ts. They are not real secrets.
+  - "bench/error-reporter.test.ts"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ prism setup --non-interactive --helius-key=$KEY    # configures trading agent
 prism dev                                         # start paper trading
 ```
 
+> **3-Layer Architecture:** Prism has 3 layers — CLI (required, runs locally),
+> API (optional cloud service), and Telegram (optional chat interface).
+> See [`docs/install.md`](docs/install.md) for the breakdown and quickstart options.
+
 ## Stack
 
 - **Runtime**: Bun 1.2+ (dev, tests, build). Node 20+ for Docker.
@@ -43,15 +47,17 @@ prism dev                                         # start paper trading
 ## Repo layout
 
 ```
+
 prism-liquidity-agent/
-├── engine/             Core agent: strategy, adapters, risk, DB, memory, scan loop (flat dir, ~23 files)
-├── cloudflare/         SEPARATE SUBPROJECT. Own package.json, vitest, wrangler config. API + Telegram bot workers
-├── cli/                User-facing CLI (commander). 13 commands: register, login, whoami, wallet, telegram, etc.
-├── ops/                Operational scripts: setup.ts (.env wizard), backtest.ts
-├── bench/              Vitest tests for engine (pure logic only)
-├── docs/               Markdown docs (install, CLI, cron, agent-harness)
-├── types/              Type declarations (bs58)
-└── .github/workflows/  ci.yml (engine) + deploy-cloudflare.yml (workers)
+├── engine/ Core agent: strategy, adapters, risk, DB, memory, scan loop (flat dir, ~23 files)
+├── cloudflare/ SEPARATE SUBPROJECT. Own package.json, vitest, wrangler config. API + Telegram bot workers
+├── cli/ User-facing CLI (commander). 13 commands: register, login, whoami, wallet, telegram, etc.
+├── ops/ Operational scripts: setup.ts (.env wizard), backtest.ts
+├── bench/ Vitest tests for engine (pure logic only)
+├── docs/ Markdown docs (install, CLI, cron, agent-harness)
+├── types/ Type declarations (bs58)
+└── .github/workflows/ ci.yml (engine) + deploy-cloudflare.yml (workers)
+
 ```
 
 **There is no `probes/`, `tools/`, `adapters/`, `risk/`, or `memory/` directory.** `ARCHITECTURE.md`'s component map is fictional. Every engine file is flat in `engine/`.

--- a/bench/error-reporter.test.ts
+++ b/bench/error-reporter.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  createErrorReporter,
+  type ErrorReporter,
+  type ErrorReporterConfig,
+} from "../engine/error-reporter.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Replace globalThis.fetch with a mock suitable for capturing calls
+ * in tests. The returned handle lets you assert on fetch invocations
+ * via the vi.mocked API.
+ */
+function mockFetch(): void {
+  globalThis.fetch = vi.fn() as unknown as typeof globalThis.fetch;
+}
+
+/**
+ * Create a test reporter with sensible defaults.
+ */
+function makeReporter(overrides?: Partial<ErrorReporterConfig>): ErrorReporter {
+  const r = createErrorReporter({
+    endpoint: "https://errors.test.local/report",
+    enabled: true,
+    batchSize: 5,
+    flushIntervalMs: 60_000,
+    ...overrides,
+  });
+  r.setAppVersion("1.0.0-test");
+  return r;
+}
+
+// ─── Setup / Teardown ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockFetch();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Sanitization ────────────────────────────────────────────────────────────
+
+describe("sanitization", () => {
+  it("redacts long base58 strings (≥64 chars, likely private keys)", () => {
+    const r = makeReporter();
+    const longBase58 =
+      "5K3NEQrLEqrEv8PByNoxGmmLXdRNY4hvoM7pBEiCwJFp5K3NEQrLEqrEv8PByNoxGmmLXdRNY4hvoM7pBEiCwJFpXX";
+    const err = new Error(`Connection failed for wallet ${longBase58}`);
+    r.report(err);
+    const pending = r.getPending();
+    expect(pending[0]?.message).not.toContain(longBase58);
+    expect(pending[0]?.message).toContain("[REDACTED]");
+    r.dispose();
+  });
+
+  it("redacts hex private keys (0x-prefixed 64+ hex)", () => {
+    const r = makeReporter();
+    const hexKey = `0x${"a".repeat(64)}`;
+    const err = new Error(`private key: ${hexKey}`);
+    r.report(err);
+    const pending = r.getPending();
+    expect(pending[0]?.message).not.toContain(hexKey);
+    expect(pending[0]?.message).toContain("[REDACTED]");
+    r.dispose();
+  });
+
+  it("redacts raw hex strings 64+ chars", () => {
+    const r = makeReporter();
+    const rawHex = "f".repeat(64);
+    const err = new Error(`Raw hex value ${rawHex} in config`);
+    r.report(err);
+    const pending = r.getPending();
+    expect(pending[0]?.message).not.toContain(rawHex);
+    expect(pending[0]?.message).toContain("[REDACTED]");
+    r.dispose();
+  });
+
+  it("redacts secret_key= / private-key= patterns", () => {
+    const r = makeReporter();
+    const err = new Error("failed auth: private_key=deadbeef1234567890abc");
+    r.report(err);
+    const pending = r.getPending();
+    expect(pending[0]?.message).toContain("[REDACTED]");
+    expect(pending[0]?.message).not.toContain("deadbeef1234567890abc");
+    r.dispose();
+  });
+
+  it("redacts password= patterns", () => {
+    const r = makeReporter();
+    const err = new Error("DB connection: password=supersecret!");
+    r.report(err);
+    const pending = r.getPending();
+    expect(pending[0]?.message).toContain("[REDACTED]");
+    expect(pending[0]?.message).not.toContain("supersecret");
+    r.dispose();
+  });
+
+  it("does NOT redact short base58 strings (e.g. pool addresses, 32-44 chars)", () => {
+    const r = makeReporter();
+    // Solana pool addresses are typically 32-44 base58 chars
+    const poolAddr = "Abcd1234Abcd1234Abcd1234Abcd1234Abcd1234";
+    expect(poolAddr.length).toBeLessThan(64);
+    const err = new Error(`Pool ${poolAddr} error`);
+    r.report(err);
+    const pending = r.getPending();
+    expect(pending[0]?.message).toContain(poolAddr);
+    r.dispose();
+  });
+
+  it("sanitizes stack traces too", () => {
+    const r = makeReporter();
+    // Must be ≥64 base58 chars to trigger redaction
+    const secret =
+      "5K3NEQrLEqrEv8PByNoxGmmLXdRNY4hvoM7pBEiCwJFp5K3NEQrLEqrEv8PByNoxGmmLXdRNY4hvoM7pBEiCwJFp";
+    expect(secret.length).toBeGreaterThanOrEqual(64);
+    const err = new Error("oops");
+    err.stack = `Error: oops\n    at foo (file.ts:10:5)\n    secret=${secret}`;
+    r.report(err);
+    const pending = r.getPending();
+    expect(pending[0]?.stack).toContain("[REDACTED]");
+    expect(pending[0]?.stack).not.toContain(secret);
+    r.dispose();
+  });
+});
+
+// ─── Classification ──────────────────────────────────────────────────────────
+
+describe("classification", () => {
+  it("classifies BigInt serialization errors as ONNX_BigInt", () => {
+    const r = makeReporter();
+    r.report(new Error("Failed to serialize BigInt value in ONNX pipeline"));
+    expect(r.getPending()[0]?.category).toBe("ONNX_BigInt");
+    r.dispose();
+  });
+
+  it("classifies sqlite-vec errors as SQLite_Vec", () => {
+    const r = makeReporter();
+    r.report(new Error("sqlite-vec error: table vec0 not found"));
+    expect(r.getPending()[0]?.category).toBe("SQLite_Vec");
+    r.dispose();
+  });
+
+  it("classifies rate limit errors as RPC_RateLimit", () => {
+    const r = makeReporter();
+    r.report(new Error("Rate limit exceeded: 429 Too Many Requests"));
+    expect(r.getPending()[0]?.category).toBe("RPC_RateLimit");
+    r.dispose();
+  });
+
+  it("classifies Helius errors", () => {
+    const r = makeReporter();
+    r.report(new Error("Helius API key invalid"));
+    expect(r.getPending()[0]?.category).toBe("Helius_Error");
+    r.dispose();
+  });
+
+  it("classifies update/tarball errors as UpdateFailure", () => {
+    const r = makeReporter();
+    r.report(new Error("Failed to download tarball: connection reset"));
+    expect(r.getPending()[0]?.category).toBe("UpdateFailure");
+    r.dispose();
+  });
+
+  it("classifies unknown patterns as Unknown", () => {
+    const r = makeReporter();
+    r.report(new Error("Something completely unexpected happened"));
+    expect(r.getPending()[0]?.category).toBe("Unknown");
+    r.dispose();
+  });
+});
+
+// ─── Buffering ───────────────────────────────────────────────────────────────
+
+describe("buffering", () => {
+  it("accumulates reports in pending buffer", () => {
+    const r = makeReporter();
+    r.report(new Error("err1"));
+    r.report(new Error("err2"));
+    expect(r.getPending()).toHaveLength(2);
+    r.dispose();
+  });
+
+  it("flushes when batch size threshold is reached", async () => {
+    const r = makeReporter({ batchSize: 3 });
+    r.report(new Error("e1"));
+    r.report(new Error("e2"));
+    // Not flushed yet
+    expect(r.getPending()).toHaveLength(2);
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+
+    // Third report triggers flush
+    r.report(new Error("e3"));
+    // Wait for the async flush
+    await new Promise((res) => setTimeout(res, 10));
+    expect(r.getPending()).toHaveLength(0);
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(1);
+    r.dispose();
+  });
+
+  it("flushSync triggers async flush for testability", async () => {
+    const r = makeReporter();
+    r.report(new Error("e1"));
+    r.report(new Error("e2"));
+    expect(r.getPending()).toHaveLength(2);
+
+    r.flushSync();
+    // Wait for the async flush
+    await new Promise((res) => setTimeout(res, 10));
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalled();
+    expect(r.getPending()).toHaveLength(0);
+    r.dispose();
+  });
+
+  it("getPending returns a copy of pending reports", () => {
+    const r = makeReporter();
+    r.report(new Error("e1"));
+    const copy = r.getPending();
+    expect(copy).toHaveLength(1);
+
+    // Mutating the copy should not affect internal state
+    (copy as unknown[]).push({} as never);
+    expect(r.getPending()).toHaveLength(1);
+    r.dispose();
+  });
+});
+
+// ─── No-op mode ──────────────────────────────────────────────────────────────
+
+describe("no-op mode", () => {
+  it("does nothing when PRISM_ERROR_REPORTING=false (enabled: false)", () => {
+    const r = makeReporter({ enabled: false });
+    r.report(new Error("should be ignored"));
+    expect(r.getPending()).toHaveLength(0);
+    r.flushSync();
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it("does nothing when PRISM_ERROR_REPORTING env is 'false'", () => {
+    process.env.PRISM_ERROR_REPORTING = "false";
+    // Create a reporter that reads from env (no explicit enabled override)
+    const r = createErrorReporter({
+      endpoint: "https://errors.test.local/report",
+      flushIntervalMs: 60_000,
+    });
+    r.setAppVersion("1.0.0-test");
+    r.report(new Error("should be ignored"));
+    expect(r.getPending()).toHaveLength(0);
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+    r.dispose();
+  });
+});
+
+// ─── Batch payload ───────────────────────────────────────────────────────────
+
+describe("batch payload", () => {
+  it("sends well-formed JSON with expected structure", async () => {
+    let capturedBody: string | undefined;
+    vi.mocked(globalThis.fetch).mockImplementation(
+      (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        capturedBody = init?.body as string;
+        return Promise.resolve(new Response(null, { status: 200 }));
+      },
+    );
+
+    const r = makeReporter({ batchSize: 2 });
+    r.report(new Error("test error 1"));
+    r.report(new Error("test error 2"));
+
+    // Wait for async flush
+    await new Promise((res) => setTimeout(res, 10));
+
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalled();
+    expect(capturedBody).toBeDefined();
+
+    const parsed = JSON.parse(capturedBody!);
+    expect(parsed).toHaveProperty("app", "prism-liquidity-agent");
+    expect(parsed).toHaveProperty("version", "1.0.0-test");
+    expect(parsed).toHaveProperty("reports");
+    expect(parsed.reports).toBeInstanceOf(Array);
+    expect(parsed.reports).toHaveLength(2);
+
+    const first = parsed.reports[0]!;
+    expect(first).toHaveProperty("id");
+    expect(first).toHaveProperty("ts");
+    expect(first).toHaveProperty("message");
+    expect(first).toHaveProperty("stack");
+    expect(first).toHaveProperty("category");
+    expect(first).toHaveProperty("severity");
+    r.dispose();
+  });
+});
+
+// ─── Failure resilience ──────────────────────────────────────────────────────
+
+describe("failure resilience", () => {
+  it("does not throw when fetch fails (network error)", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(() =>
+      Promise.reject(new Error("Network failure")),
+    );
+
+    const r = makeReporter({ batchSize: 1 });
+    expect(() => {
+      r.report(new Error("test"));
+    }).not.toThrow();
+
+    // Wait for background flush
+    await new Promise((res) => setTimeout(res, 10));
+
+    // Pending should be cleared even on failure
+    expect(r.getPending()).toHaveLength(0);
+    r.dispose();
+  });
+
+  it("does not throw when fetch returns non-OK status", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(() =>
+      Promise.resolve(new Response(null, { status: 500, statusText: "Internal Server Error" })),
+    );
+
+    const r = makeReporter({ batchSize: 1 });
+    expect(() => {
+      r.report(new Error("test"));
+    }).not.toThrow();
+
+    await new Promise((res) => setTimeout(res, 10));
+    expect(r.getPending()).toHaveLength(0);
+    r.dispose();
+  });
+
+  it("does not throw when no endpoint is configured", () => {
+    const r = createErrorReporter({ enabled: true });
+    r.setAppVersion("1.0.0-test");
+    expect(() => {
+      r.report(new Error("should be captured but not sent"));
+    }).not.toThrow();
+    expect(r.getPending()).toHaveLength(1);
+    r.dispose();
+  });
+});
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+describe("createErrorReporter factory", () => {
+  it("returns an ErrorReporter instance", () => {
+    const r = createErrorReporter({ enabled: false });
+    expect(r).toBeInstanceOf(Object);
+    expect(typeof r.report).toBe("function");
+    expect(typeof r.flushSync).toBe("function");
+    expect(typeof r.getPending).toBe("function");
+    expect(typeof r.dispose).toBe("function");
+    r.dispose();
+  });
+});

--- a/bench/error-reporter.test.ts
+++ b/bench/error-reporter.test.ts
@@ -127,7 +127,7 @@ describe("sanitization", () => {
 
   it("sanitizes stack traces too", () => {
     const r = makeReporter();
-    const longBase58 = "Abc123Xyz".repeat(8);
+    const longBase58 = "z".repeat(80);
     expect(longBase58.length).toBeGreaterThanOrEqual(64);
     const err = new Error("oops");
     err.stack = `Error: oops\n    at foo (file.ts:10:5)\n    value=${longBase58}`;

--- a/bench/error-reporter.test.ts
+++ b/bench/error-reporter.test.ts
@@ -13,7 +13,9 @@ import {
  * via the vi.mocked API.
  */
 function mockFetch(): void {
-  globalThis.fetch = vi.fn() as unknown as typeof globalThis.fetch;
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve(new Response(null, { status: 200 })),
+  ) as unknown as typeof globalThis.fetch;
 }
 
 /**
@@ -33,12 +35,25 @@ function makeReporter(overrides?: Partial<ErrorReporterConfig>): ErrorReporter {
 
 // ─── Setup / Teardown ────────────────────────────────────────────────────────
 
+const ORIGINAL_ERROR_REPORTING = process.env.PRISM_ERROR_REPORTING;
+const ORIGINAL_ERROR_ENDPOINT = process.env.PRISM_ERROR_ENDPOINT;
+
 beforeEach(() => {
   mockFetch();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  if (ORIGINAL_ERROR_REPORTING === undefined) {
+    delete process.env.PRISM_ERROR_REPORTING;
+  } else {
+    process.env.PRISM_ERROR_REPORTING = ORIGINAL_ERROR_REPORTING;
+  }
+  if (ORIGINAL_ERROR_ENDPOINT === undefined) {
+    delete process.env.PRISM_ERROR_ENDPOINT;
+  } else {
+    process.env.PRISM_ERROR_ENDPOINT = ORIGINAL_ERROR_ENDPOINT;
+  }
 });
 
 // ─── Sanitization ────────────────────────────────────────────────────────────
@@ -90,11 +105,11 @@ describe("sanitization", () => {
 
   it("redacts password= patterns", () => {
     const r = makeReporter();
-    const err = new Error("DB connection: password=supersecret!");
+    const err = new Error("DB connection: password=PLACEHOLDER_VALUE");
     r.report(err);
     const pending = r.getPending();
     expect(pending[0]?.message).toContain("[REDACTED]");
-    expect(pending[0]?.message).not.toContain("supersecret");
+    expect(pending[0]?.message).not.toContain("PLACEHOLDER_VALUE");
     r.dispose();
   });
 
@@ -112,16 +127,14 @@ describe("sanitization", () => {
 
   it("sanitizes stack traces too", () => {
     const r = makeReporter();
-    // Must be ≥64 base58 chars to trigger redaction
-    const secret =
-      "5K3NEQrLEqrEv8PByNoxGmmLXdRNY4hvoM7pBEiCwJFp5K3NEQrLEqrEv8PByNoxGmmLXdRNY4hvoM7pBEiCwJFp";
-    expect(secret.length).toBeGreaterThanOrEqual(64);
+    const longBase58 = "Abc123Xyz".repeat(8);
+    expect(longBase58.length).toBeGreaterThanOrEqual(64);
     const err = new Error("oops");
-    err.stack = `Error: oops\n    at foo (file.ts:10:5)\n    secret=${secret}`;
+    err.stack = `Error: oops\n    at foo (file.ts:10:5)\n    value=${longBase58}`;
     r.report(err);
     const pending = r.getPending();
     expect(pending[0]?.stack).toContain("[REDACTED]");
-    expect(pending[0]?.stack).not.toContain(secret);
+    expect(pending[0]?.stack).not.toContain(longBase58);
     r.dispose();
   });
 });
@@ -200,15 +213,13 @@ describe("buffering", () => {
     r.dispose();
   });
 
-  it("flushSync triggers async flush for testability", async () => {
+  it("flushAsync waits for the in-flight flush to complete", async () => {
     const r = makeReporter();
     r.report(new Error("e1"));
     r.report(new Error("e2"));
     expect(r.getPending()).toHaveLength(2);
 
-    r.flushSync();
-    // Wait for the async flush
-    await new Promise((res) => setTimeout(res, 10));
+    await r.flushAsync();
     expect(vi.mocked(globalThis.fetch)).toHaveBeenCalled();
     expect(r.getPending()).toHaveLength(0);
     r.dispose();
@@ -234,7 +245,7 @@ describe("no-op mode", () => {
     const r = makeReporter({ enabled: false });
     r.report(new Error("should be ignored"));
     expect(r.getPending()).toHaveLength(0);
-    r.flushSync();
+    r.flushAsync();
     expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
     r.dispose();
   });
@@ -297,7 +308,7 @@ describe("batch payload", () => {
 // ─── Failure resilience ──────────────────────────────────────────────────────
 
 describe("failure resilience", () => {
-  it("does not throw when fetch fails (network error)", async () => {
+  it("re-queues reports when fetch fails (network error)", async () => {
     vi.mocked(globalThis.fetch).mockImplementation(() =>
       Promise.reject(new Error("Network failure")),
     );
@@ -307,15 +318,12 @@ describe("failure resilience", () => {
       r.report(new Error("test"));
     }).not.toThrow();
 
-    // Wait for background flush
     await new Promise((res) => setTimeout(res, 10));
-
-    // Pending should be cleared even on failure
-    expect(r.getPending()).toHaveLength(0);
+    expect(r.getPending()).toHaveLength(1);
     r.dispose();
   });
 
-  it("does not throw when fetch returns non-OK status", async () => {
+  it("re-queues reports when fetch returns non-OK status", async () => {
     vi.mocked(globalThis.fetch).mockImplementation(() =>
       Promise.resolve(new Response(null, { status: 500, statusText: "Internal Server Error" })),
     );
@@ -326,17 +334,17 @@ describe("failure resilience", () => {
     }).not.toThrow();
 
     await new Promise((res) => setTimeout(res, 10));
-    expect(r.getPending()).toHaveLength(0);
+    expect(r.getPending()).toHaveLength(1);
     r.dispose();
   });
 
-  it("does not throw when no endpoint is configured", () => {
+  it("does not buffer reports when no endpoint is configured", () => {
     const r = createErrorReporter({ enabled: true });
     r.setAppVersion("1.0.0-test");
     expect(() => {
-      r.report(new Error("should be captured but not sent"));
+      r.report(new Error("should be dropped without an endpoint"));
     }).not.toThrow();
-    expect(r.getPending()).toHaveLength(1);
+    expect(r.getPending()).toHaveLength(0);
     r.dispose();
   });
 });
@@ -348,7 +356,7 @@ describe("createErrorReporter factory", () => {
     const r = createErrorReporter({ enabled: false });
     expect(r).toBeInstanceOf(Object);
     expect(typeof r.report).toBe("function");
-    expect(typeof r.flushSync).toBe("function");
+    expect(typeof r.flushAsync).toBe("function");
     expect(typeof r.getPending).toBe("function");
     expect(typeof r.dispose).toBe("function");
     r.dispose();

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -157,6 +157,23 @@ export const updateCommand = new Command("update")
       console.log("Installing dependencies...");
       execSync("bun install", { cwd: extractedDir, stdio: "inherit" });
 
+      // === Pre-apply smoke tests ===
+      console.log("Running TypeScript smoke test...");
+      try {
+        execSync("bunx tsc --noEmit", { cwd: extractedDir, stdio: "inherit" });
+      } catch {
+        throw new UpdateAbort(`TypeScript smoke test failed — refusing to install ${latest}`);
+      }
+      console.log("✓ TypeScript smoke test passed");
+
+      console.log("Running test suite smoke test...");
+      try {
+        execSync("bunx vitest run --reporter=basic", { cwd: extractedDir, stdio: "inherit" });
+      } catch {
+        throw new UpdateAbort(`Test suite smoke test failed — refusing to install ${latest}`);
+      }
+      console.log("✓ Test suite smoke test passed");
+
       // Atomic swap: stage new files alongside the install root, then rename.
       // A direct copy into the live install can leave it half-updated on failure.
       const installRoot = resolveInstallRoot();
@@ -187,6 +204,31 @@ export const updateCommand = new Command("update")
         if (existsSync(currentBackup)) {
           execSync(`mv "${currentBackup}" "${backupRoot}"`, { stdio: "inherit" });
         }
+
+        // Post-apply health check
+        console.log("Running post-apply health check...");
+        try {
+          execSync("bunx tsc --noEmit", { cwd: installRoot, stdio: "inherit", timeout: 5000 });
+        } catch (healthErr) {
+          console.error("Post-apply health check failed — rolling back");
+          try {
+            rmSync(installRoot, { recursive: true, force: true });
+            if (existsSync(backupRoot)) {
+              execSync(`mv "${backupRoot}" "${installRoot}"`, { stdio: "inherit" });
+            }
+          } catch (rollbackErr) {
+            throw new UpdateAbort(
+              "Update failed: health check did not pass AND rollback failed. " +
+                `Your install at ${installRoot} may be in an inconsistent state. ` +
+                `Previous version is at ${backupRoot}.`,
+            );
+          }
+          throw new UpdateAbort(
+            `Post-apply health check failed — rolled back to previous version. ` +
+              `Error: ${healthErr instanceof Error ? healthErr.message : String(healthErr)}`,
+          );
+        }
+        console.log("✓ Post-apply health check passed");
       } catch (swapErr) {
         if (existsSync(stagedRoot)) {
           try {

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -208,7 +208,7 @@ export const updateCommand = new Command("update")
         // Post-apply health check
         console.log("Running post-apply health check...");
         try {
-          execSync("bunx tsc --noEmit", { cwd: installRoot, stdio: "inherit", timeout: 5000 });
+          execSync("bunx tsc --noEmit", { cwd: installRoot, stdio: "inherit", timeout: 30_000 });
         } catch (healthErr) {
           console.error("Post-apply health check failed — rolling back");
           try {

--- a/cloudflare/migrations/0002_error_logs.sql
+++ b/cloudflare/migrations/0002_error_logs.sql
@@ -1,0 +1,20 @@
+-- Migration: Error reporting table for privacy-first telemetry
+-- Created: 2026-06-03
+-- See: https://github.com/fdnirkh/prism-liqudity-agent/issues/29
+
+-- Error logs table (agent-side error reports)
+CREATE TABLE IF NOT EXISTS error_logs (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT,
+    error_type TEXT NOT NULL,
+    message TEXT NOT NULL,
+    stack_trace TEXT,
+    prism_version TEXT NOT NULL,
+    platform TEXT,
+    severity TEXT DEFAULT 'error',
+    is_recoverable INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Index for dashboard queries by agent
+CREATE INDEX IF NOT EXISTS idx_error_logs_agent_created ON error_logs(agent_id, created_at);

--- a/cloudflare/migrations/0002_error_logs.sql
+++ b/cloudflare/migrations/0002_error_logs.sql
@@ -1,6 +1,6 @@
 -- Migration: Error reporting table for privacy-first telemetry
 -- Created: 2026-06-03
--- See: https://github.com/fdnirkh/prism-liqudity-agent/issues/29
+-- See: https://github.com/irfndi/prism-liqudity-agent/issues/29
 
 -- Error logs table (agent-side error reports)
 CREATE TABLE IF NOT EXISTS error_logs (

--- a/cloudflare/tsconfig.json
+++ b/cloudflare/tsconfig.json
@@ -4,7 +4,11 @@
     "module": "ES2022",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers", "vitest/globals"],
+    "types": [
+      "@cloudflare/workers-types",
+      "@cloudflare/vitest-pool-workers/types",
+      "vitest/globals"
+    ],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
@@ -16,5 +20,5 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["workers/**/*", "migrations/**/*"]
+  "include": ["workers/**/*", "migrations/**/*", "worker-configuration.d.ts"]
 }

--- a/cloudflare/worker-configuration.d.ts
+++ b/cloudflare/worker-configuration.d.ts
@@ -1,0 +1,20 @@
+// Augments Cloudflare.Env with project bindings so `import { env } from "cloudflare:test"`
+// exposes DB, CACHE, BACKUPS, MEMORY and the configured vars/secrets.
+// This is the same effect as `wrangler types` generating a worker-configuration.d.ts.
+declare namespace Cloudflare {
+  interface Env {
+    DB: D1Database;
+    CACHE: KVNamespace;
+    BACKUPS: R2Bucket;
+    MEMORY: VectorizeIndex;
+    ENVIRONMENT: string;
+    TELEGRAM_WEBHOOK_URL: string;
+    API_BASE_URL: string;
+    FEE_WALLET_ADDRESS?: string;
+    TELEGRAM_BOT_TOKEN?: string;
+    TELEGRAM_WEBHOOK_SECRET?: string;
+    GITHUB_TOKEN?: string;
+    GITHUB_REPO?: string;
+    ADMIN_API_KEY?: string;
+  }
+}

--- a/cloudflare/workers/api/errors.test.ts
+++ b/cloudflare/workers/api/errors.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { env, createExecutionContext } from "cloudflare:test";
+import worker from "./index";
+
+function buildRequest(method: string, path: string, body?: unknown, token?: string): Request {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+  return new Request(`https://example.com${path}`, init);
+}
+
+describe("Error Reporting API", () => {
+  beforeAll(async () => {
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS error_logs (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT,
+        error_type TEXT NOT NULL,
+        message TEXT NOT NULL,
+        stack_trace TEXT,
+        prism_version TEXT NOT NULL,
+        platform TEXT,
+        severity TEXT DEFAULT 'error',
+        is_recoverable INTEGER DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+    ).run();
+    await env.DB.prepare(
+      `CREATE INDEX IF NOT EXISTS idx_error_logs_agent_created ON error_logs(agent_id, created_at)`,
+    ).run();
+  });
+
+  describe("POST /v1/errors/report", () => {
+    beforeEach(async () => {
+      await env.DB.prepare("DELETE FROM error_logs").run();
+    });
+    it("should return 200 with id on valid report", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/errors/report", {
+        id: "test-uuid-1",
+        agentId: "hashed-wallet-abc",
+        errorType: "ONNX_BigInt",
+        message: "BigInt serialization failed",
+        stackTrace: "Error: BigInt...\n    at serialize (...)",
+        prismVersion: "1.2.3",
+        platform: "darwin",
+        severity: "error",
+        isRecoverable: 1,
+      });
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { id: string };
+      expect(body.id).toBe("test-uuid-1");
+    });
+
+    it("should return 400 when id is missing", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/errors/report", {
+        agentId: "hashed-wallet-abc",
+        errorType: "ONNX_BigInt",
+        message: "BigInt serialization failed",
+        prismVersion: "1.2.3",
+      });
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("should return 400 when agentId is missing", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/errors/report", {
+        id: "test-uuid-2",
+        errorType: "ONNX_BigInt",
+        message: "BigInt serialization failed",
+        prismVersion: "1.2.3",
+      });
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("should return 400 when errorType is missing", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/errors/report", {
+        id: "test-uuid-3",
+        agentId: "hashed-wallet-abc",
+        message: "BigInt serialization failed",
+        prismVersion: "1.2.3",
+      });
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("should return 400 when message is missing", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/errors/report", {
+        id: "test-uuid-4",
+        agentId: "hashed-wallet-abc",
+        errorType: "ONNX_BigInt",
+        prismVersion: "1.2.3",
+      });
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("should return 400 when prismVersion is missing", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/errors/report", {
+        id: "test-uuid-5",
+        agentId: "hashed-wallet-abc",
+        errorType: "ONNX_BigInt",
+        message: "BigInt serialization failed",
+      });
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("should return 200 on duplicate id (idempotency)", async () => {
+      const ctx = createExecutionContext();
+      const report = {
+        id: "dup-uuid",
+        agentId: "hashed-wallet-abc",
+        errorType: "SQLite_Vec",
+        message: "Vector dimension mismatch",
+        prismVersion: "1.2.3",
+      };
+      // Insert once
+      const req1 = buildRequest("POST", "/v1/errors/report", report);
+      const res1 = await worker.fetch(req1, env, ctx);
+      expect(res1.status).toBe(200);
+
+      // Insert duplicate — should still return 200
+      const req2 = buildRequest("POST", "/v1/errors/report", report);
+      const res2 = await worker.fetch(req2, env, ctx);
+      expect(res2.status).toBe(200);
+      const body = (await res2.json()) as { id: string };
+      expect(body.id).toBe("dup-uuid");
+    });
+  });
+
+  describe("POST /v1/errors/batch", () => {
+    beforeEach(async () => {
+      await env.DB.prepare("DELETE FROM error_logs").run();
+    });
+
+    it("should return 200 with inserted count on valid batch", async () => {
+      const ctx = createExecutionContext();
+      const reports = Array.from({ length: 3 }, (_, i) => ({
+        id: `batch-uuid-${i}`,
+        agentId: "hashed-wallet-xyz",
+        errorType: i % 2 === 0 ? "ONNX_BigInt" : "SQLite_Vec",
+        message: `Error ${i}`,
+        prismVersion: "1.2.3",
+      }));
+      const request = buildRequest("POST", "/v1/errors/batch", { reports });
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { inserted: number };
+      expect(body.inserted).toBe(3);
+    });
+
+    it("should return 400 when no reports provided", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/errors/batch", { reports: [] });
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("should return 400 when batch exceeds 50", async () => {
+      const ctx = createExecutionContext();
+      const reports = Array.from({ length: 51 }, (_, i) => ({
+        id: `batch-uuid-${i}`,
+        agentId: "hashed-wallet-xyz",
+        errorType: "ONNX_BigInt",
+        message: `Error ${i}`,
+        prismVersion: "1.2.3",
+      }));
+      const request = buildRequest("POST", "/v1/errors/batch", { reports });
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("should return 400 when a report in batch is missing required fields", async () => {
+      const ctx = createExecutionContext();
+      const reports = [
+        { id: "valid-1", agentId: "hash", errorType: "TypeA", message: "ok", prismVersion: "1.0" },
+        { id: "invalid-1", agentId: "hash", errorType: "TypeB", prismVersion: "1.0" }, // missing message
+      ];
+      const request = buildRequest("POST", "/v1/errors/batch", { reports });
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("GET /v1/errors/stats", () => {
+    const adminKey = "test-admin-key-value";
+
+    beforeAll(async () => {
+      // Seed some error data for stats
+      const stmt = env.DB.prepare(
+        `INSERT INTO error_logs (id, agent_id, error_type, message, stack_trace, prism_version, platform, severity, is_recoverable, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const seeds = [
+        {
+          id: "stat-1",
+          errorType: "ONNX_BigInt",
+          message: "err1",
+          createdAt: "2026-06-03T10:00:00",
+        },
+        {
+          id: "stat-2",
+          errorType: "ONNX_BigInt",
+          message: "err2",
+          createdAt: "2026-06-03T10:01:00",
+        },
+        {
+          id: "stat-3",
+          errorType: "SQLite_Vec",
+          message: "err3",
+          createdAt: "2026-06-03T10:02:00",
+        },
+        {
+          id: "stat-4",
+          errorType: "RPC_Timeout",
+          message: "err4",
+          createdAt: "2026-06-03T09:00:00",
+        },
+      ];
+      for (const s of seeds) {
+        await stmt
+          .bind(
+            s.id,
+            "stats-agent",
+            s.errorType,
+            s.message,
+            null,
+            "1.2.3",
+            "linux",
+            "error",
+            0,
+            s.createdAt,
+          )
+          .run();
+      }
+    });
+
+    it("should return 401 without bearer token", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("GET", "/v1/errors/stats");
+      const response = await worker.fetch(request, env, ctx);
+      expect(response.status).toBe(401);
+    });
+
+    it("should return 401 with invalid bearer token", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("GET", "/v1/errors/stats", undefined, "wrong-key");
+      const adminEnv = { ...env, ADMIN_API_KEY: adminKey };
+      const response = await worker.fetch(request, adminEnv, ctx);
+      expect(response.status).toBe(401);
+    });
+
+    it("should return aggregate stats with valid admin token", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("GET", "/v1/errors/stats", undefined, adminKey);
+      const adminEnv = { ...env, ADMIN_API_KEY: adminKey };
+      const response = await worker.fetch(request, adminEnv, ctx);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        stats: Array<{ error_type: string; count: number }>;
+      };
+      expect(body.stats).toBeDefined();
+      expect(body.stats.length).toBeGreaterThanOrEqual(3);
+
+      // Verify ONNX_BigInt has count 2
+      const onnxStats = body.stats.find((s) => s.error_type === "ONNX_BigInt");
+      expect(onnxStats).toBeDefined();
+      expect(onnxStats!.count).toBe(2);
+    });
+  });
+});

--- a/cloudflare/workers/api/errors.test.ts
+++ b/cloudflare/workers/api/errors.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { env, createExecutionContext } from "cloudflare:test";
-import worker from "./index";
+import worker, { type Env } from "./index";
+
+const testEnv = env as unknown as Env;
 
 function buildRequest(method: string, path: string, body?: unknown, token?: string): Request {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
@@ -52,7 +54,7 @@ describe("Error Reporting API", () => {
         severity: "error",
         isRecoverable: 1,
       });
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(200);
       const body = (await response.json()) as { id: string };
       expect(body.id).toBe("test-uuid-1");
@@ -66,7 +68,7 @@ describe("Error Reporting API", () => {
         message: "BigInt serialization failed",
         prismVersion: "1.2.3",
       });
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(400);
     });
 
@@ -78,7 +80,7 @@ describe("Error Reporting API", () => {
         message: "BigInt serialization failed",
         prismVersion: "1.2.3",
       });
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(400);
     });
 
@@ -90,7 +92,7 @@ describe("Error Reporting API", () => {
         message: "BigInt serialization failed",
         prismVersion: "1.2.3",
       });
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(400);
     });
 
@@ -102,7 +104,7 @@ describe("Error Reporting API", () => {
         errorType: "ONNX_BigInt",
         prismVersion: "1.2.3",
       });
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(400);
     });
 
@@ -114,7 +116,7 @@ describe("Error Reporting API", () => {
         errorType: "ONNX_BigInt",
         message: "BigInt serialization failed",
       });
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(400);
     });
 
@@ -129,12 +131,12 @@ describe("Error Reporting API", () => {
       };
       // Insert once
       const req1 = buildRequest("POST", "/v1/errors/report", report);
-      const res1 = await worker.fetch(req1, env, ctx);
+      const res1 = await worker.fetch(req1, testEnv, ctx);
       expect(res1.status).toBe(200);
 
       // Insert duplicate — should still return 200
       const req2 = buildRequest("POST", "/v1/errors/report", report);
-      const res2 = await worker.fetch(req2, env, ctx);
+      const res2 = await worker.fetch(req2, testEnv, ctx);
       expect(res2.status).toBe(200);
       const body = (await res2.json()) as { id: string };
       expect(body.id).toBe("dup-uuid");
@@ -156,7 +158,7 @@ describe("Error Reporting API", () => {
         prismVersion: "1.2.3",
       }));
       const request = buildRequest("POST", "/v1/errors/batch", { reports });
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(200);
       const body = (await response.json()) as { inserted: number };
       expect(body.inserted).toBe(3);
@@ -165,7 +167,7 @@ describe("Error Reporting API", () => {
     it("should return 400 when no reports provided", async () => {
       const ctx = createExecutionContext();
       const request = buildRequest("POST", "/v1/errors/batch", { reports: [] });
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(400);
     });
 
@@ -179,7 +181,7 @@ describe("Error Reporting API", () => {
         prismVersion: "1.2.3",
       }));
       const request = buildRequest("POST", "/v1/errors/batch", { reports });
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(400);
     });
 
@@ -190,7 +192,7 @@ describe("Error Reporting API", () => {
         { id: "invalid-1", agentId: "hash", errorType: "TypeB", prismVersion: "1.0" }, // missing message
       ];
       const request = buildRequest("POST", "/v1/errors/batch", { reports });
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(400);
     });
   });
@@ -251,14 +253,14 @@ describe("Error Reporting API", () => {
     it("should return 401 without bearer token", async () => {
       const ctx = createExecutionContext();
       const request = buildRequest("GET", "/v1/errors/stats");
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(request, testEnv, ctx);
       expect(response.status).toBe(401);
     });
 
     it("should return 401 with invalid bearer token", async () => {
       const ctx = createExecutionContext();
       const request = buildRequest("GET", "/v1/errors/stats", undefined, "wrong-key");
-      const adminEnv = { ...env, ADMIN_API_KEY: adminKey };
+      const adminEnv = { ...testEnv, ADMIN_API_KEY: adminKey } as Env;
       const response = await worker.fetch(request, adminEnv, ctx);
       expect(response.status).toBe(401);
     });
@@ -266,7 +268,7 @@ describe("Error Reporting API", () => {
     it("should return aggregate stats with valid admin token", async () => {
       const ctx = createExecutionContext();
       const request = buildRequest("GET", "/v1/errors/stats", undefined, adminKey);
-      const adminEnv = { ...env, ADMIN_API_KEY: adminKey };
+      const adminEnv = { ...testEnv, ADMIN_API_KEY: adminKey } as Env;
       const response = await worker.fetch(request, adminEnv, ctx);
       expect(response.status).toBe(200);
       const body = (await response.json()) as {

--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -11,6 +11,7 @@ interface Env {
   TELEGRAM_BOT_TOKEN: string;
   GITHUB_TOKEN: string;
   GITHUB_REPO: string;
+  ADMIN_API_KEY?: string;
 }
 
 // Services
@@ -483,6 +484,212 @@ app.post("/v1/issue", async (c) => {
     return c.json({ issue_number: issue.number, url: issue.html_url });
   } catch {
     return c.json({ error: "Failed to create issue" }, 500);
+  }
+});
+
+// ── Error Reporting ──────────────────────────────────────────────────────────
+// Privacy-first error telemetry (opt-in, no auth required for ingestion)
+
+app.post("/v1/errors/report", async (c) => {
+  const { DB, CACHE } = c.env;
+  const clientIp = c.req.header("CF-Connecting-IP") || "unknown";
+
+  const body = await c.req
+    .json<{
+      id?: string;
+      agentId?: string;
+      errorType?: string;
+      message?: string;
+      stackTrace?: string;
+      prismVersion?: string;
+      platform?: string;
+      severity?: string;
+      isRecoverable?: number;
+    }>()
+    .catch(() => ({}));
+
+  // Validate required fields
+  if (!body.id || !body.agentId || !body.errorType || !body.message || !body.prismVersion) {
+    return c.json(
+      { error: "Missing required fields: id, agentId, errorType, message, prismVersion" },
+      400,
+    );
+  }
+
+  // Rate limit: 100 reports per IP per hour
+  if (CACHE) {
+    const rateKey = `rate_limit:error_report:${clientIp}`;
+    const rateData = await CACHE.get(rateKey);
+    const count = rateData ? parseInt(rateData, 10) : 0;
+    if (count >= 100) {
+      return c.json({ error: "Rate limit exceeded. Try again later." }, 429);
+    }
+    await CACHE.put(rateKey, String(count + 1), { expirationTtl: 3600 });
+  }
+
+  try {
+    const severity = body.severity ?? "error";
+    const isRecoverable = body.isRecoverable ? 1 : 0;
+
+    await DB.prepare(
+      `INSERT INTO error_logs (id, agent_id, error_type, message, stack_trace, prism_version, platform, severity, is_recoverable)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        body.id,
+        body.agentId,
+        body.errorType,
+        body.message,
+        body.stackTrace ?? null,
+        body.prismVersion,
+        body.platform ?? null,
+        severity,
+        isRecoverable,
+      )
+      .run();
+
+    return c.json({ id: body.id });
+  } catch (err) {
+    // Duplicate id is expected (agent retries) — return 200 for idempotency
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("UNIQUE constraint")) {
+      return c.json({ id: body.id });
+    }
+    return c.json({ error: "Failed to store error report" }, 500);
+  }
+});
+
+app.post("/v1/errors/batch", async (c) => {
+  const { DB, CACHE } = c.env;
+  const clientIp = c.req.header("CF-Connecting-IP") || "unknown";
+
+  const body = await c.req
+    .json<{
+      reports?: Array<{
+        id?: string;
+        agentId?: string;
+        errorType?: string;
+        message?: string;
+        stackTrace?: string;
+        prismVersion?: string;
+        platform?: string;
+        severity?: string;
+        isRecoverable?: number;
+      }>;
+    }>()
+    .catch(() => ({}));
+
+  const reports = body.reports ?? [];
+
+  if (reports.length === 0) {
+    return c.json({ error: "No reports provided" }, 400);
+  }
+
+  if (reports.length > 50) {
+    return c.json({ error: "Batch size exceeds maximum of 50" }, 400);
+  }
+
+  // Rate limit: 50 batches per IP per hour
+  if (CACHE) {
+    const rateKey = `rate_limit:error_batch:${clientIp}`;
+    const rateData = await CACHE.get(rateKey);
+    const count = rateData ? parseInt(rateData, 10) : 0;
+    if (count >= 50) {
+      return c.json({ error: "Rate limit exceeded. Try again later." }, 429);
+    }
+    await CACHE.put(rateKey, String(count + 1), { expirationTtl: 3600 });
+  }
+
+  // Validate all reports
+  const validReports: Array<{
+    id: string;
+    agentId: string;
+    errorType: string;
+    message: string;
+    prismVersion: string;
+    stackTrace: string | null;
+    platform: string | null;
+    severity: string;
+    isRecoverable: number;
+  }> = [];
+
+  for (const r of reports) {
+    if (!r.id || !r.agentId || !r.errorType || !r.message || !r.prismVersion) {
+      return c.json(
+        {
+          error: "Each report requires id, agentId, errorType, message, prismVersion",
+          reportId: r.id ?? "(missing id)",
+        },
+        400,
+      );
+    }
+    validReports.push({
+      id: r.id,
+      agentId: r.agentId,
+      errorType: r.errorType,
+      message: r.message,
+      prismVersion: r.prismVersion,
+      stackTrace: r.stackTrace ?? null,
+      platform: r.platform ?? null,
+      severity: r.severity ?? "error",
+      isRecoverable: r.isRecoverable ? 1 : 0,
+    });
+  }
+
+  try {
+    const stmt = DB.prepare(
+      `INSERT OR IGNORE INTO error_logs (id, agent_id, error_type, message, stack_trace, prism_version, platform, severity, is_recoverable)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    const batchStatements = validReports.map((r) =>
+      stmt.bind(
+        r.id,
+        r.agentId,
+        r.errorType,
+        r.message,
+        r.stackTrace,
+        r.prismVersion,
+        r.platform,
+        r.severity,
+        r.isRecoverable,
+      ),
+    );
+
+    await DB.batch(batchStatements);
+
+    return c.json({ inserted: validReports.length });
+  } catch {
+    return c.json({ error: "Failed to store error reports" }, 500);
+  }
+});
+
+app.get("/v1/errors/stats", async (c) => {
+  const { DB } = c.env;
+
+  // Require admin bearer token
+  const authHeader = c.req.header("Authorization");
+  const match = authHeader?.match(/^Bearer\s+(.+)$/);
+  const token = match?.[1];
+
+  if (!token || token !== c.env.ADMIN_API_KEY) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  try {
+    const result = await DB.prepare(
+      `SELECT error_type, COUNT(*) as count
+       FROM error_logs
+       WHERE created_at >= datetime('now', '-1 day')
+       GROUP BY error_type
+       ORDER BY count DESC`,
+    ).all();
+
+    const rows = result.results ?? [];
+
+    return c.json({ stats: rows });
+  } catch {
+    return c.json({ error: "Failed to fetch stats" }, 500);
   }
 });
 

--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -14,6 +14,17 @@ export interface Env {
   ADMIN_API_KEY?: string;
 }
 
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+const MAX_ERROR_MESSAGE_LENGTH = 4096;
+
 // Services
 class DbService extends Context.Tag("DbService")<DbService, { readonly db: D1Database }>() {}
 
@@ -520,6 +531,9 @@ app.post("/v1/errors/report", async (c) => {
       400,
     );
   }
+  if (body.message.length > MAX_ERROR_MESSAGE_LENGTH) {
+    return c.json({ error: `message exceeds ${MAX_ERROR_MESSAGE_LENGTH} characters` }, 400);
+  }
 
   // Rate limit: 100 reports per IP per hour
   if (CACHE) {
@@ -626,6 +640,15 @@ app.post("/v1/errors/batch", async (c) => {
         400,
       );
     }
+    if (r.message.length > MAX_ERROR_MESSAGE_LENGTH) {
+      return c.json(
+        {
+          error: `message exceeds ${MAX_ERROR_MESSAGE_LENGTH} characters`,
+          reportId: r.id,
+        },
+        400,
+      );
+    }
     validReports.push({
       id: r.id,
       agentId: r.agentId,
@@ -659,9 +682,14 @@ app.post("/v1/errors/batch", async (c) => {
       ),
     );
 
-    await DB.batch(batchStatements);
+    const results = await DB.batch(batchStatements);
+    const inserted = results.reduce(
+      (sum, r) => sum + (typeof r.meta.changes === "number" ? r.meta.changes : 0),
+      0,
+    );
+    const duplicates = validReports.length - inserted;
 
-    return c.json({ inserted: validReports.length });
+    return c.json({ inserted, duplicates });
   } catch {
     return c.json({ error: "Failed to store error reports" }, 500);
   }
@@ -675,7 +703,7 @@ app.get("/v1/errors/stats", async (c) => {
   const match = authHeader?.match(/^Bearer\s+(.+)$/);
   const token = match?.[1];
 
-  if (!token || token !== c.env.ADMIN_API_KEY) {
+  if (!token || !c.env.ADMIN_API_KEY || !constantTimeEqual(token, c.env.ADMIN_API_KEY)) {
     return c.json({ error: "Unauthorized" }, 401);
   }
 

--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -2,7 +2,7 @@ import { Effect, Layer, Context } from "effect";
 import { Hono } from "hono";
 
 // Environment bindings interface
-interface Env {
+export interface Env {
   DB: D1Database;
   CACHE: KVNamespace;
   BACKUPS: R2Bucket;
@@ -195,14 +195,14 @@ const agentStatusHandler = (db: D1Database, telegramId: string) =>
   });
 
 // Main app
-const app = new Hono<{ Bindings: Env }>();
+const app = new Hono<{ Bindings: Env; Variables: { apiKey: string } }>();
 
 // Middleware to extract and validate API key
 app.use("/v1/*", async (c, next) => {
   const authHeader = c.req.header("Authorization");
   if (authHeader) {
     const match = authHeader.match(/^Bearer\s+(.+)$/);
-    if (match) {
+    if (match && match[1]) {
       c.set("apiKey", match[1]);
     }
   }
@@ -218,7 +218,7 @@ app.get("/health", async (c) => {
 app.post("/v1/register", async (c) => {
   const { DB, CACHE } = c.env;
   const clientIp = c.req.header("CF-Connecting-IP") || "unknown";
-  const body = await c.req.json<{ telegram_id?: string }>().catch(() => ({}));
+  const body = (await c.req.json().catch(() => ({}))) as { telegram_id?: string };
 
   try {
     // Rate limiting: max 5 registrations per IP per hour
@@ -281,7 +281,9 @@ app.get("/v1/whoami", async (c) => {
 
   try {
     const loginResult = await Effect.runPromise(loginHandler(DB, apiKey));
-    const userResult = await Effect.runPromise(whoamiHandler(DB, loginResult.id as string));
+    const userResult = await Effect.runPromise(
+      whoamiHandler(DB, (loginResult as { id: string }).id),
+    );
     return c.json(userResult);
   } catch {
     return c.json({ error: "Unauthorized" }, 401);
@@ -298,7 +300,9 @@ app.post("/v1/link-telegram/start", async (c) => {
 
   try {
     const loginResult = await Effect.runPromise(loginHandler(DB, apiKey));
-    const result = await Effect.runPromise(linkTelegramStartHandler(DB, loginResult.id as string));
+    const result = await Effect.runPromise(
+      linkTelegramStartHandler(DB, (loginResult as { id: string }).id),
+    );
     return c.json(result);
   } catch {
     return c.json({ error: "Unauthorized" }, 401);
@@ -307,7 +311,7 @@ app.post("/v1/link-telegram/start", async (c) => {
 
 app.post("/v1/link-telegram/confirm", async (c) => {
   const { DB } = c.env;
-  const body = await c.req.json<{ code: string; telegram_id: string }>();
+  const body = (await c.req.json().catch(() => ({}))) as { code: string; telegram_id: string };
 
   if (!body.code || !body.telegram_id) {
     return c.json({ error: "Code and telegram_id required" }, 400);
@@ -372,7 +376,7 @@ app.post("/v1/link-telegram/confirm", async (c) => {
 
 app.post("/v1/whoami-telegram", async (c) => {
   const { DB } = c.env;
-  const body = await c.req.json<{ telegram_id?: string }>().catch(() => ({}));
+  const body = (await c.req.json().catch(() => ({}))) as { telegram_id?: string };
 
   if (!body.telegram_id) {
     return c.json({ error: "telegram_id required" }, 400);
@@ -401,7 +405,10 @@ app.post("/v1/whoami-telegram", async (c) => {
 app.post("/v1/register-telegram", async (c) => {
   const { DB, CACHE } = c.env;
   const clientIp = c.req.header("CF-Connecting-IP") || "unknown";
-  const body = await c.req.json<{ telegram_id?: string; first_name?: string }>().catch(() => ({}));
+  const body = (await c.req.json().catch(() => ({}))) as {
+    telegram_id?: string;
+    first_name?: string;
+  };
 
   if (!body.telegram_id) {
     return c.json({ error: "telegram_id required" }, 400);
@@ -434,7 +441,7 @@ app.post("/v1/register-telegram", async (c) => {
 
 app.post("/v1/agent-status", async (c) => {
   const { DB } = c.env;
-  const body = await c.req.json<{ telegram_id?: string }>().catch(() => ({}));
+  const body = (await c.req.json().catch(() => ({}))) as { telegram_id?: string };
 
   if (!body.telegram_id) {
     return c.json({ error: "telegram_id required" }, 400);
@@ -452,7 +459,7 @@ app.post("/v1/agent-status", async (c) => {
 
 app.post("/v1/issue", async (c) => {
   const { GITHUB_TOKEN, GITHUB_REPO } = c.env;
-  const body = await c.req.json<{ title: string; body: string }>();
+  const body = (await c.req.json().catch(() => ({}))) as { title: string; body: string };
 
   if (!body.title) {
     return c.json({ error: "Title required" }, 400);
@@ -480,7 +487,7 @@ app.post("/v1/issue", async (c) => {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const issue = await response.json();
+    const issue = (await response.json()) as { number?: number; html_url?: string };
     return c.json({ issue_number: issue.number, url: issue.html_url });
   } catch {
     return c.json({ error: "Failed to create issue" }, 500);
@@ -494,19 +501,17 @@ app.post("/v1/errors/report", async (c) => {
   const { DB, CACHE } = c.env;
   const clientIp = c.req.header("CF-Connecting-IP") || "unknown";
 
-  const body = await c.req
-    .json<{
-      id?: string;
-      agentId?: string;
-      errorType?: string;
-      message?: string;
-      stackTrace?: string;
-      prismVersion?: string;
-      platform?: string;
-      severity?: string;
-      isRecoverable?: number;
-    }>()
-    .catch(() => ({}));
+  const body = (await c.req.json().catch(() => ({}))) as {
+    id?: string;
+    agentId?: string;
+    errorType?: string;
+    message?: string;
+    stackTrace?: string;
+    prismVersion?: string;
+    platform?: string;
+    severity?: string;
+    isRecoverable?: number;
+  };
 
   // Validate required fields
   if (!body.id || !body.agentId || !body.errorType || !body.message || !body.prismVersion) {
@@ -563,21 +568,19 @@ app.post("/v1/errors/batch", async (c) => {
   const { DB, CACHE } = c.env;
   const clientIp = c.req.header("CF-Connecting-IP") || "unknown";
 
-  const body = await c.req
-    .json<{
-      reports?: Array<{
-        id?: string;
-        agentId?: string;
-        errorType?: string;
-        message?: string;
-        stackTrace?: string;
-        prismVersion?: string;
-        platform?: string;
-        severity?: string;
-        isRecoverable?: number;
-      }>;
-    }>()
-    .catch(() => ({}));
+  const body = (await c.req.json().catch(() => ({}))) as {
+    reports?: Array<{
+      id?: string;
+      agentId?: string;
+      errorType?: string;
+      message?: string;
+      stackTrace?: string;
+      prismVersion?: string;
+      platform?: string;
+      severity?: string;
+      isRecoverable?: number;
+    }>;
+  };
 
   const reports = body.reports ?? [];
 

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -21,25 +21,69 @@ Agents do **not** need to deploy Cloudflare workers. They are already running:
 | Telegram Bot | `https://prism-telegram-bot.irfndi.workers.dev` |
 | Bot username | `@prism_agent_bot`                              |
 
-## Quick Start for Agents (4 steps)
+## Quick Start for Agents (3-layer approach)
+
+Prism has 3 layers. Only the CLI is required. The API (cloud) and Telegram are
+optional. See [`install.md`](install.md) for the full architecture explanation.
+
+### Layer 1: CLI (Local) — Required
 
 ```bash
-# 1. Clone and install
+# Clone and install
 git clone https://github.com/irfndi/prism-liquidity-agent.git
 cd prism-liquidity-agent
 bun install
 
-# 2. Register — calls the deployed Cloudflare API, returns an API key
-prism register
+# Setup (writes .env, no API call)
+prism setup --non-interactive --helius-key=$HELIUS_KEY
 
-# 3. Setup (non-interactive for agent-driven installs)
-prism setup --non-interactive --helius-key=$HELIUS_API_KEY
-
-# 4. Start the trading agent
+# Start trading
 prism dev
 ```
 
-That's it. The agent handles everything else (paper trading by default, no wallet needed).
+Validate: the agent starts scanning. Check `logs/audit-trail.jsonl` for decisions.
+
+### Layer 2: API (Cloud) — Optional
+
+Adds cloud account features (whoami, subscription, Telegram linking):
+
+```bash
+# Register with the cloud API
+prism register
+
+# Validate
+prism whoami   # should show your user ID and tier
+```
+
+Skip this layer for local-only setups. The trading engine works fine without it.
+
+### Layer 3: Telegram (Chat) — Optional
+
+Adds Telegram-based monitoring. Requires the API layer first:
+
+```bash
+prism link-telegram   # generates a 6-char code
+# User sends the code to @prism_agent_bot
+```
+
+### Common Mistakes
+
+1. **Manually editing .env instead of using `prism setup`.** Postinstall writes a
+   default `.env` and `prism setup` is the supported way to update it. Editing
+   `.env` by hand works but skips validation.
+
+2. **Running `bun run dev` instead of `prism dev`.** Both start the engine, but
+   `prism dev` goes through the CLI layer and respects credentials, config paths,
+   and update checks. `bun run dev` bypasses all of that. Always use `prism dev`.
+
+3. **Assuming `prism register` is required.** It's not. The CLI works without a
+   cloud account. Skip it for local-only setups.
+
+4. **Setting `ANTHROPIC_API_KEY` or `CLAUDE_MODEL`.** These env vars are dead.
+   The engine has no AI/LLM integration. See "What's Dead/Unused" in `install.md`.
+
+5. **Expecting `LOG_LEVEL` to silence output.** The env var is loaded but never
+   checked. All log levels write to the audit trail regardless.
 
 ## Agent-Driven Onboarding Paths
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,76 @@
 # Prism Installation Guide
 
-> **For agent harnesses (OpenClaw, Hermes, acpx):** The Cloudflare infrastructure is already deployed. Just clone, `bun install`, then `prism register` and `prism setup`. See [`agent-harness.md`](agent-harness.md) for the full agent setup flow.
+> **For agent harnesses (OpenClaw, Hermes, acpx):** See [`agent-harness.md`](agent-harness.md) for the full agent setup flow with architecture overview and 3-layer quickstarts.
+
+## Prism Architecture
+
+Prism has 3 layers. Only the CLI is required. The API and Telegram are optional add-ons.
+
+1. **CLI (Local)** — The trading agent runs on your machine. All strategy, memory,
+   risk management, and position execution lives here. Commands: `prism dev`,
+   `prism setup`, `prism wallet`, `prism backtest`, `prism update`.
+   **REQUIRED.**
+
+2. **API (Cloud)** — A Cloudflare Worker that handles user accounts, API keys,
+   and subscription tiers. Commands that need it: `prism register`, `prism whoami`,
+   `prism login`, `prism link-telegram`, `prism subscription`.
+   **OPTIONAL.** Skip if you only need local trading.
+
+3. **Telegram (Chat)** — A Telegram bot (`@prism_agent_bot`) for monitoring and
+   control from your phone. Requires the API layer for auth.
+   **OPTIONAL.** Skip if you don't use Telegram.
+
+### Quickstart by Layer
+
+Pick the option that matches your use case:
+
+**Option A: Minimal (CLI only)** — Local-only trading, no cloud account.
+
+```bash
+git clone https://github.com/irfndi/prism-liquidity-agent.git
+cd prism-liquidity-agent
+bun install
+prism setup --non-interactive --helius-key=$HELIUS_KEY   # wizard, no API call
+prism dev                                                  # start paper trading
+```
+
+**Option B: Standard (CLI + API)** — Most users. Adds cloud account, subscription
+management, and multi-device support.
+
+```bash
+git clone https://github.com/irfndi/prism-liquidity-agent.git
+cd prism-liquidity-agent
+bun install
+prism register                                              # get API key from cloud
+prism setup --non-interactive --helius-key=$HELIUS_KEY
+prism dev
+```
+
+**Option C: Full (CLI + API + Telegram)** — Power users who want Telegram alerts
+and phone-based monitoring.
+
+```bash
+# Same as Standard, then:
+prism link-telegram   # generates 6-char code
+# Send the code to @prism_agent_bot on Telegram
+```
+
+### Feature Matrix
+
+| Feature            | CLI | API | Telegram |
+| ------------------ | --- | --- | -------- |
+| Core trading agent | ✅  | -   | -        |
+| Paper trading      | ✅  | -   | -        |
+| Live trading       | ✅  | -   | -        |
+| Backtesting        | ✅  | -   | -        |
+| User registration  | -   | ✅  | -        |
+| API key management | -   | ✅  | -        |
+| Subscription tiers | -   | ✅  | -        |
+| Position alerts    | ✅  | ✅  | ✅       |
+| Phone monitoring   | -   | -   | ✅       |
+| Multi-device sync  | -   | ✅  | -        |
+| Wallet management  | ✅  | -   | -        |
+| Auto-updates       | ✅  | -   | -        |
 
 ## Prerequisites
 
@@ -27,29 +97,38 @@ Then:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"   # if not already on PATH
-prism register                          # get an API key from the deployed Cloudflare API
+
+# For cloud features (optional):
+prism register                          # get an API key from the Cloudflare API
+
+# Required:
 prism setup --non-interactive --helius-key=your-helius-key
 prism dev                               # start paper trading
 ```
 
 ## Quick Start (Manual)
 
+Choose your path based on the architecture above:
+
+**CLI only (no cloud account):**
+
 ```bash
-# 1. Clone the repository
 git clone https://github.com/irfndi/prism-liquidity-agent.git
 cd prism-liquidity-agent
-
-# 2. Install dependencies (postinstall writes a default .env if missing)
 bun install
+prism setup     # interactive .env wizard (local, no API call)
+prism dev       # start paper trading
+```
 
-# 3. Register with Prism (get your API key from deployed Cloudflare API)
-prism register
+**With cloud account (for whoami, Telegram, subscriptions):**
 
-# 4. Configure your trading agent
-prism setup
-
-# 5. Start paper trading
-prism dev
+```bash
+git clone https://github.com/irfndi/prism-liquidity-agent.git
+cd prism-liquidity-agent
+bun install
+prism register  # get API key from Cloudflare API
+prism setup     # configure Helius key + watchlist
+prism dev       # start paper trading
 ```
 
 ## Step-by-Step Setup
@@ -65,13 +144,19 @@ bun install  # postinstall writes a default .env next to package.json
 If the postinstall hook is disabled (`bun install --ignore-scripts`), run
 `bun run setup:env` manually to write the default `.env`.
 
-### 2. Register (Get API Key)
+### 2. Register (Get API Key) — OPTIONAL
 
 ```bash
 prism register
 ```
 
-This creates your identity with Prism's Cloudflare Worker and returns an API key. Store it securely in `~/.config/prism/credentials.json`.
+Creates your identity with Prism's Cloudflare Worker and returns an API key. Store it
+securely in `~/.config/prism/credentials.json`.
+
+**Skip this step if you only need local trading.** The CLI works without an API key.
+You lose access to `prism whoami`, `prism link-telegram`, `prism subscription`,
+and `prism issue` — but all trading commands (`prism dev`, `prism setup`,
+`prism wallet`, `prism backtest`, `prism update`) work fine.
 
 ### 3. Configure (Helius Key Required)
 
@@ -112,6 +197,10 @@ PAPER_TRADING=false prism dev
 ## What's Preconfigured
 
 You don't need to set these — they have sensible defaults (auto-written by the postinstall hook if missing):
+
+All env vars below are for the **CLI layer** (the local trading engine). The API and
+Telegram layers have their own configuration via the Cloudflare Dashboard and are
+not set through `.env`.
 
 - `PAPER_TRADING=true` — start with simulated trades
 - `SCAN_INTERVAL_MS=600000` — scan every 10 minutes

--- a/engine/error-reporter.ts
+++ b/engine/error-reporter.ts
@@ -4,7 +4,8 @@
  * - Sanitizes stack traces and messages (replaces base58-like keys, private keys, passwords)
  * - Buffers reports in memory and flushes in batches (5 reports or 60 seconds)
  * - Sends to a configurable endpoint via fetch (PRISM_ERROR_ENDPOINT env var, default unset = no-op)
- * - If the endpoint fetch fails, logs to console and drops the batch
+ * - If the endpoint fetch fails, the batch is re-queued at the front of the pending buffer
+ *   (oldest reports beyond MAX_PENDING_BUFFER are dropped to bound memory)
  * - Classifies errors by string match
  * - If PRISM_ERROR_REPORTING env var is "false", the reporter is a no-op (opt-out)
  * - For testability: flushAsync(), getPending(), and createErrorReporter(config) factory
@@ -213,7 +214,7 @@ export class ErrorReporter {
     console.error(`[ErrorReporter] ${category}: ${sanitizedMessage}`);
   }
 
-  async flush(): Promise<void> {
+  async flush(timeoutMs = 10_000): Promise<void> {
     if (!this.enabled || !this.endpoint || this.pending.length === 0) {
       return;
     }
@@ -225,45 +226,60 @@ export class ErrorReporter {
       reports: batch,
     };
 
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
       const response = await fetch(this.endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
+        signal: controller.signal,
       });
       if (!response.ok) {
-        this.pending.unshift(...batch);
+        this.requeueBatch(batch);
         console.error(
           `[ErrorReporter] Failed to send batch: ${response.status} ${response.statusText} (${batch.length} reports re-queued)`,
         );
       }
     } catch (err) {
-      this.pending.unshift(...batch);
+      this.requeueBatch(batch);
       console.error("[ErrorReporter] Failed to send error report batch, re-queued:", err);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private requeueBatch(batch: ReadonlyArray<ErrorReport>): void {
+    this.pending.unshift(...batch);
+    const overflow = this.pending.length - MAX_PENDING_BUFFER;
+    if (overflow > 0) {
+      this.pending.splice(MAX_PENDING_BUFFER, overflow);
     }
   }
 
   /**
    * Trigger an async flush and return a Promise that resolves when it
    * completes. Useful for shutdown paths and tests that need to assert
-   * the network call happened.
+   * the network call happened. Aborts the fetch after `timeoutMs` so a
+   * hung endpoint cannot block process exit.
    */
-  flushAsync(): Promise<void> {
+  flushAsync(timeoutMs = 10_000): Promise<void> {
     if (!this.enabled) {
       return Promise.resolve();
     }
-    return this.flush();
+    return this.flush(timeoutMs);
   }
 
   getPending(): ReadonlyArray<ErrorReport> {
     return [...this.pending];
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     if (this.timerId !== null) {
       clearInterval(this.timerId);
       this.timerId = null;
     }
+    await this.flushAsync(2_000);
   }
 }
 

--- a/engine/error-reporter.ts
+++ b/engine/error-reporter.ts
@@ -1,0 +1,274 @@
+/**
+ * Privacy-first error reporter for Prism.
+ *
+ * - Sanitizes stack traces and messages (replaces base58-like keys, private keys, passwords)
+ * - Buffers reports in memory and flushes in batches (5 reports or 60 seconds)
+ * - Sends to a configurable endpoint via fetch (PRISM_ERROR_ENDPOINT env var, default unset = no-op)
+ * - If the endpoint fetch fails, logs to console and drops the batch
+ * - Classifies errors by string match
+ * - If PRISM_ERROR_REPORTING env var is "false", the reporter is a no-op (opt-out)
+ * - For testability: flushSync(), getPending(), and createErrorReporter(config) factory
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type ErrorCategory =
+  | "ONNX_BigInt"
+  | "SQLite_Vec"
+  | "RPC_RateLimit"
+  | "UpdateFailure"
+  | "Helius_Error"
+  | "Solana_RPC"
+  | "Config_Error"
+  | "Unknown";
+
+export type ErrorSeverity = "low" | "medium" | "high" | "critical";
+
+export interface ReportContext {
+  readonly cycleId?: string;
+  readonly poolAddress?: string;
+  readonly severity?: ErrorSeverity;
+}
+
+export interface ErrorReport {
+  readonly id: string;
+  readonly ts: string;
+  readonly message: string;
+  readonly stack: string;
+  readonly category: ErrorCategory;
+  readonly severity: ErrorSeverity;
+  readonly cycleId?: string;
+  readonly poolAddress?: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface ErrorReporterConfig {
+  readonly endpoint?: string;
+  readonly enabled?: boolean;
+  readonly flushIntervalMs?: number;
+  readonly batchSize?: number;
+}
+
+export interface BatchPayload {
+  readonly app: string;
+  readonly version: string;
+  readonly reports: ReadonlyArray<ErrorReport>;
+}
+
+// ─── Defaults ────────────────────────────────────────────────────────────────
+
+const DEFAULT_FLUSH_INTERVAL_MS = 60_000;
+const DEFAULT_BATCH_SIZE = 5;
+
+// ─── Sanitization patterns ───────────────────────────────────────────────────
+// Base58 chars (no 0/O/I/l): 1-9 A-H J-N P-Z a-k m-z
+// Private keys on Solana are 64 bytes → 88 base58 chars typically.
+// We target strings >= 64 chars to avoid false-positives on pool addresses.
+
+const BASE58_LONG_PATTERN = /[1-9A-HJ-NP-Za-km-z]{64,}/g;
+const HEX_KEY_PATTERN = /\b0x[0-9a-fA-F]{64,}\b/g;
+const RAW_HEX_PATTERN = /\b[0-9a-fA-F]{64,}\b/g;
+const SECRET_PATTERN =
+  /(?:private[-_]?key|secret[-_]?key|mnemonic|seed[-_]?phrase|secret[-_]?recovery)\s*[:=]\s*[^\s,;"]+/gi;
+const PASSWORD_PATTERN = /password\s*[:=]\s*[^\s,;"]+/gi;
+
+function sanitizeMessage(msg: string): string {
+  let sanitized = msg;
+  sanitized = sanitized.replace(BASE58_LONG_PATTERN, "[REDACTED]");
+  sanitized = sanitized.replace(HEX_KEY_PATTERN, "[REDACTED]");
+  sanitized = sanitized.replace(RAW_HEX_PATTERN, "[REDACTED]");
+  sanitized = sanitized.replace(SECRET_PATTERN, (match) => {
+    const keyPart = match.split(/[:=]/)[0] ?? match;
+    return `${keyPart}=[REDACTED]`;
+  });
+  sanitized = sanitized.replace(PASSWORD_PATTERN, (match) => {
+    const keyPart = match.split(/[:=]/)[0] ?? match;
+    return `${keyPart}=[REDACTED]`;
+  });
+  return sanitized;
+}
+
+function sanitizeStack(stack: string): string {
+  return stack
+    .split("\n")
+    .map((line) => sanitizeMessage(line))
+    .join("\n");
+}
+
+// ─── Error classification ────────────────────────────────────────────────────
+
+function classifyError(error: Error): ErrorCategory {
+  const msg = error.message;
+  const stack = error.stack ?? "";
+  const combined = `${msg} ${stack}`.toLowerCase();
+
+  if (combined.includes("bigint") && combined.includes("serializ")) {
+    return "ONNX_BigInt";
+  }
+  if (combined.includes("sqlite") && combined.includes("vec")) {
+    return "SQLite_Vec";
+  }
+  if (combined.includes("rate limit") || combined.includes(" 429 ")) {
+    return "RPC_RateLimit";
+  }
+  if (combined.includes("helius")) {
+    return "Helius_Error";
+  }
+  if (combined.includes("solana") || combined.includes("rpc error")) {
+    return "Solana_RPC";
+  }
+  if (combined.includes("config")) {
+    return "Config_Error";
+  }
+  if (
+    combined.includes("update") ||
+    combined.includes("tarball") ||
+    combined.includes("download")
+  ) {
+    return "UpdateFailure";
+  }
+
+  return "Unknown";
+}
+
+// ─── ID generator ────────────────────────────────────────────────────────────
+
+let idCounter = 0;
+
+function generateId(): string {
+  idCounter++;
+  return `${Date.now().toString(36)}-${idCounter.toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// ─── ErrorReporter class ─────────────────────────────────────────────────────
+
+export class ErrorReporter {
+  private readonly endpoint: string | undefined;
+  private readonly enabled: boolean;
+  private readonly batchSize: number;
+  private readonly flushIntervalMs: number;
+  private readonly pending: Array<ErrorReport> = [];
+  private timerId: ReturnType<typeof setInterval> | null = null;
+  private appVersion: string = "0.0.0";
+
+  constructor(config: ErrorReporterConfig = {}) {
+    this.endpoint =
+      config.endpoint ??
+      (typeof process !== "undefined" ? process.env.PRISM_ERROR_ENDPOINT : undefined);
+    const reportingEnv =
+      typeof process !== "undefined" ? process.env.PRISM_ERROR_REPORTING : undefined;
+    this.enabled = config.enabled !== undefined ? config.enabled : reportingEnv !== "false";
+    this.batchSize = config.batchSize ?? DEFAULT_BATCH_SIZE;
+    this.flushIntervalMs = config.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+
+    if (this.enabled && this.endpoint) {
+      this.timerId = setInterval(() => {
+        this.flush().catch(() => {
+          /* swallow background flush errors */
+        });
+      }, this.flushIntervalMs);
+      // Allow the process to exit even if the timer is still active
+      if (typeof this.timerId === "object" && this.timerId !== null && "unref" in this.timerId) {
+        (this.timerId as NodeJS.Timeout).unref();
+      }
+    }
+  }
+
+  setAppVersion(version: string): void {
+    this.appVersion = version;
+  }
+
+  report(error: Error, context?: ReportContext): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    const category = classifyError(error);
+    const sanitizedMessage = sanitizeMessage(error.message);
+    const sanitizedStack = error.stack ? sanitizeStack(error.stack) : "";
+
+    const report: ErrorReport = {
+      id: generateId(),
+      ts: new Date().toISOString(),
+      message: sanitizedMessage,
+      stack: sanitizedStack,
+      category,
+      severity: (context?.severity ?? "medium") as ErrorSeverity,
+      ...(context?.cycleId !== undefined ? { cycleId: context.cycleId } : {}),
+      ...(context?.poolAddress !== undefined ? { poolAddress: context.poolAddress } : {}),
+    } as unknown as ErrorReport;
+
+    this.pending.push(report);
+
+    if (this.pending.length >= this.batchSize) {
+      this.flush().catch(() => {
+        /* swallow background flush errors */
+      });
+    }
+
+    console.error(`[ErrorReporter] ${category}: ${sanitizedMessage}`);
+  }
+
+  async flush(): Promise<void> {
+    if (!this.enabled || !this.endpoint || this.pending.length === 0) {
+      return;
+    }
+
+    // Take all pending reports as one batch
+    const batch = this.pending.splice(0, this.pending.length);
+    const payload: BatchPayload = {
+      app: "prism-liquidity-agent",
+      version: this.appVersion,
+      reports: batch,
+    };
+
+    try {
+      const response = await fetch(this.endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        console.error(
+          `[ErrorReporter] Failed to send batch: ${response.status} ${response.statusText}`,
+        );
+      }
+    } catch (err) {
+      console.error("[ErrorReporter] Failed to send error report batch:", err);
+    }
+  }
+
+  /**
+   * Synchronous flush — best-effort for shutdown / test scenarios.
+   * Does NOT actually wait for the network; it triggers the async flush
+   * but returns immediately.
+   */
+  flushSync(): void {
+    if (!this.enabled) {
+      return;
+    }
+    // Trigger an async flush but don't await it
+    this.flush();
+  }
+
+  getPending(): ReadonlyArray<ErrorReport> {
+    return [...this.pending];
+  }
+
+  dispose(): void {
+    if (this.timerId !== null) {
+      clearInterval(this.timerId);
+      this.timerId = null;
+    }
+  }
+}
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+export function createErrorReporter(config?: ErrorReporterConfig): ErrorReporter {
+  return new ErrorReporter(config);
+}
+
+// ─── Module-level singleton ──────────────────────────────────────────────────
+
+export const errorReporter: ErrorReporter = new ErrorReporter();

--- a/engine/error-reporter.ts
+++ b/engine/error-reporter.ts
@@ -7,7 +7,7 @@
  * - If the endpoint fetch fails, logs to console and drops the batch
  * - Classifies errors by string match
  * - If PRISM_ERROR_REPORTING env var is "false", the reporter is a no-op (opt-out)
- * - For testability: flushSync(), getPending(), and createErrorReporter(config) factory
+ * - For testability: flushAsync(), getPending(), and createErrorReporter(config) factory
  */
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -59,6 +59,7 @@ export interface BatchPayload {
 
 const DEFAULT_FLUSH_INTERVAL_MS = 60_000;
 const DEFAULT_BATCH_SIZE = 5;
+const MAX_PENDING_BUFFER = 1000;
 
 // ─── Sanitization patterns ───────────────────────────────────────────────────
 // Base58 chars (no 0/O/I/l): 1-9 A-H J-N P-Z a-k m-z
@@ -179,7 +180,7 @@ export class ErrorReporter {
   }
 
   report(error: Error, context?: ReportContext): void {
-    if (!this.enabled) {
+    if (!this.enabled || !this.endpoint) {
       return;
     }
 
@@ -193,11 +194,14 @@ export class ErrorReporter {
       message: sanitizedMessage,
       stack: sanitizedStack,
       category,
-      severity: (context?.severity ?? "medium") as ErrorSeverity,
+      severity: context?.severity ?? "medium",
       ...(context?.cycleId !== undefined ? { cycleId: context.cycleId } : {}),
       ...(context?.poolAddress !== undefined ? { poolAddress: context.poolAddress } : {}),
-    } as unknown as ErrorReport;
+    };
 
+    if (this.pending.length >= MAX_PENDING_BUFFER) {
+      this.pending.shift();
+    }
     this.pending.push(report);
 
     if (this.pending.length >= this.batchSize) {
@@ -214,7 +218,6 @@ export class ErrorReporter {
       return;
     }
 
-    // Take all pending reports as one batch
     const batch = this.pending.splice(0, this.pending.length);
     const payload: BatchPayload = {
       app: "prism-liquidity-agent",
@@ -229,26 +232,27 @@ export class ErrorReporter {
         body: JSON.stringify(payload),
       });
       if (!response.ok) {
+        this.pending.unshift(...batch);
         console.error(
-          `[ErrorReporter] Failed to send batch: ${response.status} ${response.statusText}`,
+          `[ErrorReporter] Failed to send batch: ${response.status} ${response.statusText} (${batch.length} reports re-queued)`,
         );
       }
     } catch (err) {
-      console.error("[ErrorReporter] Failed to send error report batch:", err);
+      this.pending.unshift(...batch);
+      console.error("[ErrorReporter] Failed to send error report batch, re-queued:", err);
     }
   }
 
   /**
-   * Synchronous flush — best-effort for shutdown / test scenarios.
-   * Does NOT actually wait for the network; it triggers the async flush
-   * but returns immediately.
+   * Trigger an async flush and return a Promise that resolves when it
+   * completes. Useful for shutdown paths and tests that need to assert
+   * the network call happened.
    */
-  flushSync(): void {
+  flushAsync(): Promise<void> {
     if (!this.enabled) {
-      return;
+      return Promise.resolve();
     }
-    // Trigger an async flush but don't await it
-    this.flush();
+    return this.flush();
   }
 
   getPending(): ReadonlyArray<ErrorReport> {

--- a/engine/index.ts
+++ b/engine/index.ts
@@ -18,7 +18,7 @@ process.on("uncaughtException", (err) => {
   errorReporter.report(ensureError(err), { severity: "critical" });
   console.error("Uncaught exception:", err);
   setImmediate(() => {
-    errorReporter.flushAsync().finally(() => {
+    errorReporter.flushAsync(2_000).finally(() => {
       process.exit(1);
     });
   });
@@ -38,7 +38,7 @@ Effect.runPromise(
         errorReporter.report(ensureError(err), { severity: "critical" });
         console.error("Fatal error:", err);
         setImmediate(() => {
-          errorReporter.flushAsync().finally(() => {
+          errorReporter.flushAsync(2_000).finally(() => {
             process.exit(1);
           });
         });

--- a/engine/index.ts
+++ b/engine/index.ts
@@ -2,6 +2,23 @@ import "dotenv/config";
 import { Effect } from "effect";
 import { program, buildLayer } from "./program.js";
 import { ConfigService, ConfigLive } from "./config-service.js";
+import { errorReporter } from "./error-reporter.js";
+import { getCurrentVersion } from "./version.js";
+
+errorReporter.setAppVersion(getCurrentVersion());
+
+function ensureError(cause: unknown): Error {
+  if ((cause as object) instanceof Error) {
+    return cause as Error;
+  }
+  return new Error(String(cause));
+}
+
+process.on("uncaughtException", (err) => {
+  errorReporter.report(ensureError(err), { severity: "critical" });
+  console.error("Uncaught exception:", err);
+  process.exit(1);
+});
 
 const config = Effect.runSync(
   Effect.gen(function* () {
@@ -14,6 +31,7 @@ Effect.runPromise(
     Effect.provide(buildLayer(config)),
     Effect.catchAll((err) =>
       Effect.sync(() => {
+        errorReporter.report(ensureError(err), { severity: "critical" });
         console.error("Fatal error:", err);
         process.exit(1);
       }),

--- a/engine/index.ts
+++ b/engine/index.ts
@@ -17,7 +17,11 @@ function ensureError(cause: unknown): Error {
 process.on("uncaughtException", (err) => {
   errorReporter.report(ensureError(err), { severity: "critical" });
   console.error("Uncaught exception:", err);
-  process.exit(1);
+  setImmediate(() => {
+    errorReporter.flushAsync().finally(() => {
+      process.exit(1);
+    });
+  });
 });
 
 const config = Effect.runSync(
@@ -33,7 +37,11 @@ Effect.runPromise(
       Effect.sync(() => {
         errorReporter.report(ensureError(err), { severity: "critical" });
         console.error("Fatal error:", err);
-        process.exit(1);
+        setImmediate(() => {
+          errorReporter.flushAsync().finally(() => {
+            process.exit(1);
+          });
+        });
       }),
     ),
   ),

--- a/engine/update-service.ts
+++ b/engine/update-service.ts
@@ -14,6 +14,7 @@ import {
   type ReleaseInfo,
 } from "./update-utils.js";
 import { createLogger } from "./logger.js";
+import { errorReporter } from "./error-reporter.js";
 
 const logger = createLogger("update-service");
 
@@ -142,6 +143,23 @@ export const UpdateServiceLive = Effect.gen(function* () {
           });
         });
 
+        // Pre-apply smoke tests
+        yield* Effect.try(() => {
+          execSync("bunx tsc --noEmit", { cwd: extractedDir, stdio: "inherit" });
+        }).pipe(
+          Effect.catchAll(() =>
+            Effect.fail(new Error(`TypeScript smoke test failed — refusing to install ${version}`)),
+          ),
+        );
+
+        yield* Effect.try(() => {
+          execSync("bunx vitest run --reporter=basic", { cwd: extractedDir, stdio: "inherit" });
+        }).pipe(
+          Effect.catchAll(() =>
+            Effect.fail(new Error(`Test suite smoke test failed — refusing to install ${version}`)),
+          ),
+        );
+
         // Atomic swap: stage new files alongside install root, then rename.
         // This avoids leaving the live install in a half-updated state on failure.
         const installRoot = process.cwd();
@@ -180,6 +198,31 @@ export const UpdateServiceLive = Effect.gen(function* () {
             if (existsSync(currentBackup)) {
               execSync(`mv "${currentBackup}" "${backupRoot}"`, { stdio: "inherit" });
             }
+
+            // Post-apply health check
+            console.log("Running post-apply health check...");
+            try {
+              execSync("bunx tsc --noEmit", { cwd: installRoot, stdio: "inherit", timeout: 5000 });
+            } catch (healthErr) {
+              console.error("Post-apply health check failed — rolling back");
+              try {
+                rmSync(installRoot, { recursive: true, force: true });
+                if (existsSync(backupRoot)) {
+                  execSync(`mv "${backupRoot}" "${installRoot}"`, { stdio: "inherit" });
+                }
+              } catch (rollbackErr) {
+                throw new Error(
+                  "Update failed: health check did not pass AND rollback failed. " +
+                    `Your install at ${installRoot} may be in an inconsistent state. ` +
+                    `Previous version is at ${backupRoot}.`,
+                );
+              }
+              throw new Error(
+                `Post-apply health check failed — rolled back to previous version. ` +
+                  `Error: ${(healthErr as Error).message}`,
+              );
+            }
+            console.log("✓ Post-apply health check passed");
           } catch (swapErr) {
             // Best-effort cleanup of any orphaned staging directory.
             if (existsSync(stagedRoot)) {
@@ -201,7 +244,14 @@ export const UpdateServiceLive = Effect.gen(function* () {
           rmSync(workDir, { recursive: true, force: true });
         }
       }
-    });
+    }).pipe(
+      Effect.tapError((err) =>
+        Effect.sync(() => {
+          const error = err instanceof Error ? err : new Error(String(err));
+          errorReporter.report(error, { severity: "critical" });
+        }),
+      ),
+    );
 
   const service: UpdateService = {
     checkForUpdates,

--- a/engine/update-service.ts
+++ b/engine/update-service.ts
@@ -202,7 +202,11 @@ export const UpdateServiceLive = Effect.gen(function* () {
             // Post-apply health check
             console.log("Running post-apply health check...");
             try {
-              execSync("bunx tsc --noEmit", { cwd: installRoot, stdio: "inherit", timeout: 5000 });
+              execSync("bunx tsc --noEmit", {
+                cwd: installRoot,
+                stdio: "inherit",
+                timeout: 30_000,
+              });
             } catch (healthErr) {
               console.error("Post-apply health check failed — rolling back");
               try {
@@ -217,9 +221,11 @@ export const UpdateServiceLive = Effect.gen(function* () {
                     `Previous version is at ${backupRoot}.`,
                 );
               }
+              const healthMessage =
+                healthErr instanceof Error ? healthErr.message : String(healthErr);
               throw new Error(
                 `Post-apply health check failed — rolled back to previous version. ` +
-                  `Error: ${(healthErr as Error).message}`,
+                  `Error: ${healthMessage}`,
               );
             }
             console.log("✓ Post-apply health check passed");


### PR DESCRIPTION
## Summary

Closes #28 (agent doesn't use CLI / connect to Cloudflare API) and #29 (remote error logging + auto-update resilience). Two issues, one PR: docs + infrastructure.

## Issue #28 — 3-Layer Architecture Docs

The agent wasn't aware of Prism's 3 interaction layers and bypassed the CLI by manually editing `.env` and running `bun run dev`. Made the layer architecture explicit and marked API/Telegram as optional.

- `docs/install.md`: New 'Prism Architecture' section explaining 3 layers (CLI required; API + Telegram optional) with Quickstart Options A/B/C and a feature matrix. 'One-liner Install' + 'Quick Start' + 'Step-by-Step Setup' now mark `prism register` as OPTIONAL. 'What's Preconfigured' clarified which env vars are engine config vs. cloud API config.
- `docs/agent-harness.md`: Rewrote 'Quick Start for Agents' around the 3-layer model. New 'Common Mistakes' section listing the anti-patterns from the issue (manual .env edits, `bun run dev` instead of `prism dev`, etc.).
- `AGENTS.md`: Added a minimal 3-layer note to the TL;DR section, pointing to docs/install.md for the full breakdown.

## Issue #29 — Error Reporting + Update Resilience

**New client side: `engine/error-reporter.ts`**
- Privacy-first `ErrorReporter` class with: PII sanitization (base58-like keys, hex keys, `password=xxx` patterns all replaced with `[REDACTED]`); automatic classification into ONNX_BigInt / SQLite_Vec / RPC_RateLimit / UpdateFailure / etc.; batch flushing at 5 reports or 60s; configurable endpoint via `PRISM_ERROR_ENDPOINT`; opt-out via `PRISM_ERROR_REPORTING=false`; no-op if endpoint unset.
- API: `report(err, context?)`, `flush()`, `flushSync()`, `getPending()`, `dispose()`, `setAppVersion()`.

**Wiring**
- `engine/index.ts`: Hook the reporter into the existing `Effect.catchAll` block and a process-level `uncaughtException` handler.
- `engine/update-service.ts`: `Effect.tapError` on `applyUpdate` reports failures as 'UpdateFailure'. Atomic swap rollback logic unchanged.

**CLI update resilience: `cli/update.ts`**
- Pre-apply smoke tests: `bunx tsc --noEmit` + `bunx vitest run --reporter=basic` in `extractedDir`. If either fails, throw `UpdateAbort` refusing to install.
- Post-apply health check: `bunx tsc --noEmit` (5s timeout) against the swapped-in install root. On failure, restore the previous install from `backupRoot`.

**New server side**
- `cloudflare/migrations/0002_error_logs.sql`: D1 schema for `error_logs` (id, agent_id, error_type, message, stack_trace, prism_version, platform, severity, is_recoverable, created_at) + an index on (agent_id, created_at).
- `cloudflare/workers/api/index.ts`: 
  - `POST /v1/errors/report` — accepts a single report
  - `POST /v1/errors/batch` — accepts up to 50 reports
  - `GET /v1/errors/stats` — aggregate counts per error_type over the last 24h, bearer-auth required
- `cloudflare/workers/api/errors.test.ts`: 14 vitest tests covering all endpoints, auth, batch-size validation.

**Tests**
- `bench/error-reporter.test.ts`: 24 vitest tests covering sanitization (base58, hex, password, `key=value`), classification (ONNX/SQLite/RPC/Update), batch flush at threshold, no-op when disabled, batch payload shape, failed fetch doesn't throw.

## Verification
- `bun run lint` (tsc + oxlint): **clean**
- `bun run test`: **93/93 pass** (69 prior + 24 new for the error-reporter)
- `bunx vitest run` (cloudflare): **34/34 pass** (20 prior + 14 new for errors API)

## Stats
11 files changed, 1421 insertions(+), 31 deletions(-).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Privacy-first error telemetry with automatic sensitive-data redaction, buffering, and export endpoints plus admin daily stats.
  * Stronger update/install flow with pre/post validation and rollback on failed health checks.
  * Server-side error logs storage and updated cloud environment bindings.

* **Documentation**
  * Clarified 3-layer architecture and expanded install/quickstart guidance by layer.

* **Tests**
  * Added comprehensive tests for error reporting and the new API endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->