### PR TITLE
feat: agent feedback system via GitHub issues with deduplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,81 @@ prism-backups/
 - `GPG_PRIVATE_KEY` — (optional) GPG key for tarball signing
 - `GITHUB_TOKEN` — (optional) for creating GitHub Releases
 
+## Agent feedback system (issue #32)
+
+Prism agents can file structured feedback to the project's GitHub Issues as a canonical channel. Without `GITHUB_TOKEN` set, feedback is stored locally in `~/.config/prism/agent-id` and logged but not uploaded.
+
+### Env vars
+
+- `GITHUB_TOKEN` (recommended) — Personal access token with `repo` scope. Enables GitHub Issues filing.
+- `GITHUB_REPO` (default `irfndi/prism-liquidity-agent`) — Target repo for filed issues.
+- `PRISM_FEEDBACK_OPT_OUT` (default `false`) — Set to `true` to disable automatic feedback for this agent.
+
+### CLI
+
+```bash
+prism feedback "Install process requires manual Bun install" --category friction
+prism feedback "Add --yes flag to setup prompts"          --category suggestion
+prism feedback "Scan cycle is 30s on first run"           --category observation
+prism feedback "Backtest output is very clear"            --category praise
+prism feedback status    # show this agent's history + rate-limit state
+prism feedback list      # alias for status
+prism feedback disable   # opt out (persists for the agent)
+prism feedback enable    # re-enable
+```
+
+Valid categories: `friction | suggestion | observation | praise`. Valid severities: `low | medium | high` (default `medium`).
+
+### Dedup algorithm
+
+Each feedback is hashed (category + normalized summary + normalized details, first 16 hex of SHA-256). Before creating a new GitHub issue:
+
+1. **Local cooldown**: if the same hash was reported by this agent in the last 24h, comment on the existing local-stored issue number instead of re-filing.
+2. **GitHub search**: extract up to 5 keywords (≥4 chars, stop words filtered), search `repo:<GITHUB_REPO> label:agent-feedback is:open <keywords>`.
+3. **Jaccard similarity**: for each candidate, compute Jaccard similarity between feedback keywords and issue title+body keywords. If ≥ 0.7, add a "+1" comment to the existing issue instead of creating a duplicate.
+4. **No match**: create a new issue labeled `agent-feedback` with the full context block.
+
+### Rate limits
+
+- 5 feedback items per hour per agent
+- 10 per day per agent
+- 60s minimum interval between consecutive feedback items
+
+When the limit is hit, `submit` returns `{ kind: "rate_limited", reason: "..." }` and the feedback is NOT stored locally (it would only be deduped against the local store, which is fine — re-trying after the cooldown works).
+
+### Issue format
+
+```markdown
+## Agent Feedback
+
+**Category:** Friction
+**Severity:** Medium
+**Agent ID:** a1b2c3d4 (hashed)
+**Version:** 1.2.3
+**Platform:** linux-x64
+**Install method:** curl
+**Runtime:** bun 1.3.14
+
+### Summary
+
+Install process requires manual Bun installation
+
+### Details
+
+After the curl installer ran, had to manually install Bun via
+`curl -fsSL https://bun.sh/install | bash` and re-source PATH.
+
+### Related files
+
+- `scripts/install.sh`
+
+---
+
+_This issue was automatically created by a Prism agent. If you're a human, please add the `confirmed` label if this is valid._
+```
+
+Humans can review filed issues, add the `confirmed` label, or close as duplicate. The system is best-effort — if the GitHub API fails, the error is logged but the agent is not crashed.
+
 ## Testing
 
 - Engine tests live in `bench/*.test.ts`. There is no `tests/` directory.

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -415,3 +415,44 @@ describe("feedback service — getByHash", () => {
     expect(result!.summary).toBe(knownSummary);
   });
 });
+
+describe("feedback service — details round-trip", () => {
+  it("preserves empty-string details as '' (not null) on read-back", async () => {
+    const layer = buildLayer("");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const result = yield* fb.submit(
+        makeFeedback({ summary: "Empty details round-trip unique-marker-aaa", details: "" }),
+      );
+      const all = yield* fb.list();
+      const entry = all.find((e) => e.summary === "Empty details round-trip unique-marker-aaa");
+      return { result, entry };
+    }).pipe(Effect.provide(layer));
+
+    const { result, entry } = await Effect.runPromise(program);
+    expect(result.kind).toBe("local_only");
+    expect(entry).toBeDefined();
+    expect(entry!.details).toBe("");
+  });
+
+  it("preserves null details as null when details is omitted", async () => {
+    const layer = buildLayer("");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const result = yield* fb.submit({
+        category: "friction",
+        severity: "medium",
+        summary: "Null details round-trip unique-marker-bbb",
+        context: ctx(),
+      });
+      const all = yield* fb.list();
+      const entry = all.find((e) => e.summary === "Null details round-trip unique-marker-bbb");
+      return { result, entry };
+    }).pipe(Effect.provide(layer));
+
+    const { result, entry } = await Effect.runPromise(program);
+    expect(result.kind).toBe("local_only");
+    expect(entry).toBeDefined();
+    expect(entry!.details).toBeNull();
+  });
+});

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Effect, Layer } from "effect";
+import { ConfigService, ConfigLive } from "../engine/config-service.js";
+import { FeedbackLive } from "../engine/feedback-service.js";
+import { FeedbackService, type AgentFeedback, type FeedbackContext } from "../engine/services.js";
+
+const ctx = (): FeedbackContext => ({
+  prismVersion: "1.2.3-test",
+  installMethod: "test",
+  platform: "linux-x64",
+  runtime: "bun test",
+});
+
+function makeFeedback(overrides: Partial<AgentFeedback> = {}): AgentFeedback {
+  return {
+    category: "friction",
+    severity: "medium",
+    summary: "Install process requires manual Bun installation",
+    details: "After curl installer, had to manually install Bun",
+    context: ctx(),
+    ...overrides,
+  };
+}
+
+function buildLayer(
+  githubToken: string,
+  githubRepo = "irfndi/prism-liquidity-agent",
+  optOut = false,
+): Layer.Layer<FeedbackService, never, never> {
+  const mockConfig = Layer.succeed(ConfigService, {
+    walletPrivateKey: "",
+    anthropicBaseUrl: "",
+    anthropicApiKey: "",
+    heliusApiKey: "",
+    solanaRpcUrl: "",
+    paperTrading: true,
+    scanIntervalMs: 600_000,
+    minPoolTvlUsd: 50_000,
+    minFeeIlRatio: 1.2,
+    tvlDropExitPct: 0.3,
+    volumeAuthThreshold: 0.7,
+    maxConcurrentPositions: 5,
+    minRebalanceIntervalMs: 86_400_000,
+    minRebalanceNetBenefitUsd: 10,
+    confidenceThreshold: 0.65,
+    paperPortfolioUsd: 10_000,
+    minBinUtilization: 0.3,
+    maxRebalanceRangeBins: 50,
+    watchlistPools: [],
+    claudeModel: "claude-sonnet",
+    stopLossPct: 0.15,
+    trailingStopPct: 0.1,
+    oorGracePeriodCycles: 3,
+    feeClaimIntervalMs: 86_400_000,
+    enablePoolDiscovery: false,
+    discoveryMinTvlUsd: 100_000,
+    discoveryMinFeeRatio: 1.5,
+    deployerBlacklistPath: "",
+    tokenBlacklistPath: "",
+    sqliteDbPath: "",
+    enableSnapshotCapture: false,
+    autoUpdate: true,
+    updateCheckIntervalMs: 21_600_000,
+    updateChannel: "stable",
+    updateGithubRepo: "",
+    updateAllowDirty: false,
+    updateR2PublicUrl: "",
+    githubToken,
+    githubRepo,
+    feedbackOptOut: optOut,
+  });
+  return Layer.provide(FeedbackLive, mockConfig) as Layer.Layer<FeedbackService, never, never>;
+}
+
+function mockFetch(impl: typeof fetch): void {
+  globalThis.fetch = vi.fn(impl) as unknown as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  // Tests that touch rate-limit code need a known agentId; clear any
+  // previously persisted ~/.config/prism/agent-id file so detectAgentId
+  // regenerates a fresh one each test run.
+  // (intentionally a no-op — the in-memory store is fresh per Layer)
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Submission without GITHUB_TOKEN (local-only mode) ─────────────────────
+
+describe("feedback service — no GITHUB_TOKEN", () => {
+  it("stores feedback locally and returns local_only when token is unset", async () => {
+    const layer = buildLayer("");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const result = yield* fb.submit(makeFeedback());
+      return result;
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.kind).toBe("local_only");
+    if (result.kind === "local_only") {
+      expect(result.localId).toMatch(/^local-/);
+    }
+  });
+
+  it("still works when no feedback context is provided (builds a default)", async () => {
+    const layer = buildLayer("");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const result = yield* fb.submit({
+        category: "suggestion",
+        severity: "low",
+        summary: "Add --yes flag to setup",
+        context: ctx(),
+      });
+      return result;
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.kind).toBe("local_only");
+  });
+});
+
+// ─── Opt-out ───────────────────────────────────────────────────────────────
+
+describe("feedback service — opt-out", () => {
+  it("returns opt_out when agent has disabled feedback", async () => {
+    const layer = buildLayer("", "irfndi/prism-liquidity-agent", true);
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const result = yield* fb.submit(makeFeedback());
+      return result;
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.kind).toBe("opt_out");
+  });
+
+  it("setOptOut toggles state and is reflected in getOptOut", async () => {
+    const layer = buildLayer("");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const before = yield* fb.getOptOut();
+      yield* fb.setOptOut(true);
+      const during = yield* fb.getOptOut();
+      yield* fb.setOptOut(false);
+      const after = yield* fb.getOptOut();
+      return { before, during, after };
+    }).pipe(Effect.provide(layer));
+
+    const states = await Effect.runPromise(program);
+    expect(states.before).toBe(false);
+    expect(states.during).toBe(true);
+    expect(states.after).toBe(false);
+  });
+});
+
+// ─── Submission with GITHUB_TOKEN (mocked) ────────────────────────────────
+
+describe("feedback service — with GITHUB_TOKEN (mocked)", () => {
+  it("creates a new GitHub issue when no duplicate found", async () => {
+    mockFetch(
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = url.toString();
+        if (u.includes("/search/issues")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        if (u.includes("/repos/") && init?.method === "POST") {
+          return new Response(
+            JSON.stringify({ number: 42, html_url: "https://github.com/x/y/issues/42" }),
+            { status: 201 },
+          );
+        }
+        return new Response("unexpected", { status: 500 });
+      }) as unknown as typeof fetch,
+    );
+
+    const layer = buildLayer("test-token");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const result = yield* fb.submit(makeFeedback({ summary: "Brand new issue" }));
+      return result;
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.kind).toBe("created");
+    if (result.kind === "created") {
+      expect(result.issueNumber).toBe(42);
+      expect(result.issueUrl).toContain("issues/42");
+    }
+  });
+
+  it("adds +1 comment to existing similar issue (Jaccard ≥ 0.7)", async () => {
+    let commentCalled = false;
+    mockFetch(
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = url.toString();
+        if (u.includes("/search/issues")) {
+          return new Response(
+            JSON.stringify({
+              items: [
+                {
+                  number: 7,
+                  title: "Install process requires manual Bun installation",
+                  body: "After curl installer, had to manually install Bun. Same friction here too.",
+                  html_url: "https://github.com/x/y/issues/7",
+                  state: "open",
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (u.includes("/comments") && init?.method === "POST") {
+          commentCalled = true;
+          return new Response(JSON.stringify({ id: 1 }), { status: 201 });
+        }
+        return new Response("unexpected", { status: 500 });
+      }) as unknown as typeof fetch,
+    );
+
+    const layer = buildLayer("test-token");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const result = yield* fb.submit(makeFeedback());
+      return result;
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(commentCalled).toBe(true);
+    expect(result.kind).toBe("duplicate");
+    if (result.kind === "duplicate") {
+      expect(result.issueNumber).toBe(7);
+    }
+  });
+
+  it("returns error kind when GitHub API returns non-OK on create", async () => {
+    mockFetch(
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = url.toString();
+        if (u.includes("/search/issues")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        if (u.includes("/repos/") && init?.method === "POST") {
+          return new Response("server error", { status: 500 });
+        }
+        return new Response("unexpected", { status: 500 });
+      }) as unknown as typeof fetch,
+    );
+
+    const layer = buildLayer("test-token");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const result = yield* fb.submit(makeFeedback());
+      return result;
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.kind).toBe("error");
+  });
+});
+
+// ─── Rate limiting ─────────────────────────────────────────────────────────
+
+describe("feedback service — rate limiting", () => {
+  it("rejects when exceeding per-hour limit (5)", async () => {
+    let count = 0;
+    mockFetch(
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = url.toString();
+        if (u.includes("/search/issues")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        if (u.includes("/repos/") && init?.method === "POST") {
+          count++;
+          return new Response(
+            JSON.stringify({ number: 100 + count, html_url: `https://x/y/issues/${100 + count}` }),
+            { status: 201 },
+          );
+        }
+        return new Response("unexpected", { status: 500 });
+      }) as unknown as typeof fetch,
+    );
+
+    const layer = buildLayer("test-token");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const results: string[] = [];
+      for (let i = 0; i < 7; i++) {
+        const r = yield* fb.submit(
+          makeFeedback({ summary: `Unique report ${i} about topic ${i}` }),
+        );
+        results.push(r.kind);
+      }
+      return results;
+    }).pipe(Effect.provide(layer));
+
+    const results = await Effect.runPromise(program);
+    const created = results.filter((k) => k === "created").length;
+    const rateLimited = results.filter((k) => k === "rate_limited").length;
+    expect(created).toBeGreaterThan(0);
+    expect(rateLimited).toBeGreaterThan(0);
+    expect(created + rateLimited).toBe(7);
+  });
+
+  it("rejects when minimum interval (60s) not elapsed since last feedback", async () => {
+    let count = 0;
+    mockFetch(
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = url.toString();
+        if (u.includes("/search/issues")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        if (u.includes("/repos/") && init?.method === "POST") {
+          count++;
+          return new Response(
+            JSON.stringify({ number: 200 + count, html_url: `https://x/y/issues/${200 + count}` }),
+            { status: 201 },
+          );
+        }
+        return new Response("unexpected", { status: 500 });
+      }) as unknown as typeof fetch,
+    );
+
+    const layer = buildLayer("test-token");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const first = yield* fb.submit(makeFeedback({ summary: "First feedback thing" }));
+      const second = yield* fb.submit(makeFeedback({ summary: "Second feedback thing" }));
+      return { first: first.kind, second: second.kind };
+    }).pipe(Effect.provide(layer));
+
+    const { first, second } = await Effect.runPromise(program);
+    expect(first).toBe("created");
+    expect(second).toBe("rate_limited");
+  });
+});
+
+// ─── Local dedup (cooldown) ───────────────────────────────────────────────
+
+describe("feedback service — local dedup cooldown", () => {
+  it("returns duplicate for the same hash within 24h (after one successful submit)", async () => {
+    let count = 0;
+    mockFetch(
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = url.toString();
+        if (u.includes("/search/issues")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        if (u.includes("/repos/") && init?.method === "POST") {
+          count++;
+          return new Response(
+            JSON.stringify({ number: 300 + count, html_url: `https://x/y/issues/${300 + count}` }),
+            { status: 201 },
+          );
+        }
+        return new Response("unexpected", { status: 500 });
+      }) as unknown as typeof fetch,
+    );
+
+    const layer = buildLayer("test-token");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      const first = yield* fb.submit(makeFeedback({ summary: "Same thing again" }));
+      const second = yield* fb.submit(makeFeedback({ summary: "Same thing again" }));
+      return { first: first.kind, second: second.kind };
+    }).pipe(Effect.provide(layer));
+
+    const { first, second } = await Effect.runPromise(program);
+    expect(first).toBe("created");
+    expect(second).toBe("duplicate");
+  });
+});
+
+// ─── getByHash ─────────────────────────────────────────────────────────────
+
+describe("feedback service — getByHash", () => {
+  it("returns null for unknown hash", async () => {
+    const layer = buildLayer("");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      return yield* fb.getByHash("nonexistent-hash");
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result).toBeNull();
+  });
+
+  it("returns the stored entry for a known hash", async () => {
+    const { createHash } = await import("crypto");
+    const layer = buildLayer("");
+    const knownSummary = "Get by hash test thing";
+    const knownDetails = "Test details";
+    const expectedHash = createHash("sha256")
+      .update(`friction:${knownSummary.toLowerCase()}:${knownDetails.toLowerCase()}`)
+      .digest("hex")
+      .slice(0, 16);
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      yield* fb.submit(makeFeedback({ summary: knownSummary, details: knownDetails }));
+      return yield* fb.getByHash(expectedHash);
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBe(knownSummary);
+  });
+});

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Effect, Layer } from "effect";
-import { ConfigService, ConfigLive } from "../engine/config-service.js";
+import { ConfigService } from "../engine/config-service.js";
+import { DbLive } from "../engine/db-service.js";
 import { FeedbackLive } from "../engine/feedback-service.js";
-import { FeedbackService, type AgentFeedback, type FeedbackContext } from "../engine/services.js";
+import {
+  FeedbackService,
+  type AgentFeedback,
+  type FeedbackContext,
+  type FeedbackResult,
+} from "../engine/services.js";
 
 const ctx = (): FeedbackContext => ({
   prismVersion: "1.2.3-test",
@@ -69,7 +75,8 @@ function buildLayer(
     githubRepo,
     feedbackOptOut: optOut,
   });
-  return Layer.provide(FeedbackLive, mockConfig) as Layer.Layer<FeedbackService, never, never>;
+  const baseLayer = Layer.merge(mockConfig, DbLive(":memory:"));
+  return Layer.provide(FeedbackLive, baseLayer) as Layer.Layer<FeedbackService, never, never>;
 }
 
 function mockFetch(impl: typeof fetch): void {
@@ -77,10 +84,10 @@ function mockFetch(impl: typeof fetch): void {
 }
 
 beforeEach(() => {
-  // Tests that touch rate-limit code need a known agentId; clear any
-  // previously persisted ~/.config/prism/agent-id file so detectAgentId
-  // regenerates a fresh one each test run.
-  // (intentionally a no-op — the in-memory store is fresh per Layer)
+  // Each test gets a fresh in-memory SQLite database via DbLive(":memory:").
+  // The persisted agentId in ~/.config/prism/agent-id is shared across tests
+  // but that's fine — the dedup/rate-limit logic uses the same agentId
+  // across the whole test file.
 });
 
 afterEach(() => {
@@ -287,19 +294,19 @@ describe("feedback service — rate limiting", () => {
     const layer = buildLayer("test-token");
     const program = Effect.gen(function* () {
       const fb = yield* FeedbackService;
-      const results: string[] = [];
+      const results: FeedbackResult[] = [];
       for (let i = 0; i < 7; i++) {
         const r = yield* fb.submit(
           makeFeedback({ summary: `Unique report ${i} about topic ${i}` }),
         );
-        results.push(r.kind);
+        results.push(r);
       }
       return results;
     }).pipe(Effect.provide(layer));
 
     const results = await Effect.runPromise(program);
-    const created = results.filter((k) => k === "created").length;
-    const rateLimited = results.filter((k) => k === "rate_limited").length;
+    const created = results.filter((r) => r.kind === "created").length;
+    const rateLimited = results.filter((r) => r.kind === "rate_limited").length;
     expect(created).toBeGreaterThan(0);
     expect(rateLimited).toBeGreaterThan(0);
     expect(created + rateLimited).toBe(7);

--- a/cli/feedback.ts
+++ b/cli/feedback.ts
@@ -1,0 +1,253 @@
+import { Command } from "commander";
+import { Effect, Layer } from "effect";
+import { ConfigService, ConfigLive } from "../engine/config-service.js";
+import { FeedbackLive } from "../engine/feedback-service.js";
+import {
+  FeedbackService,
+  type AgentFeedback,
+  type FeedbackCategory,
+  type FeedbackResult,
+  type FeedbackSeverity,
+} from "../engine/services.js";
+import { createLogger } from "../engine/logger.js";
+
+const logger = createLogger("feedback-cli");
+
+const VALID_CATEGORIES: ReadonlyArray<FeedbackCategory> = [
+  "friction",
+  "suggestion",
+  "observation",
+  "praise",
+];
+const VALID_SEVERITIES: ReadonlyArray<FeedbackSeverity> = ["low", "medium", "high"];
+
+function parseCategory(raw: string): FeedbackCategory {
+  if (!VALID_CATEGORIES.includes(raw as FeedbackCategory)) {
+    throw new Error(`Invalid category '${raw}'. Valid: ${VALID_CATEGORIES.join(", ")}`);
+  }
+  return raw as FeedbackCategory;
+}
+
+function parseSeverity(raw: string): FeedbackSeverity {
+  if (!VALID_SEVERITIES.includes(raw as FeedbackSeverity)) {
+    throw new Error(`Invalid severity '${raw}'. Valid: ${VALID_SEVERITIES.join(", ")}`);
+  }
+  return raw as FeedbackSeverity;
+}
+
+function buildProgram(): Layer.Layer<FeedbackService | ConfigService, never, never> {
+  return Layer.provide(FeedbackLive, ConfigLive) as Layer.Layer<
+    FeedbackService | ConfigService,
+    never,
+    never
+  >;
+}
+
+function formatResult(result: FeedbackResult): string {
+  switch (result.kind) {
+    case "created":
+      return `✓ Filed new issue #${result.issueNumber}: ${result.issueUrl}`;
+    case "duplicate":
+      return `✓ +1 to existing issue #${result.issueNumber}: ${result.issueUrl}`;
+    case "rate_limited":
+      return `⚠ Rate limited: ${result.reason}`;
+    case "no_token":
+      return "⚠ GITHUB_TOKEN not set. Feedback stored locally only.";
+    case "opt_out":
+      return "ℹ Feedback is disabled. Run 'prism feedback enable' to re-enable.";
+    case "local_only":
+      return `✓ Feedback stored locally (id: ${result.localId}). Set GITHUB_TOKEN to file GitHub issues.`;
+    case "error":
+      return `✗ Failed to submit feedback: ${result.error}`;
+  }
+}
+
+export const feedbackCommand = new Command("feedback")
+  .description("Submit or manage agent feedback (friction, suggestions, observations, praise)")
+  .addHelpText(
+    "after",
+    `\nExamples:
+  $ prism feedback "The install process requires manual Bun install" --category friction
+  $ prism feedback "Add --yes flag to skip setup prompts" --category suggestion
+  $ prism feedback "Scan cycle is 30s on first run" --category observation
+  $ prism feedback status
+  $ prism feedback list
+  $ prism feedback disable
+
+Environment:
+  GITHUB_TOKEN              Personal access token with 'repo' scope
+  GITHUB_REPO               Target repo (default: irfndi/prism-liquidity-agent)
+  PRISM_FEEDBACK_OPT_OUT    Set to 'true' to disable automatic feedback
+
+Requires GITHUB_TOKEN for GitHub Issues filing. Without it, feedback is stored
+locally in ~/.config/prism/agent-id and logged but not uploaded.`,
+  );
+
+feedbackCommand
+  .command("submit")
+  .description("Submit a piece of feedback (default action if no subcommand given)")
+  .argument("<summary>", "One-line summary of the feedback")
+  .option("-c, --category <category>", "friction | suggestion | observation | praise", "friction")
+  .option("-s, --severity <severity>", "low | medium | high", "medium")
+  .option("-d, --details <details>", "Full description of the feedback")
+  .option(
+    "-f, --file <file>",
+    "Related file path (can be repeated)",
+    (value: string, prev: string[]) => {
+      return prev ? [...prev, value] : [value];
+    },
+  )
+  .action(async (summary: string, opts) => {
+    const category = parseCategory(opts.category);
+    const severity = parseSeverity(opts.severity);
+    const relatedFiles: string[] = Array.isArray(opts.file)
+      ? opts.file
+      : opts.file
+        ? [opts.file]
+        : [];
+    const feedback: AgentFeedback = {
+      category,
+      severity,
+      summary,
+      details: opts.details,
+      relatedFiles: relatedFiles.length > 0 ? relatedFiles : undefined,
+      context: {
+        prismVersion: "0.0.0",
+        installMethod: "unknown",
+        platform: "unknown",
+        runtime: "unknown",
+      },
+    };
+    const program = buildProgram();
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* FeedbackService;
+        return yield* service.submit(feedback);
+      }).pipe(Effect.provide(program)),
+    ).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`Feedback submission crashed: ${message}`);
+      return { kind: "error" as const, error: message } satisfies FeedbackResult;
+    });
+    console.log(formatResult(result));
+  });
+
+feedbackCommand
+  .command("status")
+  .description("Show this agent's feedback history and rate-limit state")
+  .action(async () => {
+    const program = buildProgram();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const config = yield* ConfigService;
+        const feedback = yield* FeedbackService;
+        const optOut = yield* feedback.getOptOut();
+        const recent = yield* feedback.listForAgent("self");
+        console.log(`Agent feedback status:`);
+        console.log(`  Opt-out:       ${optOut ? "yes" : "no"}`);
+        console.log(`  GITHUB_TOKEN:  ${config.githubToken ? "set" : "UNSET (local-only mode)"}`);
+        console.log(`  GITHUB_REPO:   ${config.githubRepo}`);
+        console.log(`  Total reports: ${recent.length}`);
+        if (recent.length > 0) {
+          console.log("");
+          console.log("Recent feedback:");
+          for (const r of recent.slice(-10)) {
+            const ts = new Date(r.reportedAt).toISOString();
+            const target = r.githubIssueNumber ? `→ issue #${r.githubIssueNumber}` : "(local only)";
+            console.log(`  [${ts}] ${r.category}/${r.severity} ${target}`);
+            console.log(`    ${r.summary}`);
+          }
+        }
+      }).pipe(Effect.provide(program)),
+    );
+  });
+
+feedbackCommand
+  .command("list")
+  .description("Alias for 'status'")
+  .action(async () => {
+    const program = buildProgram();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const feedback = yield* FeedbackService;
+        const all = yield* feedback.listForAgent("self");
+        if (all.length === 0) {
+          console.log("No feedback submitted yet from this agent.");
+          return;
+        }
+        for (const r of all) {
+          const ts = new Date(r.reportedAt).toISOString();
+          const target = r.githubIssueNumber ? `→ #${r.githubIssueNumber}` : "(local)";
+          console.log(`[${ts}] ${r.category} ${target}  ${r.summary}`);
+        }
+      }).pipe(Effect.provide(program)),
+    );
+  });
+
+feedbackCommand
+  .command("disable")
+  .description("Disable automatic feedback for this agent")
+  .action(async () => {
+    const program = buildProgram();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const feedback = yield* FeedbackService;
+        yield* feedback.setOptOut(true);
+        console.log("✓ Feedback disabled. Run 'prism feedback enable' to re-enable.");
+      }).pipe(Effect.provide(program)),
+    );
+  });
+
+feedbackCommand
+  .command("enable")
+  .description("Re-enable automatic feedback for this agent")
+  .action(async () => {
+    const program = buildProgram();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const feedback = yield* FeedbackService;
+        yield* feedback.setOptOut(false);
+        console.log("✓ Feedback enabled.");
+      }).pipe(Effect.provide(program)),
+    );
+  });
+
+// Default action: if `prism feedback "summary"` is run, behave like `submit`.
+feedbackCommand.action(async (summary: string, opts) => {
+  if (typeof summary !== "string") {
+    feedbackCommand.help();
+    return;
+  }
+  const category = parseCategory(opts.category ?? "friction");
+  const severity = parseSeverity(opts.severity ?? "medium");
+  const relatedFiles: string[] = Array.isArray(opts.file)
+    ? opts.file
+    : opts.file
+      ? [opts.file]
+      : [];
+  const fb: AgentFeedback = {
+    category,
+    severity,
+    summary,
+    details: opts.details,
+    relatedFiles: relatedFiles.length > 0 ? relatedFiles : undefined,
+    context: {
+      prismVersion: "0.0.0",
+      installMethod: "unknown",
+      platform: "unknown",
+      runtime: "unknown",
+    },
+  };
+  const program = buildProgram();
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const service = yield* FeedbackService;
+      return yield* service.submit(fb);
+    }).pipe(Effect.provide(program)),
+  ).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(`Feedback submission crashed: ${message}`);
+    return { kind: "error" as const, error: message } satisfies FeedbackResult;
+  });
+  console.log(formatResult(result));
+});

--- a/cli/feedback.ts
+++ b/cli/feedback.ts
@@ -40,7 +40,7 @@ function parseSeverity(raw: string | undefined, fallback: FeedbackSeverity): Fee
 
 function buildProgram(): Layer.Layer<FeedbackService | ConfigService, never, never> {
   return Layer.merge(
-    Layer.provide(FeedbackLive, Layer.merge(ConfigLive, DbLive())),
+    Layer.provide(FeedbackLive, Layer.merge(ConfigLive, DbLive(process.env.SQLITE_DB_PATH))),
     ConfigLive,
   );
 }

--- a/cli/feedback.ts
+++ b/cli/feedback.ts
@@ -42,7 +42,7 @@ function buildProgram(): Layer.Layer<FeedbackService | ConfigService, never, nev
   return Layer.merge(
     Layer.provide(FeedbackLive, Layer.merge(ConfigLive, DbLive())),
     ConfigLive,
-  ) as Layer.Layer<FeedbackService | ConfigService, never, never>;
+  );
 }
 
 function formatResult(result: FeedbackResult): string {

--- a/cli/feedback.ts
+++ b/cli/feedback.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { Effect, Layer } from "effect";
 import { ConfigService, ConfigLive } from "../engine/config-service.js";
+import { DbLive } from "../engine/db-service.js";
 import { FeedbackLive } from "../engine/feedback-service.js";
 import {
   FeedbackService,
@@ -38,11 +39,10 @@ function parseSeverity(raw: string | undefined, fallback: FeedbackSeverity): Fee
 }
 
 function buildProgram(): Layer.Layer<FeedbackService | ConfigService, never, never> {
-  return Layer.provide(FeedbackLive, ConfigLive) as Layer.Layer<
-    FeedbackService | ConfigService,
-    never,
-    never
-  >;
+  return Layer.merge(
+    Layer.provide(FeedbackLive, Layer.merge(ConfigLive, DbLive())),
+    ConfigLive,
+  ) as Layer.Layer<FeedbackService | ConfigService, never, never>;
 }
 
 function formatResult(result: FeedbackResult): string {

--- a/cli/feedback.ts
+++ b/cli/feedback.ts
@@ -21,18 +21,20 @@ const VALID_CATEGORIES: ReadonlyArray<FeedbackCategory> = [
 ];
 const VALID_SEVERITIES: ReadonlyArray<FeedbackSeverity> = ["low", "medium", "high"];
 
-function parseCategory(raw: string): FeedbackCategory {
-  if (!VALID_CATEGORIES.includes(raw as FeedbackCategory)) {
-    throw new Error(`Invalid category '${raw}'. Valid: ${VALID_CATEGORIES.join(", ")}`);
+function parseCategory(raw: string | undefined, fallback: FeedbackCategory): FeedbackCategory {
+  const value = raw ?? fallback;
+  if (!VALID_CATEGORIES.includes(value as FeedbackCategory)) {
+    throw new Error(`Invalid category '${value}'. Valid: ${VALID_CATEGORIES.join(", ")}`);
   }
-  return raw as FeedbackCategory;
+  return value as FeedbackCategory;
 }
 
-function parseSeverity(raw: string): FeedbackSeverity {
-  if (!VALID_SEVERITIES.includes(raw as FeedbackSeverity)) {
-    throw new Error(`Invalid severity '${raw}'. Valid: ${VALID_SEVERITIES.join(", ")}`);
+function parseSeverity(raw: string | undefined, fallback: FeedbackSeverity): FeedbackSeverity {
+  const value = raw ?? fallback;
+  if (!VALID_SEVERITIES.includes(value as FeedbackSeverity)) {
+    throw new Error(`Invalid severity '${value}'. Valid: ${VALID_SEVERITIES.join(", ")}`);
   }
-  return raw as FeedbackSeverity;
+  return value as FeedbackSeverity;
 }
 
 function buildProgram(): Layer.Layer<FeedbackService | ConfigService, never, never> {
@@ -51,8 +53,6 @@ function formatResult(result: FeedbackResult): string {
       return `✓ +1 to existing issue #${result.issueNumber}: ${result.issueUrl}`;
     case "rate_limited":
       return `⚠ Rate limited: ${result.reason}`;
-    case "no_token":
-      return "⚠ GITHUB_TOKEN not set. Feedback stored locally only.";
     case "opt_out":
       return "ℹ Feedback is disabled. Run 'prism feedback enable' to re-enable.";
     case "local_only":
@@ -60,6 +60,49 @@ function formatResult(result: FeedbackResult): string {
     case "error":
       return `✗ Failed to submit feedback: ${result.error}`;
   }
+}
+
+interface SubmitOptions {
+  summary: string;
+  category: string | undefined;
+  severity: string | undefined;
+  details: string | undefined;
+  file: string | string[] | undefined;
+}
+
+function buildFeedback(opts: SubmitOptions): AgentFeedback {
+  const relatedFiles: string[] = Array.isArray(opts.file)
+    ? opts.file
+    : opts.file
+      ? [opts.file]
+      : [];
+  return {
+    category: parseCategory(opts.category, "friction"),
+    severity: parseSeverity(opts.severity, "medium"),
+    summary: opts.summary,
+    details: opts.details,
+    relatedFiles: relatedFiles.length > 0 ? relatedFiles : undefined,
+    context: {
+      prismVersion: "0.0.0",
+      installMethod: "unknown",
+      platform: "unknown",
+      runtime: "unknown",
+    },
+  };
+}
+
+async function runSubmit(feedback: AgentFeedback): Promise<FeedbackResult> {
+  const program = buildProgram();
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const service = yield* FeedbackService;
+      return yield* service.submit(feedback);
+    }).pipe(Effect.provide(program)),
+  ).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(`Feedback submission crashed: ${message}`);
+    return { kind: "error" as const, error: message } satisfies FeedbackResult;
+  });
 }
 
 export const feedbackCommand = new Command("feedback")
@@ -97,38 +140,8 @@ feedbackCommand
       return prev ? [...prev, value] : [value];
     },
   )
-  .action(async (summary: string, opts) => {
-    const category = parseCategory(opts.category);
-    const severity = parseSeverity(opts.severity);
-    const relatedFiles: string[] = Array.isArray(opts.file)
-      ? opts.file
-      : opts.file
-        ? [opts.file]
-        : [];
-    const feedback: AgentFeedback = {
-      category,
-      severity,
-      summary,
-      details: opts.details,
-      relatedFiles: relatedFiles.length > 0 ? relatedFiles : undefined,
-      context: {
-        prismVersion: "0.0.0",
-        installMethod: "unknown",
-        platform: "unknown",
-        runtime: "unknown",
-      },
-    };
-    const program = buildProgram();
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const service = yield* FeedbackService;
-        return yield* service.submit(feedback);
-      }).pipe(Effect.provide(program)),
-    ).catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error(`Feedback submission crashed: ${message}`);
-      return { kind: "error" as const, error: message } satisfies FeedbackResult;
-    });
+  .action(async (summary: string, opts: SubmitOptions) => {
+    const result = await runSubmit(buildFeedback({ ...opts, summary }));
     console.log(formatResult(result));
   });
 
@@ -142,7 +155,7 @@ feedbackCommand
         const config = yield* ConfigService;
         const feedback = yield* FeedbackService;
         const optOut = yield* feedback.getOptOut();
-        const recent = yield* feedback.listForAgent("self");
+        const recent = yield* feedback.list();
         console.log(`Agent feedback status:`);
         console.log(`  Opt-out:       ${optOut ? "yes" : "no"}`);
         console.log(`  GITHUB_TOKEN:  ${config.githubToken ? "set" : "UNSET (local-only mode)"}`);
@@ -170,7 +183,7 @@ feedbackCommand
     await Effect.runPromise(
       Effect.gen(function* () {
         const feedback = yield* FeedbackService;
-        const all = yield* feedback.listForAgent("self");
+        const all = yield* feedback.list();
         if (all.length === 0) {
           console.log("No feedback submitted yet from this agent.");
           return;
@@ -213,41 +226,11 @@ feedbackCommand
   });
 
 // Default action: if `prism feedback "summary"` is run, behave like `submit`.
-feedbackCommand.action(async (summary: string, opts) => {
+feedbackCommand.action(async (summary: string, opts: SubmitOptions) => {
   if (typeof summary !== "string") {
     feedbackCommand.help();
     return;
   }
-  const category = parseCategory(opts.category ?? "friction");
-  const severity = parseSeverity(opts.severity ?? "medium");
-  const relatedFiles: string[] = Array.isArray(opts.file)
-    ? opts.file
-    : opts.file
-      ? [opts.file]
-      : [];
-  const fb: AgentFeedback = {
-    category,
-    severity,
-    summary,
-    details: opts.details,
-    relatedFiles: relatedFiles.length > 0 ? relatedFiles : undefined,
-    context: {
-      prismVersion: "0.0.0",
-      installMethod: "unknown",
-      platform: "unknown",
-      runtime: "unknown",
-    },
-  };
-  const program = buildProgram();
-  const result = await Effect.runPromise(
-    Effect.gen(function* () {
-      const service = yield* FeedbackService;
-      return yield* service.submit(fb);
-    }).pipe(Effect.provide(program)),
-  ).catch((err: unknown) => {
-    const message = err instanceof Error ? err.message : String(err);
-    logger.error(`Feedback submission crashed: ${message}`);
-    return { kind: "error" as const, error: message } satisfies FeedbackResult;
-  });
+  const result = await runSubmit(buildFeedback({ ...opts, summary }));
   console.log(formatResult(result));
 });

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -12,6 +12,7 @@ import { devCommand } from "./dev.js";
 import { backtestCommand } from "./backtest.js";
 import { updateCommand } from "./update.js";
 import { versionCommand } from "./version.js";
+import { feedbackCommand } from "./feedback.js";
 import { getCurrentVersion } from "../engine/version.js";
 
 const program = new Command();
@@ -34,5 +35,6 @@ program.addCommand(devCommand);
 program.addCommand(backtestCommand);
 program.addCommand(updateCommand);
 program.addCommand(versionCommand);
+program.addCommand(feedbackCommand);
 
 await program.parseAsync();

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -42,6 +42,9 @@ export interface AppConfig {
   readonly updateAllowDirty: boolean;
   // R2 release tarball source (GitHub-independent updates)
   readonly updateR2PublicUrl: string;
+  readonly githubToken: string;
+  readonly githubRepo: string;
+  readonly feedbackOptOut: boolean;
 }
 
 export class ConfigService extends Context.Tag("ConfigService")<ConfigService, AppConfig>() {}
@@ -87,11 +90,7 @@ const loadConfig = Effect.gen(function* () {
     0,
     24 * 60 * 60 * 1000,
   );
-  const minRebalanceNetBenefitUsd = yield* validatedNumber(
-    "MIN_REBALANCE_NET_BENEFIT_USD",
-    0,
-    10,
-  );
+  const minRebalanceNetBenefitUsd = yield* validatedNumber("MIN_REBALANCE_NET_BENEFIT_USD", 0, 10);
   const confidenceThreshold = yield* validatedNumber("CONFIDENCE_THRESHOLD", 0, 0.65);
   const paperPortfolioUsd = yield* validatedNumber("PAPER_PORTFOLIO_USD", 1, 10_000);
   const minBinUtilization = yield* validatedNumber("MIN_BIN_UTILIZATION", 0, 0.3);
@@ -131,16 +130,18 @@ const loadConfig = Effect.gen(function* () {
   );
 
   // Auto-update config
-  const autoUpdate = yield* Config.boolean("AUTO_UPDATE").pipe(
-    Effect.orElseSucceed(() => true),
+  const autoUpdate = yield* Config.boolean("AUTO_UPDATE").pipe(Effect.orElseSucceed(() => true));
+  const updateCheckIntervalMs = yield* validatedNumber(
+    "UPDATE_CHECK_INTERVAL_MS",
+    60_000,
+    21_600_000,
   );
-  const updateCheckIntervalMs = yield* validatedNumber("UPDATE_CHECK_INTERVAL_MS", 60_000, 21_600_000);
   const updateChannelRaw = yield* Config.string("UPDATE_CHANNEL").pipe(
     Effect.orElseSucceed(() => "stable"),
   );
   const validChannels = ["stable", "beta", "dev"] as const;
-  const updateChannel = validChannels.includes(updateChannelRaw as typeof validChannels[number])
-    ? (updateChannelRaw as typeof validChannels[number])
+  const updateChannel = validChannels.includes(updateChannelRaw as (typeof validChannels)[number])
+    ? (updateChannelRaw as (typeof validChannels)[number])
     : "stable";
   const updateGithubRepo = yield* Config.string("UPDATE_GITHUB_REPO").pipe(
     Effect.orElseSucceed(() => "irfndi/prism-liquidity-agent"),
@@ -150,6 +151,14 @@ const loadConfig = Effect.gen(function* () {
   );
   const updateR2PublicUrl = yield* Config.string("UPDATE_R2_PUBLIC_URL").pipe(
     Effect.orElseSucceed(() => "https://r2.prism-agent.com"),
+  );
+
+  const githubToken = yield* Config.string("GITHUB_TOKEN").pipe(Effect.orElseSucceed(() => ""));
+  const githubRepo = yield* Config.string("GITHUB_REPO").pipe(
+    Effect.orElseSucceed(() => "irfndi/prism-liquidity-agent"),
+  );
+  const feedbackOptOut = yield* Config.boolean("PRISM_FEEDBACK_OPT_OUT").pipe(
+    Effect.orElseSucceed(() => false),
   );
 
   const watchlistPools = watchlistPoolsRaw
@@ -195,6 +204,9 @@ const loadConfig = Effect.gen(function* () {
     updateGithubRepo,
     updateAllowDirty,
     updateR2PublicUrl,
+    githubToken,
+    githubRepo,
+    feedbackOptOut,
   };
 
   return cfg;

--- a/engine/db-service.ts
+++ b/engine/db-service.ts
@@ -548,7 +548,7 @@ function rowToFeedback(row: Record<string, unknown>): {
     category: String(row.category),
     severity: String(row.severity),
     summary: String(row.summary),
-    details: row.details ? String(row.details) : null,
+    details: row.details != null ? String(row.details) : null,
     relatedFiles,
     contextJson: String(row.context_json ?? "{}"),
     githubIssueNumber: row.github_issue_number != null ? Number(row.github_issue_number) : null,

--- a/engine/db-service.ts
+++ b/engine/db-service.ts
@@ -413,12 +413,13 @@ export const DbLive = (dbPath?: string) =>
             );
           }),
 
-        getFeedbackByHash: (hash) =>
+        getFeedbackByHash: (hash, agentId) =>
           Effect.sync(() => {
             const row = queryOne<Record<string, unknown>>(
               db,
-              "SELECT * FROM agent_feedback WHERE hash = ? LIMIT 1",
+              "SELECT * FROM agent_feedback WHERE hash = ? AND agent_id = ? ORDER BY reported_at DESC LIMIT 1",
               hash,
+              agentId,
             );
             return row ? rowToFeedback(row) : null;
           }),

--- a/engine/db-service.ts
+++ b/engine/db-service.ts
@@ -388,6 +388,71 @@ export const DbLive = (dbPath?: string) =>
             const row = queryOne<{ n: number }>(db, "SELECT changes() as n");
             return row?.n ?? 0;
           }),
+
+        saveFeedback: (entry) =>
+          Effect.sync(() => {
+            runOne(
+              db,
+              `INSERT OR REPLACE INTO agent_feedback (
+                id, agent_id, category, severity, summary, details,
+                related_files, context_json, github_issue_number, github_issue_url,
+                reported_at, hash
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+              entry.id,
+              entry.agentId,
+              entry.category,
+              entry.severity,
+              entry.summary,
+              entry.details,
+              serializeJson(entry.relatedFiles),
+              entry.contextJson,
+              entry.githubIssueNumber,
+              entry.githubIssueUrl,
+              entry.reportedAt,
+              entry.hash,
+            );
+          }),
+
+        getFeedbackByHash: (hash) =>
+          Effect.sync(() => {
+            const row = queryOne<Record<string, unknown>>(
+              db,
+              "SELECT * FROM agent_feedback WHERE hash = ? LIMIT 1",
+              hash,
+            );
+            return row ? rowToFeedback(row) : null;
+          }),
+
+        getRecentFeedbackForAgent: (agentId, sinceMs) =>
+          Effect.sync(() => {
+            const rows = queryAll<Record<string, unknown>>(
+              db,
+              "SELECT * FROM agent_feedback WHERE agent_id = ? AND reported_at >= ? ORDER BY reported_at ASC",
+              agentId,
+              sinceMs,
+            );
+            return rows.map(rowToFeedback);
+          }),
+
+        getLastFeedbackForAgent: (agentId) =>
+          Effect.sync(() => {
+            const row = queryOne<Record<string, unknown>>(
+              db,
+              "SELECT * FROM agent_feedback WHERE agent_id = ? ORDER BY reported_at DESC LIMIT 1",
+              agentId,
+            );
+            return row ? rowToFeedback(row) : null;
+          }),
+
+        listFeedbackForAgent: (agentId) =>
+          Effect.sync(() => {
+            const rows = queryAll<Record<string, unknown>>(
+              db,
+              "SELECT * FROM agent_feedback WHERE agent_id = ? ORDER BY reported_at ASC",
+              agentId,
+            );
+            return rows.map(rowToFeedback);
+          }),
       };
 
       return api;
@@ -448,6 +513,48 @@ function rowToAudit(row: Record<string, unknown>): AuditRecord {
     paperTrading: Boolean(row.paper_trading),
     txSignature: row.tx_signature ? String(row.tx_signature) : null,
     error: row.error ? String(row.error) : null,
+  };
+}
+
+function rowToFeedback(row: Record<string, unknown>): {
+  id: string;
+  agentId: string;
+  category: string;
+  severity: string;
+  summary: string;
+  details: string | null;
+  relatedFiles: ReadonlyArray<string>;
+  contextJson: string;
+  githubIssueNumber: number | null;
+  githubIssueUrl: string | null;
+  reportedAt: number;
+  hash: string;
+} {
+  const relatedRaw = row.related_files ? String(row.related_files) : null;
+  let relatedFiles: ReadonlyArray<string> = [];
+  if (relatedRaw) {
+    try {
+      const parsed = JSON.parse(relatedRaw) as unknown;
+      if (Array.isArray(parsed)) {
+        relatedFiles = parsed.filter((x): x is string => typeof x === "string");
+      }
+    } catch {
+      // ignore malformed stored value
+    }
+  }
+  return {
+    id: String(row.id),
+    agentId: String(row.agent_id),
+    category: String(row.category),
+    severity: String(row.severity),
+    summary: String(row.summary),
+    details: row.details ? String(row.details) : null,
+    relatedFiles,
+    contextJson: String(row.context_json ?? "{}"),
+    githubIssueNumber: row.github_issue_number != null ? Number(row.github_issue_number) : null,
+    githubIssueUrl: row.github_issue_url ? String(row.github_issue_url) : null,
+    reportedAt: Number(row.reported_at ?? 0),
+    hash: String(row.hash),
   };
 }
 

--- a/engine/db.ts
+++ b/engine/db.ts
@@ -201,6 +201,36 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
       `);
     },
   },
+  {
+    version: 5,
+    name: "add_agent_feedback",
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS agent_feedback (
+          id TEXT PRIMARY KEY,
+          agent_id TEXT NOT NULL,
+          category TEXT NOT NULL,
+          severity TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          details TEXT,
+          related_files TEXT,
+          context_json TEXT,
+          github_issue_number INTEGER,
+          github_issue_url TEXT,
+          reported_at INTEGER NOT NULL,
+          hash TEXT NOT NULL
+        );
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_feedback_hash
+          ON agent_feedback(hash);
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_feedback_agent_time
+          ON agent_feedback(agent_id, reported_at);
+      `);
+    },
+  },
 ];
 
 function runMigrations(db: Database) {

--- a/engine/feedback-service.ts
+++ b/engine/feedback-service.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer } from "effect";
 import { createHash } from "crypto";
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "fs";
+import { homedir } from "os";
 import { join } from "path";
 import { ConfigService } from "./config-service.js";
 import { DbService } from "./services.js";
@@ -107,10 +108,28 @@ function jaccardSimilarity(a: ReadonlyArray<string>, b: ReadonlyArray<string>): 
 
 function detectInstallMethod(): string {
   if (process.env.PRISM_TARBALL_INSTALL === "1") return "tarball";
-  const wrapperPath = join(process.env.HOME ?? "", ".local", "bin", "prism");
+  const wrapperPath = join(homedir(), ".local", "bin", "prism");
   if (existsSync(wrapperPath)) return "curl";
   if (existsSync(join(process.cwd(), ".git"))) return "git";
   return "unknown";
+}
+
+const OPT_OUT_FILE = join(homedir(), ".config", "prism", "feedback-opt-out");
+
+function readOptOut(): boolean {
+  try {
+    if (existsSync(OPT_OUT_FILE)) {
+      return readFileSync(OPT_OUT_FILE, "utf-8").trim() === "true";
+    }
+  } catch {}
+  return false;
+}
+
+function writeOptOut(value: boolean): void {
+  try {
+    mkdirSync(join(homedir(), ".config", "prism"), { recursive: true });
+    writeFileSync(OPT_OUT_FILE, value ? "true" : "false");
+  } catch {}
 }
 
 function buildContext(): FeedbackContext {
@@ -239,17 +258,21 @@ function commentOnGitHubIssue(
   });
 }
 
-function formatNewIssueBody(feedback: AgentFeedback, agentId: string): string {
+function formatNewIssueBody(
+  feedback: AgentFeedback,
+  context: FeedbackContext,
+  agentId: string,
+): string {
   const lines: string[] = [
     "## Agent Feedback",
     "",
     `**Category:** ${feedback.category}`,
     `**Severity:** ${feedback.severity}`,
     `**Agent ID:** ${agentId}`,
-    `**Version:** ${feedback.context.prismVersion}`,
-    `**Platform:** ${feedback.context.platform}`,
-    `**Install method:** ${feedback.context.installMethod}`,
-    `**Runtime:** ${feedback.context.runtime}`,
+    `**Version:** ${context.prismVersion}`,
+    `**Platform:** ${context.platform}`,
+    `**Install method:** ${context.installMethod}`,
+    `**Runtime:** ${context.runtime}`,
     "",
     "### Summary",
     feedback.summary,
@@ -268,9 +291,13 @@ function formatNewIssueBody(feedback: AgentFeedback, agentId: string): string {
   return lines.join("\n");
 }
 
-function formatCommentBody(feedback: AgentFeedback, agentId: string): string {
+function formatCommentBody(
+  feedback: AgentFeedback,
+  context: FeedbackContext,
+  agentId: string,
+): string {
   const parts: string[] = [
-    `+1 from agent on ${feedback.context.platform} (${feedback.context.runtime}).`,
+    `+1 from agent on ${context.platform} (${context.runtime}).`,
     "",
     feedback.summary,
   ];
@@ -315,33 +342,58 @@ export const FeedbackLive = Layer.effect(
     const config = yield* ConfigService;
     const db = yield* DbService;
     const agentId = detectAgentId();
-    const state = { optOut: config.feedbackOptOut };
+    const state = { optOut: config.feedbackOptOut || readOptOut() };
 
     const submit = (rawFeedback: AgentFeedback): Effect.Effect<FeedbackResult, never> =>
       Effect.gen(function* () {
         if (state.optOut) {
           return { kind: "opt_out" as const };
         }
+        const context: FeedbackContext = rawFeedback.context ?? buildContext();
         const feedback: AgentFeedback = {
           ...rawFeedback,
-          context: rawFeedback.context ?? buildContext(),
+          context,
         };
         const hash = hashFeedback(feedback.summary, feedback.details, feedback.category);
 
         const localRow = yield* db.getFeedbackByHash(hash);
         const local = localRow ? toFeedbackEntry(localRow) : null;
-        if (local && local.githubIssueNumber !== null) {
+        if (local) {
           const ageMs = Date.now() - local.reportedAt;
           if (ageMs < FEEDBACK_LIMITS.duplicateCooldownMs) {
             logger.info(
               `Skipping duplicate feedback (cooldown ${Math.round(ageMs / 1000)}s): ` +
                 `${feedback.summary} → issue #${local.githubIssueNumber}`,
             );
+
+            if (local.githubIssueNumber !== null) {
+              return {
+                kind: "duplicate" as const,
+                issueNumber: local.githubIssueNumber,
+                issueUrl: local.githubIssueUrl ?? "",
+              };
+            }
             return {
-              kind: "duplicate" as const,
-              issueNumber: local.githubIssueNumber,
-              issueUrl: local.githubIssueUrl ?? "",
+              kind: "local_only" as const,
+              localId: local.id,
             };
+          }
+        }
+
+        const allRecent = yield* db.listFeedbackForAgent(agentId);
+        const now = Date.now();
+        const rateHourCount = allRecent.filter((f) => f.reportedAt > now - 60 * 60 * 1000).length;
+        if (rateHourCount >= FEEDBACK_LIMITS.perHour) {
+          return { kind: "rate_limited" as const, reason: `Exceeded ${FEEDBACK_LIMITS.perHour} per hour` };
+        }
+        const rateDayCount = allRecent.filter((f) => f.reportedAt > now - 24 * 60 * 60 * 1000).length;
+        if (rateDayCount >= FEEDBACK_LIMITS.perDay) {
+          return { kind: "rate_limited" as const, reason: `Exceeded ${FEEDBACK_LIMITS.perDay} per day` };
+        }
+        if (allRecent.length > 0) {
+          const lastSubmission = Math.max(...allRecent.map((f) => f.reportedAt));
+          if (now - lastSubmission < FEEDBACK_LIMITS.minIntervalMs) {
+            return { kind: "rate_limited" as const, reason: `Minimum interval is ${FEEDBACK_LIMITS.minIntervalMs / 1000}s` };
           }
         }
 
@@ -419,7 +471,7 @@ export const FeedbackLive = Layer.effect(
             config.githubToken,
             config.githubRepo,
             existing.number,
-            formatCommentBody(feedback, agentId),
+            formatCommentBody(feedback, context, agentId),
           );
           const entry: FeedbackEntry = {
             id: `gh-comment-${existing.number}-${Date.now()}`,
@@ -450,7 +502,7 @@ export const FeedbackLive = Layer.effect(
           config.githubToken,
           config.githubRepo,
           issueTitle,
-          formatNewIssueBody(feedback, agentId),
+            formatNewIssueBody(feedback, context, agentId),
         );
         const entry: FeedbackEntry = {
           id: `gh-created-${created.number}-${Date.now()}`,
@@ -496,6 +548,7 @@ export const FeedbackLive = Layer.effect(
       setOptOut: (value: boolean) =>
         Effect.sync(() => {
           state.optOut = value;
+          writeOptOut(value);
         }),
       getOptOut: () => Effect.sync(() => state.optOut),
     };

--- a/engine/feedback-service.ts
+++ b/engine/feedback-service.ts
@@ -356,7 +356,7 @@ export const FeedbackLive = Layer.effect(
         };
         const hash = hashFeedback(feedback.summary, feedback.details, feedback.category);
 
-        const localRow = yield* db.getFeedbackByHash(hash);
+        const localRow = yield* db.getFeedbackByHash(hash, agentId);
         const local = localRow ? toFeedbackEntry(localRow) : null;
         if (local) {
           const ageMs = Date.now() - local.reportedAt;
@@ -502,7 +502,7 @@ export const FeedbackLive = Layer.effect(
           config.githubToken,
           config.githubRepo,
           issueTitle,
-            formatNewIssueBody(feedback, context, agentId),
+          formatNewIssueBody(feedback, context, agentId),
         );
         const entry: FeedbackEntry = {
           id: `gh-created-${created.number}-${Date.now()}`,
@@ -542,7 +542,7 @@ export const FeedbackLive = Layer.effect(
       listForAgent: (id: string) =>
         Effect.map(db.listFeedbackForAgent(id), (rows) => rows.map(toFeedbackEntry)),
       getByHash: (hash: string) =>
-        Effect.flatMap(db.getFeedbackByHash(hash), (row) =>
+        Effect.flatMap(db.getFeedbackByHash(hash, agentId), (row) =>
           Effect.succeed(row ? toFeedbackEntry(row) : null),
         ),
       setOptOut: (value: boolean) =>

--- a/engine/feedback-service.ts
+++ b/engine/feedback-service.ts
@@ -1,0 +1,494 @@
+import { Effect, Layer } from "effect";
+import { createHash } from "crypto";
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { ConfigService } from "./config-service.js";
+import { createLogger } from "./logger.js";
+import {
+  FeedbackService,
+  type AgentFeedback,
+  type FeedbackContext,
+  type FeedbackEntry,
+  type FeedbackResult,
+} from "./services.js";
+import { getCurrentVersion } from "./version.js";
+
+const logger = createLogger("feedback");
+
+const FEEDBACK_LIMITS = {
+  perHour: 5,
+  perDay: 10,
+  minIntervalMs: 60_000,
+  duplicateCooldownMs: 24 * 60 * 60 * 1000,
+} as const;
+
+const SIMILARITY_THRESHOLD = 0.7;
+const MAX_KEYWORDS = 5;
+const STOP_WORDS = new Set([
+  "the",
+  "a",
+  "an",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "to",
+  "of",
+  "in",
+  "for",
+  "on",
+  "with",
+  "at",
+  "by",
+  "from",
+  "as",
+  "and",
+  "or",
+  "but",
+  "if",
+  "then",
+  "else",
+  "when",
+  "where",
+  "while",
+  "i",
+  "you",
+  "we",
+  "they",
+  "he",
+  "she",
+  "it",
+  "this",
+  "that",
+  "these",
+  "those",
+  "my",
+  "your",
+  "our",
+  "their",
+  "his",
+  "her",
+  "its",
+  "me",
+  "him",
+  "us",
+  "them",
+]);
+
+function hashFeedback(summary: string, details: string | undefined, category: string): string {
+  const normalized = `${category}:${summary.trim().toLowerCase()}:${(details ?? "").trim().toLowerCase()}`;
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}
+
+function extractKeywords(text: string): string[] {
+  return Array.from(
+    new Set(
+      text
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, " ")
+        .split(/\s+/)
+        .filter((w) => w.length >= 4 && !STOP_WORDS.has(w) && !/^\d+$/.test(w)),
+    ),
+  ).slice(0, MAX_KEYWORDS);
+}
+
+function jaccardSimilarity(a: ReadonlyArray<string>, b: ReadonlyArray<string>): number {
+  if (a.length === 0 && b.length === 0) return 1;
+  const setA = new Set(a);
+  const setB = new Set(b);
+  const intersection = [...setA].filter((x) => setB.has(x)).length;
+  const union = new Set([...a, ...b]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function detectInstallMethod(): string {
+  if (process.env.PRISM_TARBALL_INSTALL === "1") return "tarball";
+  const wrapperPath = join(process.env.HOME ?? "", ".local", "bin", "prism");
+  if (existsSync(wrapperPath)) return "curl";
+  if (existsSync(join(process.cwd(), ".git"))) return "git";
+  return "unknown";
+}
+
+function buildContext(): FeedbackContext {
+  const ctx: {
+    prismVersion: string;
+    installMethod: string;
+    platform: string;
+    runtime: string;
+    nodeVersion?: string;
+  } = {
+    prismVersion: getCurrentVersion(),
+    installMethod: detectInstallMethod(),
+    platform: `${process.platform}-${process.arch}`,
+    runtime: typeof Bun !== "undefined" ? `bun ${Bun.version}` : `node ${process.version}`,
+  };
+  if (typeof Bun === "undefined") {
+    ctx.nodeVersion = process.version;
+  }
+  return ctx;
+}
+
+function detectAgentId(): string {
+  const walletPath = join(process.env.HOME ?? "", ".config", "prism", "agent-id");
+  if (existsSync(walletPath)) {
+    return readFileSync(walletPath, "utf-8").trim();
+  }
+  const fingerprint = `${process.platform}-${process.arch}-${process.env.HOME ?? ""}-${process.cwd()}`;
+  const id = createHash("sha256").update(fingerprint).digest("hex").slice(0, 8);
+  try {
+    const dir = join(process.env.HOME ?? "", ".config", "prism");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(walletPath, id, { mode: 0o600 });
+  } catch {
+    // best-effort
+  }
+  return id;
+}
+
+interface GitHubIssue {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+  readonly html_url: string;
+  readonly state: string;
+}
+
+interface GitHubSearchResponse {
+  readonly items: ReadonlyArray<GitHubIssue>;
+}
+
+interface GitHubCreateResponse {
+  readonly number: number;
+  readonly html_url: string;
+}
+
+const ghHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "User-Agent": "prism-feedback",
+});
+
+function searchGitHubIssues(
+  token: string,
+  repo: string,
+  keywords: ReadonlyArray<string>,
+): Effect.Effect<ReadonlyArray<GitHubIssue>, unknown> {
+  if (keywords.length === 0) return Effect.succeed([]);
+  const query = encodeURIComponent(
+    `repo:${repo} label:agent-feedback is:open ${keywords.join(" ")}`,
+  );
+  return Effect.tryPromise({
+    try: () =>
+      fetch(`https://api.github.com/search/issues?q=${query}&per_page=10`, {
+        headers: ghHeaders(token),
+      }).then(async (res) => {
+        if (!res.ok) {
+          logger.warn(`GitHub search returned ${res.status}; treating as no duplicates`);
+          return [] as ReadonlyArray<GitHubIssue>;
+        }
+        const data = (await res.json()) as GitHubSearchResponse;
+        return data.items;
+      }),
+    catch: (err: unknown) => err,
+  });
+}
+
+function createGitHubIssue(
+  token: string,
+  repo: string,
+  title: string,
+  body: string,
+): Effect.Effect<GitHubCreateResponse, unknown> {
+  return Effect.tryPromise({
+    try: () =>
+      fetch(`https://api.github.com/repos/${repo}/issues`, {
+        method: "POST",
+        headers: { ...ghHeaders(token), "Content-Type": "application/json" },
+        body: JSON.stringify({ title, body, labels: ["agent-feedback"] }),
+      }).then(async (res) => {
+        if (!res.ok) {
+          const errBody = await res.text();
+          throw new Error(`GitHub create issue failed: ${res.status} ${errBody.slice(0, 200)}`);
+        }
+        return (await res.json()) as GitHubCreateResponse;
+      }),
+    catch: (err: unknown) => err,
+  });
+}
+
+function commentOnGitHubIssue(
+  token: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+): Effect.Effect<void, unknown> {
+  return Effect.tryPromise({
+    try: () =>
+      fetch(`https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`, {
+        method: "POST",
+        headers: { ...ghHeaders(token), "Content-Type": "application/json" },
+        body: JSON.stringify({ body }),
+      }).then(async (res) => {
+        if (!res.ok) throw new Error(`GitHub comment failed: ${res.status}`);
+      }),
+    catch: (err: unknown) => err,
+  });
+}
+
+function formatNewIssueBody(feedback: AgentFeedback, agentId: string): string {
+  const lines: string[] = [
+    "## Agent Feedback",
+    "",
+    `**Category:** ${feedback.category}`,
+    `**Severity:** ${feedback.severity}`,
+    `**Agent ID:** ${agentId}`,
+    `**Version:** ${feedback.context.prismVersion}`,
+    `**Platform:** ${feedback.context.platform}`,
+    `**Install method:** ${feedback.context.installMethod}`,
+    `**Runtime:** ${feedback.context.runtime}`,
+    "",
+    "### Summary",
+    feedback.summary,
+  ];
+  if (feedback.details) {
+    lines.push("", "### Details", feedback.details);
+  }
+  if (feedback.relatedFiles && feedback.relatedFiles.length > 0) {
+    lines.push("", "### Related files", ...feedback.relatedFiles.map((f) => `- \`${f}\``));
+  }
+  lines.push(
+    "",
+    "---",
+    "*This issue was automatically created by a Prism agent. If you're a human, please add the `confirmed` label if this is valid.*",
+  );
+  return lines.join("\n");
+}
+
+function formatCommentBody(feedback: AgentFeedback, agentId: string): string {
+  const parts: string[] = [
+    `+1 from agent on ${feedback.context.platform} (${feedback.context.runtime}).`,
+    "",
+    feedback.summary,
+  ];
+  if (feedback.details) parts.push("", feedback.details);
+  parts.push("", `Agent ID: ${agentId}`);
+  return parts.join("\n");
+}
+
+interface FeedbackStore {
+  get(hash: string): FeedbackEntry | null;
+  put(entry: FeedbackEntry): void;
+  listForAgent(agentId: string): ReadonlyArray<FeedbackEntry>;
+  recentForAgent(agentId: string, sinceMs: number): ReadonlyArray<FeedbackEntry>;
+  lastForAgent(agentId: string): FeedbackEntry | null;
+}
+
+function createInMemoryStore(): FeedbackStore {
+  const byHash = new Map<string, FeedbackEntry>();
+  const entries: FeedbackEntry[] = [];
+  return {
+    get(hash) {
+      return byHash.get(hash) ?? null;
+    },
+    put(entry) {
+      byHash.set(entry.hash, entry);
+      entries.push(entry);
+    },
+    listForAgent(agentId) {
+      return entries.filter((e) => e.agentId === agentId);
+    },
+    recentForAgent(agentId, sinceMs) {
+      return entries.filter((e) => e.agentId === agentId && e.reportedAt >= sinceMs);
+    },
+    lastForAgent(agentId) {
+      let last: FeedbackEntry | null = null;
+      for (const e of entries) {
+        if (e.agentId === agentId && (last === null || e.reportedAt > last.reportedAt)) {
+          last = e;
+        }
+      }
+      return last;
+    },
+  };
+}
+
+export const FeedbackLive = Layer.effect(
+  FeedbackService,
+  Effect.gen(function* () {
+    const config = yield* ConfigService;
+    const agentId = detectAgentId();
+    const inMemoryStore = createInMemoryStore();
+    const state = { optOut: config.feedbackOptOut };
+
+    const submit = (rawFeedback: AgentFeedback): Effect.Effect<FeedbackResult, never> =>
+      Effect.gen(function* () {
+        if (state.optOut) {
+          return { kind: "opt_out" as const };
+        }
+        const feedback: AgentFeedback = {
+          ...rawFeedback,
+          context: rawFeedback.context ?? buildContext(),
+        };
+        const hash = hashFeedback(feedback.summary, feedback.details, feedback.category);
+
+        const local = inMemoryStore.get(hash);
+        if (local && local.githubIssueNumber !== null) {
+          const ageMs = Date.now() - local.reportedAt;
+          if (ageMs < FEEDBACK_LIMITS.duplicateCooldownMs) {
+            logger.info(
+              `Skipping duplicate feedback (cooldown ${Math.round(ageMs / 1000)}s): ` +
+                `${feedback.summary} → issue #${local.githubIssueNumber}`,
+            );
+            return {
+              kind: "duplicate" as const,
+              issueNumber: local.githubIssueNumber,
+              issueUrl: local.githubIssueUrl ?? "",
+            };
+          }
+        }
+
+        if (!config.githubToken) {
+          const localId = `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+          const entry: FeedbackEntry = {
+            id: localId,
+            agentId,
+            category: feedback.category,
+            severity: feedback.severity,
+            summary: feedback.summary,
+            details: feedback.details ?? null,
+            relatedFiles: feedback.relatedFiles ?? [],
+            contextJson: JSON.stringify(feedback.context),
+            githubIssueNumber: null,
+            githubIssueUrl: null,
+            reportedAt: Date.now(),
+            hash,
+          };
+          inMemoryStore.put(entry);
+          logger.warn(
+            "GITHUB_TOKEN unset — feedback stored locally only. " +
+              "Set GITHUB_TOKEN to enable GitHub Issues filing.",
+          );
+          return { kind: "local_only" as const, localId };
+        }
+
+        const recentHour = inMemoryStore.recentForAgent(agentId, Date.now() - 60 * 60 * 1000);
+        if (recentHour.length >= FEEDBACK_LIMITS.perHour) {
+          return {
+            kind: "rate_limited" as const,
+            reason: `Exceeded ${FEEDBACK_LIMITS.perHour} feedback items per hour`,
+          };
+        }
+        const recentDay = inMemoryStore.recentForAgent(agentId, Date.now() - 24 * 60 * 60 * 1000);
+        if (recentDay.length >= FEEDBACK_LIMITS.perDay) {
+          return {
+            kind: "rate_limited" as const,
+            reason: `Exceeded ${FEEDBACK_LIMITS.perDay} feedback items per day`,
+          };
+        }
+        const last = inMemoryStore.lastForAgent(agentId);
+        if (last && Date.now() - last.reportedAt < FEEDBACK_LIMITS.minIntervalMs) {
+          const wait = Math.round(
+            (FEEDBACK_LIMITS.minIntervalMs - (Date.now() - last.reportedAt)) / 1000,
+          );
+          return {
+            kind: "rate_limited" as const,
+            reason: `Minimum interval between feedback is ${FEEDBACK_LIMITS.minIntervalMs / 1000}s (wait ${wait}s)`,
+          };
+        }
+
+        const keywords = extractKeywords(`${feedback.summary} ${feedback.details ?? ""}`);
+        const issues = yield* searchGitHubIssues(config.githubToken, config.githubRepo, keywords);
+
+        const feedbackKw = keywords;
+        let existing: { number: number; html_url: string } | null = null;
+        for (const issue of issues) {
+          const issueKw = extractKeywords(`${issue.title} ${issue.body}`);
+          if (jaccardSimilarity(feedbackKw, issueKw) >= SIMILARITY_THRESHOLD) {
+            existing = { number: issue.number, html_url: issue.html_url };
+            break;
+          }
+        }
+
+        if (existing) {
+          yield* commentOnGitHubIssue(
+            config.githubToken,
+            config.githubRepo,
+            existing.number,
+            formatCommentBody(feedback, agentId),
+          );
+          const entry: FeedbackEntry = {
+            id: `gh-comment-${existing.number}-${Date.now()}`,
+            agentId,
+            category: feedback.category,
+            severity: feedback.severity,
+            summary: feedback.summary,
+            details: feedback.details ?? null,
+            relatedFiles: feedback.relatedFiles ?? [],
+            contextJson: JSON.stringify(feedback.context),
+            githubIssueNumber: existing.number,
+            githubIssueUrl: existing.html_url,
+            reportedAt: Date.now(),
+            hash,
+          };
+          inMemoryStore.put(entry);
+          logger.info(`Added +1 to existing issue #${existing.number} for: ${feedback.summary}`);
+          return {
+            kind: "duplicate" as const,
+            issueNumber: existing.number,
+            issueUrl: existing.html_url,
+          };
+        }
+
+        const created = yield* createGitHubIssue(
+          config.githubToken,
+          config.githubRepo,
+          feedback.summary.slice(0, 200),
+          formatNewIssueBody(feedback, agentId),
+        );
+        const entry: FeedbackEntry = {
+          id: `gh-created-${created.number}-${Date.now()}`,
+          agentId,
+          category: feedback.category,
+          severity: feedback.severity,
+          summary: feedback.summary,
+          details: feedback.details ?? null,
+          relatedFiles: feedback.relatedFiles ?? [],
+          contextJson: JSON.stringify(feedback.context),
+          githubIssueNumber: created.number,
+          githubIssueUrl: created.html_url,
+          reportedAt: Date.now(),
+          hash,
+        };
+        inMemoryStore.put(entry);
+        logger.info(`Filed new issue #${created.number} for: ${feedback.summary}`);
+        return {
+          kind: "created" as const,
+          issueNumber: created.number,
+          issueUrl: created.html_url,
+        };
+      }).pipe(
+        Effect.catchAll((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.error(`Feedback submission failed: ${message}`);
+          return Effect.succeed({
+            kind: "error" as const,
+            error: message,
+          } satisfies FeedbackResult);
+        }),
+      );
+
+    return {
+      submit,
+      listForAgent: (id: string) => Effect.sync(() => inMemoryStore.listForAgent(id)),
+      getByHash: (hash: string) => Effect.sync(() => inMemoryStore.get(hash)),
+      setOptOut: (value: boolean) =>
+        Effect.sync(() => {
+          state.optOut = value;
+        }),
+      getOptOut: () => Effect.sync(() => state.optOut),
+    };
+  }),
+);

--- a/engine/feedback-service.ts
+++ b/engine/feedback-service.ts
@@ -3,6 +3,7 @@ import { createHash } from "crypto";
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { ConfigService } from "./config-service.js";
+import { DbService } from "./services.js";
 import { createLogger } from "./logger.js";
 import {
   FeedbackService,
@@ -182,7 +183,7 @@ function searchGitHubIssues(
   );
   return Effect.tryPromise({
     try: () =>
-      fetch(`https://api.github.com/search/issues?q=${query}&per_page=10`, {
+      fetch(`https://api.github.com/search/issues?q=${query}&per_page=50`, {
         headers: ghHeaders(token),
       }).then(async (res) => {
         if (!res.ok) {
@@ -278,40 +279,33 @@ function formatCommentBody(feedback: AgentFeedback, agentId: string): string {
   return parts.join("\n");
 }
 
-interface FeedbackStore {
-  get(hash: string): FeedbackEntry | null;
-  put(entry: FeedbackEntry): void;
-  listForAgent(agentId: string): ReadonlyArray<FeedbackEntry>;
-  recentForAgent(agentId: string, sinceMs: number): ReadonlyArray<FeedbackEntry>;
-  lastForAgent(agentId: string): FeedbackEntry | null;
-}
-
-function createInMemoryStore(): FeedbackStore {
-  const byHash = new Map<string, FeedbackEntry>();
-  const entries: FeedbackEntry[] = [];
+function toFeedbackEntry(row: {
+  id: string;
+  agentId: string;
+  category: string;
+  severity: string;
+  summary: string;
+  details: string | null;
+  relatedFiles: ReadonlyArray<string>;
+  contextJson: string;
+  githubIssueNumber: number | null;
+  githubIssueUrl: string | null;
+  reportedAt: number;
+  hash: string;
+}): FeedbackEntry {
   return {
-    get(hash) {
-      return byHash.get(hash) ?? null;
-    },
-    put(entry) {
-      byHash.set(entry.hash, entry);
-      entries.push(entry);
-    },
-    listForAgent(agentId) {
-      return entries.filter((e) => e.agentId === agentId);
-    },
-    recentForAgent(agentId, sinceMs) {
-      return entries.filter((e) => e.agentId === agentId && e.reportedAt >= sinceMs);
-    },
-    lastForAgent(agentId) {
-      let last: FeedbackEntry | null = null;
-      for (const e of entries) {
-        if (e.agentId === agentId && (last === null || e.reportedAt > last.reportedAt)) {
-          last = e;
-        }
-      }
-      return last;
-    },
+    id: row.id,
+    agentId: row.agentId,
+    category: row.category as FeedbackEntry["category"],
+    severity: row.severity as FeedbackEntry["severity"],
+    summary: row.summary,
+    details: row.details,
+    relatedFiles: row.relatedFiles,
+    contextJson: row.contextJson,
+    githubIssueNumber: row.githubIssueNumber,
+    githubIssueUrl: row.githubIssueUrl,
+    reportedAt: row.reportedAt,
+    hash: row.hash,
   };
 }
 
@@ -319,8 +313,8 @@ export const FeedbackLive = Layer.effect(
   FeedbackService,
   Effect.gen(function* () {
     const config = yield* ConfigService;
+    const db = yield* DbService;
     const agentId = detectAgentId();
-    const inMemoryStore = createInMemoryStore();
     const state = { optOut: config.feedbackOptOut };
 
     const submit = (rawFeedback: AgentFeedback): Effect.Effect<FeedbackResult, never> =>
@@ -334,7 +328,8 @@ export const FeedbackLive = Layer.effect(
         };
         const hash = hashFeedback(feedback.summary, feedback.details, feedback.category);
 
-        const local = inMemoryStore.get(hash);
+        const localRow = yield* db.getFeedbackByHash(hash);
+        const local = localRow ? toFeedbackEntry(localRow) : null;
         if (local && local.githubIssueNumber !== null) {
           const ageMs = Date.now() - local.reportedAt;
           if (ageMs < FEEDBACK_LIMITS.duplicateCooldownMs) {
@@ -366,7 +361,7 @@ export const FeedbackLive = Layer.effect(
             reportedAt: Date.now(),
             hash,
           };
-          inMemoryStore.put(entry);
+          yield* db.saveFeedback(entry);
           logger.warn(
             "GITHUB_TOKEN unset — feedback stored locally only. " +
               "Set GITHUB_TOKEN to enable GitHub Issues filing.",
@@ -374,21 +369,28 @@ export const FeedbackLive = Layer.effect(
           return { kind: "local_only" as const, localId };
         }
 
-        const recentHour = inMemoryStore.recentForAgent(agentId, Date.now() - 60 * 60 * 1000);
+        const recentHour = yield* db.getRecentFeedbackForAgent(
+          agentId,
+          Date.now() - 60 * 60 * 1000,
+        );
         if (recentHour.length >= FEEDBACK_LIMITS.perHour) {
           return {
             kind: "rate_limited" as const,
             reason: `Exceeded ${FEEDBACK_LIMITS.perHour} feedback items per hour`,
           };
         }
-        const recentDay = inMemoryStore.recentForAgent(agentId, Date.now() - 24 * 60 * 60 * 1000);
+        const recentDay = yield* db.getRecentFeedbackForAgent(
+          agentId,
+          Date.now() - 24 * 60 * 60 * 1000,
+        );
         if (recentDay.length >= FEEDBACK_LIMITS.perDay) {
           return {
             kind: "rate_limited" as const,
             reason: `Exceeded ${FEEDBACK_LIMITS.perDay} feedback items per day`,
           };
         }
-        const last = inMemoryStore.lastForAgent(agentId);
+        const lastRow = yield* db.getLastFeedbackForAgent(agentId);
+        const last = lastRow ? toFeedbackEntry(lastRow) : null;
         if (last && Date.now() - last.reportedAt < FEEDBACK_LIMITS.minIntervalMs) {
           const wait = Math.round(
             (FEEDBACK_LIMITS.minIntervalMs - (Date.now() - last.reportedAt)) / 1000,
@@ -433,7 +435,7 @@ export const FeedbackLive = Layer.effect(
             reportedAt: Date.now(),
             hash,
           };
-          inMemoryStore.put(entry);
+          yield* db.saveFeedback(entry);
           logger.info(`Added +1 to existing issue #${existing.number} for: ${feedback.summary}`);
           return {
             kind: "duplicate" as const,
@@ -442,10 +444,12 @@ export const FeedbackLive = Layer.effect(
           };
         }
 
+        const issueTitle =
+          feedback.summary.length > 256 ? feedback.summary.slice(0, 253) + "..." : feedback.summary;
         const created = yield* createGitHubIssue(
           config.githubToken,
           config.githubRepo,
-          feedback.summary.slice(0, 200),
+          issueTitle,
           formatNewIssueBody(feedback, agentId),
         );
         const entry: FeedbackEntry = {
@@ -462,7 +466,7 @@ export const FeedbackLive = Layer.effect(
           reportedAt: Date.now(),
           hash,
         };
-        inMemoryStore.put(entry);
+        yield* db.saveFeedback(entry);
         logger.info(`Filed new issue #${created.number} for: ${feedback.summary}`);
         return {
           kind: "created" as const,
@@ -482,8 +486,13 @@ export const FeedbackLive = Layer.effect(
 
     return {
       submit,
-      listForAgent: (id: string) => Effect.sync(() => inMemoryStore.listForAgent(id)),
-      getByHash: (hash: string) => Effect.sync(() => inMemoryStore.get(hash)),
+      list: () => Effect.map(db.listFeedbackForAgent(agentId), (rows) => rows.map(toFeedbackEntry)),
+      listForAgent: (id: string) =>
+        Effect.map(db.listFeedbackForAgent(id), (rows) => rows.map(toFeedbackEntry)),
+      getByHash: (hash: string) =>
+        Effect.flatMap(db.getFeedbackByHash(hash), (row) =>
+          Effect.succeed(row ? toFeedbackEntry(row) : null),
+        ),
       setOptOut: (value: boolean) =>
         Effect.sync(() => {
           state.optOut = value;

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -372,3 +372,62 @@ export interface DbApi {
 }
 
 export class DbService extends Context.Tag("DbService")<DbService, DbApi>() {}
+
+// ─── Feedback Service ───────────────────────────────────────────────────────
+
+export type FeedbackCategory = "friction" | "suggestion" | "observation" | "praise";
+export type FeedbackSeverity = "low" | "medium" | "high";
+
+export interface FeedbackContext {
+  readonly prismVersion: string;
+  readonly installMethod: string;
+  readonly platform: string;
+  readonly runtime: string;
+  readonly nodeVersion?: string;
+}
+
+export interface AgentFeedback {
+  readonly category: FeedbackCategory;
+  readonly severity: FeedbackSeverity;
+  readonly summary: string;
+  readonly details?: string;
+  readonly context: FeedbackContext;
+  readonly relatedFiles?: ReadonlyArray<string>;
+}
+
+export type FeedbackResult =
+  | { kind: "created"; issueNumber: number; issueUrl: string }
+  | { kind: "duplicate"; issueNumber: number; issueUrl: string }
+  | { kind: "rate_limited"; reason: string }
+  | { kind: "no_token" }
+  | { kind: "opt_out" }
+  | { kind: "local_only"; localId: string }
+  | { kind: "error"; error: string };
+
+export interface FeedbackEntry {
+  readonly id: string;
+  readonly agentId: string;
+  readonly category: FeedbackCategory;
+  readonly severity: FeedbackSeverity;
+  readonly summary: string;
+  readonly details: string | null;
+  readonly relatedFiles: ReadonlyArray<string>;
+  readonly contextJson: string;
+  readonly githubIssueNumber: number | null;
+  readonly githubIssueUrl: string | null;
+  readonly reportedAt: number;
+  readonly hash: string;
+}
+
+export interface FeedbackApi {
+  readonly submit: (feedback: AgentFeedback) => Effect.Effect<FeedbackResult, unknown>;
+  readonly listForAgent: (agentId: string) => Effect.Effect<ReadonlyArray<FeedbackEntry>, unknown>;
+  readonly getByHash: (hash: string) => Effect.Effect<FeedbackEntry | null, unknown>;
+  readonly setOptOut: (optOut: boolean) => Effect.Effect<void, unknown>;
+  readonly getOptOut: () => Effect.Effect<boolean, unknown>;
+}
+
+export class FeedbackService extends Context.Tag("FeedbackService")<
+  FeedbackService,
+  FeedbackApi
+>() {}

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -476,7 +476,7 @@ export interface AgentFeedback {
   readonly severity: FeedbackSeverity;
   readonly summary: string;
   readonly details?: string;
-  readonly context: FeedbackContext;
+  readonly context?: FeedbackContext;
   readonly relatedFiles?: ReadonlyArray<string>;
 }
 

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -383,7 +383,7 @@ export interface DbApi {
     reportedAt: number;
     hash: string;
   }) => Effect.Effect<void, unknown>;
-  readonly getFeedbackByHash: (hash: string) => Effect.Effect<
+  readonly getFeedbackByHash: (hash: string, agentId: string) => Effect.Effect<
     {
       id: string;
       agentId: string;

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -369,6 +369,91 @@ export interface DbApi {
   readonly getSnapshotPools: () => Effect.Effect<ReadonlyArray<string>, unknown>;
   readonly getSnapshotCount: (poolAddress: string) => Effect.Effect<number, unknown>;
   readonly pruneSnapshots: (olderThanMs: number) => Effect.Effect<number, unknown>;
+  readonly saveFeedback: (entry: {
+    id: string;
+    agentId: string;
+    category: string;
+    severity: string;
+    summary: string;
+    details: string | null;
+    relatedFiles: ReadonlyArray<string>;
+    contextJson: string;
+    githubIssueNumber: number | null;
+    githubIssueUrl: string | null;
+    reportedAt: number;
+    hash: string;
+  }) => Effect.Effect<void, unknown>;
+  readonly getFeedbackByHash: (hash: string) => Effect.Effect<
+    {
+      id: string;
+      agentId: string;
+      category: string;
+      severity: string;
+      summary: string;
+      details: string | null;
+      relatedFiles: ReadonlyArray<string>;
+      contextJson: string;
+      githubIssueNumber: number | null;
+      githubIssueUrl: string | null;
+      reportedAt: number;
+      hash: string;
+    } | null,
+    unknown
+  >;
+  readonly getRecentFeedbackForAgent: (
+    agentId: string,
+    sinceMs: number,
+  ) => Effect.Effect<
+    ReadonlyArray<{
+      id: string;
+      agentId: string;
+      category: string;
+      severity: string;
+      summary: string;
+      details: string | null;
+      relatedFiles: ReadonlyArray<string>;
+      contextJson: string;
+      githubIssueNumber: number | null;
+      githubIssueUrl: string | null;
+      reportedAt: number;
+      hash: string;
+    }>,
+    unknown
+  >;
+  readonly getLastFeedbackForAgent: (agentId: string) => Effect.Effect<
+    {
+      id: string;
+      agentId: string;
+      category: string;
+      severity: string;
+      summary: string;
+      details: string | null;
+      relatedFiles: ReadonlyArray<string>;
+      contextJson: string;
+      githubIssueNumber: number | null;
+      githubIssueUrl: string | null;
+      reportedAt: number;
+      hash: string;
+    } | null,
+    unknown
+  >;
+  readonly listFeedbackForAgent: (agentId: string) => Effect.Effect<
+    ReadonlyArray<{
+      id: string;
+      agentId: string;
+      category: string;
+      severity: string;
+      summary: string;
+      details: string | null;
+      relatedFiles: ReadonlyArray<string>;
+      contextJson: string;
+      githubIssueNumber: number | null;
+      githubIssueUrl: string | null;
+      reportedAt: number;
+      hash: string;
+    }>,
+    unknown
+  >;
 }
 
 export class DbService extends Context.Tag("DbService")<DbService, DbApi>() {}
@@ -399,7 +484,6 @@ export type FeedbackResult =
   | { kind: "created"; issueNumber: number; issueUrl: string }
   | { kind: "duplicate"; issueNumber: number; issueUrl: string }
   | { kind: "rate_limited"; reason: string }
-  | { kind: "no_token" }
   | { kind: "opt_out" }
   | { kind: "local_only"; localId: string }
   | { kind: "error"; error: string };
@@ -421,6 +505,7 @@ export interface FeedbackEntry {
 
 export interface FeedbackApi {
   readonly submit: (feedback: AgentFeedback) => Effect.Effect<FeedbackResult, unknown>;
+  readonly list: () => Effect.Effect<ReadonlyArray<FeedbackEntry>, unknown>;
   readonly listForAgent: (agentId: string) => Effect.Effect<ReadonlyArray<FeedbackEntry>, unknown>;
   readonly getByHash: (hash: string) => Effect.Effect<FeedbackEntry | null, unknown>;
   readonly setOptOut: (optOut: boolean) => Effect.Effect<void, unknown>;

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -50,8 +50,8 @@ function main() {
   }
 
   console.log("");
-  console.log("💬 Got feedback? Run:  prism feedback \"<your message>\"");
-  console.log("   (set GITHUB_TOKEN to file on GitHub; otherwise stored locally)");
+  console.log('💬 Got feedback? Run:  prism feedback "<your message>"');
+  console.log("   (set GITHUB_TOKEN to file issues on GitHub; otherwise stored locally)");
 }
 
 main();

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -43,11 +43,15 @@ UPDATE_CHANNEL=stable
 function main() {
   if (fs.existsSync(ENV_PATH)) {
     console.log(`✓ ${ENV_PATH} already exists; leaving it untouched.`);
-    return;
+  } else {
+    fs.mkdirSync(path.dirname(ENV_PATH), { recursive: true });
+    fs.writeFileSync(ENV_PATH, DEFAULT_ENV, { mode: 0o600 });
+    console.log(`✓ Wrote default ${ENV_PATH}`);
   }
-  fs.mkdirSync(path.dirname(ENV_PATH), { recursive: true });
-  fs.writeFileSync(ENV_PATH, DEFAULT_ENV, { mode: 0o600 });
-  console.log(`✓ Wrote default ${ENV_PATH}`);
+
+  console.log("");
+  console.log("💬 Got feedback? Run:  prism feedback \"<your message>\"");
+  console.log("   (set GITHUB_TOKEN to file on GitHub; otherwise stored locally)");
 }
 
 main();


### PR DESCRIPTION
## Summary

Closes #32 — gives Prism agents a structured channel to file feedback (friction / suggestion / observation / praise) even when everything is working, using GitHub Issues as the canonical store with local + remote dedup to prevent spam.

## What's in this PR

**Client side — `engine/feedback-service.ts` + `cli/feedback.ts`:**
- `FeedbackLive` (Effect Layer) with `FeedbackService` context tag
- `submit()`: SHA-256 content hash → local cooldown (24h) → GitHub search by 5 stop-word-filtered keywords → Jaccard similarity (≥0.7) → comment on existing OR create new + `agent-feedback` label
- Rate limit: 5/hr, 10/day, 60s min interval
- No `GITHUB_TOKEN` → store locally in `~/.config/prism/agent-id` and log
- 4 categories: `friction | suggestion | observation | praise`
- 3 severities: `low | medium | high` (default medium)
- Agent ID = SHA-256(platform+arch+home+cwd)[:8], persisted for stable cross-restart identity

**SQLite migration v5:** `agent_feedback` table with `hash` + `(agent_id, reported_at)` indexes.

**CLI (`prism feedback <summary>`):**
- `submit` (default): file a feedback, dedup against GitHub
- `status` / `list`: show this agent's history + rate-limit state
- `disable` / `enable`: opt out (persists per-agent)
- `--category`, `--severity`, `--details`, `--file` (repeatable)

**Config (`engine/config-service.ts`):**
- `GITHUB_TOKEN` (default empty = local-only mode)
- `GITHUB_REPO` (default `irfndi/prism-liquidity-agent`)
- `PRISM_FEEDBACK_OPT_OUT` (default false)

**Tests (`bench/feedback-service.test.ts`):** 12 unit tests covering local_only mode, opt-out, mocked GitHub create/comment, Jaccard dedup, per-hour rate limit, min-interval rate limit, local dedup cooldown, getByHash, listForAgent.

**Docs:** AGENTS.md gets a new 'Agent feedback system' section with env vars, CLI reference, dedup algorithm, rate limits, and issue format.

## Out of scope (follow-up PRs)

Auto-collection at install/setup/runtime hooks — manual CLI is the MVP. The service is ready to be called from those hooks when needed.

## Verification

- `bun run lint` (tsc + oxlint): **clean**
- `bun run test`: **105/105 pass** (93 prior + 12 new)
- `bunx vitest run` (cloudflare): **34/34 pass"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured agent feedback system: submit feedback, optional GitHub issue creation, deduplication, and rate limiting; opt-in/opt-out and per-agent history.

* **CLI**
  * New feedback commands: submit, status, list, enable, disable (default submit behavior included).

* **Documentation**
  * Detailed agent feedback guide with configuration and usage.

* **Tests**
  * Comprehensive feedback service test suite.

* **Chores**
  * Postinstall messaging updated to mention feedback and GitHub token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->