### PR TITLE
fix(version): sync package.json to v0.0.2 to match latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
+      - name: Sync package.json version
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          node -e "const fs=require('fs');const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));pkg.version='${VERSION}';fs.writeFileSync('package.json',JSON.stringify(pkg,null,2)+'\n');"
+          echo "→ package.json version set to ${VERSION}"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,7 @@ jobs:
 
       - name: Sync package.json version
         run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          node -e "const fs=require('fs');const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));pkg.version='${VERSION}';fs.writeFileSync('package.json',JSON.stringify(pkg,null,2)+'\n');"
+          node -e "const fs=require('fs');const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));pkg.version=process.env.VERSION;fs.writeFileSync('package.json',JSON.stringify(pkg,null,2)+'\n');"
           echo "→ package.json version set to ${VERSION}"
 
       - name: Setup Bun

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-liquidity-agent",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "description": "Autonomous liquidity agent for Solana pools (currently Meteora DLMM)",
   "keywords": [
     "ai-agent",


### PR DESCRIPTION
## Problem

Issue #36 sub-issue 4: `prism update` is broken for every current user.

`package.json` declared version `1.0.0` but the latest GitHub release was `v0.0.2`. The updater compared the local `1.0.0` against the release manifest's `0.0.2` and concluded "no update available" — so no one could ever upgrade.

Symptoms:
- `prism --version` reports `1.0.0` but no `1.0.0` exists on GitHub
- `prism update` always says "no update available"
- Update mechanism effectively dead for all installations

## Fix

Two atomic changes in one commit:

1. **`package.json`**: bump `1.0.0` → `0.0.2` to match the actual latest release
2. **`.github/workflows/release.yml`**: add a step that syncs `package.json` version to the pushed tag on every release, so this drift cannot happen again

## Verification

- `bun run lint` clean
- `bun run test` 93/93 passing
- `node -e "console.log(require('./package.json').version)"` → `0.0.2`

## Out of scope (for a follow-up PR)

The release workflow also hardcodes `min_cli_version: "1.0.0"` in all three manifest files (stable/beta/dev). After this PR, the local version is `0.0.2` but the manifest still says the minimum CLI version is `1.0.0`. This is inconsistent and should be fixed in PR #B (or a separate cleanup PR).

Part of #36 (sub-issue 4). PR #B will address the other 3 sub-issues (install flow bypass, doc contradiction, anonymous telemetry).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.0.2.
  * Enhanced release automation to synchronize version information during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->