### PR TITLE
feat(skills): publish Prism skills to 4 agent harness marketplaces (issue #33 partial)

### DIFF
--- a/.agents/skills/prism-install.md
+++ b/.agents/skills/prism-install.md
@@ -30,13 +30,6 @@ curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/s
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-For a pinned release tarball (faster, no git history, reproducible):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/download/v0.0.2/prism-v0.0.2.tar.gz bash
-export PATH="$HOME/.local/bin:$PATH"
-```
-
 ## Configure
 
 Non-interactive (for agents and CI):

--- a/.agents/skills/prism-install.md
+++ b/.agents/skills/prism-install.md
@@ -33,7 +33,7 @@ export PATH="$HOME/.local/bin:$PATH"
 For a pinned release tarball (faster, no git history, reproducible):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/download/v0.0.2/prism-v0.0.2.tar.gz bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
@@ -110,7 +110,7 @@ tail -n 20 logs/audit-trail.jsonl   # should show scan cycle decisions
 Stop the engine with Ctrl+C (or `pkill -f "bun.*prism"`). The agent's install root is `~/.prism` by default. To uninstall:
 
 ```bash
-rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id
+rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id ~/.config/prism/credentials.json ~/.config/prism/wallet.json
 ```
 
 ## See Also

--- a/.agents/skills/prism-install.md
+++ b/.agents/skills/prism-install.md
@@ -33,8 +33,7 @@ export PATH="$HOME/.local/bin:$PATH"
 For a pinned release tarball (faster, no git history, reproducible):
 
 ```bash
-PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz \
-  curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
@@ -45,6 +44,8 @@ Non-interactive (for agents and CI):
 ```bash
 prism setup --non-interactive --helius-key=$HELIUS_KEY
 ```
+
+If you don't know which pools to watch, also set `ENABLE_POOL_DISCOVERY=true` in `.env` so the agent can find candidates on its own.
 
 Interactive (for humans):
 

--- a/.agents/skills/prism-install.md
+++ b/.agents/skills/prism-install.md
@@ -1,0 +1,121 @@
+# Prism Install Skill
+
+Use this skill when an agent needs to install, configure, or run the Prism liquidity agent for automated Meteora DLMM rebalancing on Solana.
+
+## When to Activate
+
+- User asks to install a Solana liquidity agent, trading bot, or DLMM rebalancer
+- User wants to automate Meteora DLMM pool positions
+- User wants to earn fees from concentrated-liquidity pools without manual management
+- User mentions `prism`, `prism-liquidity-agent`, or `@irfndi/prism-liquidity-agent`
+
+## Three Layers (CLI is the only required one)
+
+Prism is designed in three independent layers. The CLI is required; the API and Telegram are optional add-ons.
+
+| Layer | Purpose | Required? |
+|---|---|---|
+| CLI (local) | Runs the trading engine, reads `.env`, persists positions to SQLite | **Yes** |
+| API (cloud) | Cloud account, whoami, subscription, issue filing, feedback | No |
+| Telegram (chat) | Monitor and control the agent from `@prism_agent_bot` | No |
+
+The CLI is fully functional without the API. Do not assume `prism register` is required — it isn't.
+
+## Install
+
+The one-liner installer handles Bun (installs if missing), clones the repo, installs dependencies, runs postinstall, and writes a `prism` wrapper to `~/.local/bin/`.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+For a pinned release tarball (faster, no git history, reproducible):
+
+```bash
+PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz \
+  curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Configure
+
+Non-interactive (for agents and CI):
+
+```bash
+prism setup --non-interactive --helius-key=$HELIUS_KEY
+```
+
+Interactive (for humans):
+
+```bash
+prism setup
+```
+
+This writes `.env` with the Helius key, an optional watchlist, and paper-trading defaults. The default mode is **paper trading** — no real funds are at risk.
+
+## Start Trading
+
+```bash
+prism dev
+```
+
+This spawns the engine. Decisions are logged to `logs/audit-trail.jsonl`. To stop, send SIGINT (Ctrl+C).
+
+## Common Commands
+
+| Command | Purpose |
+|---|---|
+| `prism status` | Check current state (alias for `prism whoami` if registered) |
+| `prism whoami` | Show cloud account info (requires `prism register`) |
+| `prism register` | Create a cloud account, returns an API key (optional) |
+| `prism setup` | Interactive `.env` wizard |
+| `prism dev` | Start the trading engine |
+| `prism backtest` | Run a historical simulation (synthetic or replay from snapshots) |
+| `prism update` | Check for and apply updates from R2/GitHub releases |
+| `prism feedback "<msg>"` | File structured feedback to the project (auto-deduped) |
+| `prism wallet {generate,import,show}` | Manage the local Solana keypair (required for live trading) |
+| `prism link-telegram` | Link the cloud account to `@prism_agent_bot` |
+
+## Common Mistakes
+
+1. **Running `bun run dev` instead of `prism dev`.** Both start the engine, but `prism dev` goes through the CLI wrapper that resolves the install root and respects config. `bun run dev` bypasses that and may write `.env` to the wrong directory.
+2. **Manually editing `.env`.** Use `prism setup` to update config. Hand-edits work but skip validation.
+3. **Assuming `prism register` is required.** It isn't. Skip it for local-only setups.
+4. **Setting `PAPER_TRADING=false` without a wallet.** Live mode requires `WALLET_PRIVATE_KEY` in `.env`. Use `prism wallet generate` to create one.
+5. **Forgetting to export `PATH`.** After the one-liner install, `~/.local/bin` must be on `PATH` for the `prism` wrapper to be found.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `prism: command not found` | `~/.local/bin` not on PATH | `export PATH="$HOME/.local/bin:$PATH"` |
+| `Bun not found` during install | Bun not installed | Installer auto-installs Bun; check `$HOME/.bun/bin` |
+| `sqlite-vec` fails on Linux | Bundled SQLite lacks extensions | Engine falls back to system `libsqlite3.so` automatically (see `engine/db.ts`) |
+| `BigInt` serialization error from embeddings | ONNX runtime issue in Node.js | Set `EMBEDDINGS_BACKEND=fallback` in `.env` (default) |
+| Helius 401/403 | Invalid API key | Re-run `prism setup --non-interactive --helius-key=$NEW_KEY` |
+| Engine starts but makes no decisions | Empty watchlist and `ENABLE_POOL_DISCOVERY=false` | Set `ENABLE_POOL_DISCOVERY=true` in `.env` |
+
+## Verify Installation
+
+```bash
+prism --version       # should print 0.0.2 or later
+prism dev &           # start engine in background
+sleep 30
+tail -n 20 logs/audit-trail.jsonl   # should show scan cycle decisions
+```
+
+## When Done
+
+Stop the engine with Ctrl+C (or `pkill -f "bun.*prism"`). The agent's install root is `~/.prism` by default. To uninstall:
+
+```bash
+rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id
+```
+
+## See Also
+
+- `dlmm-rebalancer` skill — strategy-level reasoning (HOLD/REBALANCE/EXIT/ENTER)
+- `prism-rebalance` skill (planned, in `marketplaces/`) — trading operations
+- `docs/agent-harness.md` — full agent integration guide
+- `AGENTS.md` — repo notes for AI agents

--- a/.agents/skills/prism-install.md
+++ b/.agents/skills/prism-install.md
@@ -67,14 +67,13 @@ This spawns the engine. Decisions are logged to `logs/audit-trail.jsonl`. To sto
 
 | Command | Purpose |
 |---|---|
-| `prism status` | Check current state (alias for `prism whoami` if registered) |
 | `prism whoami` | Show cloud account info (requires `prism register`) |
 | `prism register` | Create a cloud account, returns an API key (optional) |
 | `prism setup` | Interactive `.env` wizard |
 | `prism dev` | Start the trading engine |
 | `prism backtest` | Run a historical simulation (synthetic or replay from snapshots) |
 | `prism update` | Check for and apply updates from R2/GitHub releases |
-| `prism feedback "<msg>"` | File structured feedback to the project (auto-deduped) |
+| `prism issue "<msg>"` | File a GitHub issue (auto-deduped) |
 | `prism wallet {generate,import,show}` | Manage the local Solana keypair (required for live trading) |
 | `prism link-telegram` | Link the cloud account to `@prism_agent_bot` |
 

--- a/.agents/skills/prism-install.md
+++ b/.agents/skills/prism-install.md
@@ -73,7 +73,6 @@ This spawns the engine. Decisions are logged to `logs/audit-trail.jsonl`. To sto
 | `prism dev` | Start the trading engine |
 | `prism backtest` | Run a historical simulation (synthetic or replay from snapshots) |
 | `prism update` | Check for and apply updates from R2/GitHub releases |
-| `prism issue "<msg>"` | File a GitHub issue (auto-deduped) |
 | `prism wallet {generate,import,show}` | Manage the local Solana keypair (required for live trading) |
 | `prism link-telegram` | Link the cloud account to `@prism_agent_bot` |
 
@@ -82,7 +81,7 @@ This spawns the engine. Decisions are logged to `logs/audit-trail.jsonl`. To sto
 1. **Running `bun run dev` instead of `prism dev`.** Both start the engine, but `prism dev` goes through the CLI wrapper that resolves the install root and respects config. `bun run dev` bypasses that and may write `.env` to the wrong directory.
 2. **Manually editing `.env`.** Use `prism setup` to update config. Hand-edits work but skip validation.
 3. **Assuming `prism register` is required.** It isn't. Skip it for local-only setups.
-4. **Setting `PAPER_TRADING=false` without a wallet.** Live mode requires `WALLET_PRIVATE_KEY` in `.env`. Use `prism wallet generate` to create one.
+4. **Setting `PAPER_TRADING=false` without a wallet.** Live mode requires `WALLET_PRIVATE_KEY` in `.env`. Generate a keypair with `prism wallet generate` (saves to `~/.config/prism/wallet.json`) and copy the private key into `WALLET_PRIVATE_KEY=` in `.env`.
 5. **Forgetting to export `PATH`.** After the one-liner install, `~/.local/bin` must be on `PATH` for the `prism` wrapper to be found.
 
 ## Troubleshooting

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -35,8 +35,6 @@ function buildLayer(
 ): Layer.Layer<FeedbackService, never, never> {
   const mockConfig = Layer.succeed(ConfigService, {
     walletPrivateKey: "",
-    anthropicBaseUrl: "",
-    anthropicApiKey: "",
     heliusApiKey: "",
     solanaRpcUrl: "",
     paperTrading: true,
@@ -53,7 +51,6 @@ function buildLayer(
     minBinUtilization: 0.3,
     maxRebalanceRangeBins: 50,
     watchlistPools: [],
-    claudeModel: "claude-sonnet",
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
     oorGracePeriodCycles: 3,

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -17,7 +17,7 @@ Agent harnesses discover installation guides automatically when a skill file is 
 
 | Harness | Local install path | Skill file |
 |---|---|---|
-| OpenCode | `~/.opencode/skills/prism-install/SKILL.md` | [`../marketplaces/opencode/SKILL.md`](../marketplaces/opencode/SKILL.md) |
+| OpenCode | `~/.config/opencode/skills/prism-install/SKILL.md` | [`../marketplaces/opencode/SKILL.md`](../marketplaces/opencode/SKILL.md) |
 | OpenClaw | `~/.openclaw/skills/prism-install/SKILL.md` | [`../marketplaces/openclaw/SKILL.md`](../marketplaces/openclaw/SKILL.md) |
 | Hermes | `~/.hermes/skills/software-development/prism-install/SKILL.md` | [`../marketplaces/hermes/SKILL.md`](../marketplaces/hermes/SKILL.md) |
 | acpx / custom | `~/.agents/skills/prism-install.md` | [`../.agents/skills/prism-install.md`](../.agents/skills/prism-install.md) |

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -11,6 +11,21 @@ Prism is designed to be operated by AI agent harnesses (OpenClaw, Hermes, acpx, 
 | acpx          | ✅ Supported | CLI wrapper         |
 | Custom agents | ✅ Supported | HTTP API + CLI      |
 
+## Skills (auto-discovered by agent harnesses)
+
+Agent harnesses discover installation guides automatically when a skill file is placed in their skills directory. Prism ships copy-paste-ready skills for all four Markdown-based harnesses:
+
+| Harness | Local install path | Skill file |
+|---|---|---|
+| OpenCode | `~/.opencode/skills/prism-install/SKILL.md` | [`../marketplaces/opencode/SKILL.md`](../marketplaces/opencode/SKILL.md) |
+| OpenClaw | `~/.openclaw/skills/prism-install/SKILL.md` | [`../marketplaces/openclaw/SKILL.md`](../marketplaces/openclaw/SKILL.md) |
+| Hermes | `~/.hermes/skills/software-development/prism-install/SKILL.md` | [`../marketplaces/hermes/SKILL.md`](../marketplaces/hermes/SKILL.md) |
+| acpx / custom | `~/.agents/skills/prism-install.md` | [`../.agents/skills/prism-install.md`](../.agents/skills/prism-install.md) |
+
+The project's own strategy skill ([`../.agents/skills/dlmm-rebalancer.md`](../.agents/skills/dlmm-rebalancer.md)) covers HOLD/REBALANCE/EXIT/ENTER reasoning and is usable from any harness.
+
+For the full status of all 10 target marketplaces (including the 6 that still need code packages — MCP server, AutoGPT, LangChain, CrewAI, Dify, Flowise), see [`../marketplaces/README.md`](../marketplaces/README.md).
+
 ## Live Infrastructure (Already Deployed)
 
 Agents do **not** need to deploy Cloudflare workers. They are already running:

--- a/marketplaces/README.md
+++ b/marketplaces/README.md
@@ -88,7 +88,7 @@ The content can be adapted from the existing four skill files — the install/co
 
 ## See Also
 
-- [Issue #33](https://github.com/irfndi/prism-liqudity-agent/issues/33) — original phased plan
+- [Issue #33](https://github.com/irfndi/prism-liquidity-agent/issues/33) — original phased plan
 - [`docs/agent-harness.md`](../docs/agent-harness.md) — full agent integration guide
 - [`.agents/skills/`](../.agents/skills/) — the project's own skill directory (acpx format)
 - [`dlmm-rebalancer`](../.agents/skills/dlmm-rebalancer.md) — strategy-level reasoning skill

--- a/marketplaces/README.md
+++ b/marketplaces/README.md
@@ -6,7 +6,7 @@ This directory contains Prism installation skills for various agent harness mark
 
 | # | Marketplace | Status | Skill file | Local install path |
 |---|---|---|---|---|
-| 1 | **OpenCode** | ✅ Ready | [`opencode/SKILL.md`](opencode/SKILL.md) | `~/.opencode/skills/prism-install/SKILL.md` |
+| 1 | **OpenCode** | ✅ Ready | [`opencode/SKILL.md`](opencode/SKILL.md) | `~/.config/opencode/skills/prism-install/SKILL.md` |
 | 1b | **OpenClaw** | ✅ Ready | [`openclaw/SKILL.md`](openclaw/SKILL.md) | `~/.openclaw/skills/prism-install/SKILL.md` |
 | 1c | **Hermes** | ✅ Ready | [`hermes/SKILL.md`](hermes/SKILL.md) | `~/.hermes/skills/software-development/prism-install/SKILL.md` |
 | 1d | **acpx / custom** | ✅ Ready | [`.agents/skills/prism-install.md`](../.agents/skills/prism-install.md) | `~/.agents/skills/prism-install.md` |
@@ -48,8 +48,8 @@ For each ready marketplace, copy the SKILL.md to the local path shown in the tab
 
 ```bash
 # OpenCode
-mkdir -p ~/.opencode/skills/prism-install
-cp marketplaces/opencode/SKILL.md ~/.opencode/skills/prism-install/SKILL.md
+mkdir -p ~/.config/opencode/skills/prism-install
+cp marketplaces/opencode/SKILL.md ~/.config/opencode/skills/prism-install/SKILL.md
 
 # OpenClaw
 mkdir -p ~/.openclaw/skills/prism-install

--- a/marketplaces/README.md
+++ b/marketplaces/README.md
@@ -6,11 +6,11 @@ This directory contains Prism installation skills for various agent harness mark
 
 | # | Marketplace | Status | Skill file | Local install path |
 |---|---|---|---|---|
-| 1 | **OpenCode** | ⏳ Pending | (added in PR #40, not in this branch) | `~/.opencode/skills/prism-install/SKILL.md` |
-| 1b | **OpenClaw** | ⏳ Pending | (added in PR #40, not in this branch) | `~/.openclaw/skills/prism-install/SKILL.md` |
-| 1c | **Hermes** | ⏳ Pending | (added in PR #40, not in this branch) | `~/.hermes/skills/software-development/prism-install/SKILL.md` |
-| 1d | **acpx / custom** | ⏳ Pending | (added in PR #40, not in this branch) | `~/.agents/skills/prism-install.md` |
-| 2 | Claude Desktop (MCP) | ✅ Ready | [`../mcp-server/README.md`](../mcp-server/README.md) | Configure in `claude_desktop_config.json` |
+| 1 | **OpenCode** | ✅ Ready | [`opencode/SKILL.md`](opencode/SKILL.md) | `~/.opencode/skills/prism-install/SKILL.md` |
+| 1b | **OpenClaw** | ✅ Ready | [`openclaw/SKILL.md`](openclaw/SKILL.md) | `~/.openclaw/skills/prism-install/SKILL.md` |
+| 1c | **Hermes** | ✅ Ready | [`hermes/SKILL.md`](hermes/SKILL.md) | `~/.hermes/skills/software-development/prism-install/SKILL.md` |
+| 1d | **acpx / custom** | ✅ Ready | [`.agents/skills/prism-install.md`](../.agents/skills/prism-install.md) | `~/.agents/skills/prism-install.md` |
+| 2 | Claude Desktop (MCP) | ❌ Not started | — | Requires `prism-mcp-server` npm package |
 | 3 | OpenAI GPTs | ❌ Not started | — | Requires OpenAI GPT Store submission (UI-only) |
 | 4 | AutoGPT | ❌ Not started | — | Requires `autogpt-prism` PyPI package |
 | 5 | LangChain | ❌ Not started | — | Requires `langchain-prism` PyPI package |
@@ -20,26 +20,31 @@ This directory contains Prism installation skills for various agent harness mark
 | 9 | ChatGPT Plugins (legacy) | ❌ Not started | — | Deprecated; OpenAI GPTs is the successor |
 | 10 | Custom agent harnesses | ✅ Ready | Same as 1d (acpx) | See [docs/agent-harness.md](../docs/agent-harness.md) |
 
-## What's Done (5/10)
+## What's Done (4/10)
 
-- **4 Markdown-based harnesses** (OpenCode, OpenClaw, Hermes, acpx) — copy-paste-ready skill files
-- **Claude Desktop (MCP)** — standalone `prism-mcp-server` npm package with 4 tools (status, positions, whoami, backtest)
+The four Markdown-based harnesses have copy-paste-ready skill files:
 
-## What's Not Done (5/10)
+- **OpenCode** uses YAML frontmatter (`name`, `description`)
+- **OpenClaw** uses plain Markdown with no frontmatter
+- **Hermes** uses a richer frontmatter with `metadata.hermes.{tags, related_skills, category}`
+- **acpx / custom** uses the project's own `.agents/skills/` format (plain Markdown, no frontmatter)
 
-The remaining five harnesses require code packages or platform submissions that are each multi-day projects:
+## What's Not Done (6/10)
 
+The remaining six harnesses require code packages or platform submissions that are each multi-day projects:
+
+- **MCP server** (Claude Desktop) — needs a new `prism-mcp-server` npm package exposing `prism_status`, `prism_positions`, `prism_start`, `prism_stop`, `prism_backtest` as MCP tools
 - **OpenAI GPTs** — UI-only submission to the GPT Store; can't be automated from this repo
 - **AutoGPT / LangChain / CrewAI** — each needs a separate PyPI package with a Python class wrapping the CLI
 - **Dify / Flowise** — each needs a platform-specific plugin format and submission
 
-These are tracked in the issue #33 phased plan. None of them block the core install path (the 5 ready harnesses cover all major agent ecosystems).
+These are tracked in the issue #33 phased plan. None of them block the core install path (the 4 ready harnesses cover all major agent ecosystems that use Markdown skills).
 
 ## How to Use
 
 ### Install via the ready skill files
 
-For each ready Markdown marketplace, copy the SKILL.md to the local path shown in the table above:
+For each ready marketplace, copy the SKILL.md to the local path shown in the table above:
 
 ```bash
 # OpenCode
@@ -61,26 +66,14 @@ cp .agents/skills/prism-install.md ~/.agents/skills/prism-install.md
 
 After copying, restart your agent harness so it picks up the new skill.
 
-### Configure the MCP server (Claude Desktop)
+### Verify the skill was discovered
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+The exact command depends on the harness:
 
-```json
-{
-  "mcpServers": {
-    "prism": {
-      "command": "node",
-      "args": ["/absolute/path/to/mcp-server/dist/index.js"],
-      "env": {
-        "PRISM_BIN": "/absolute/path/to/prism",
-        "SQLITE_DB_PATH": "/absolute/path/to/prism.db"
-      }
-    }
-  }
-}
-```
-
-See [`../mcp-server/README.md`](../mcp-server/README.md) for the full configuration guide.
+- **OpenCode**: `skill()` then ask for `prism-install`
+- **OpenClaw**: restart the harness; skills in `~/.openclaw/skills/` are loaded automatically
+- **Hermes**: restart the harness; skills in `~/.hermes/skills/` are loaded automatically
+- **acpx**: the skill is in the standard `.agents/skills/` location; acpx discovers it on next run
 
 ## Adding a New Marketplace
 
@@ -95,7 +88,7 @@ The content can be adapted from the existing four skill files — the install/co
 
 ## See Also
 
-- [Issue #33](https://github.com/irfndi/prism-liquidity-agent/issues/33) — original phased plan
+- [Issue #33](https://github.com/irfndi/prism-liqudity-agent/issues/33) — original phased plan
 - [`docs/agent-harness.md`](../docs/agent-harness.md) — full agent integration guide
 - [`.agents/skills/`](../.agents/skills/) — the project's own skill directory (acpx format)
 - [`dlmm-rebalancer`](../.agents/skills/dlmm-rebalancer.md) — strategy-level reasoning skill

--- a/marketplaces/hermes/SKILL.md
+++ b/marketplaces/hermes/SKILL.md
@@ -41,8 +41,7 @@ export PATH="$HOME/.local/bin:$PATH"
 For a pinned release tarball (faster, no git history, reproducible):
 
 ```bash
-PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz \
-  curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 

--- a/marketplaces/hermes/SKILL.md
+++ b/marketplaces/hermes/SKILL.md
@@ -53,6 +53,8 @@ prism setup --non-interactive --helius-key=$HELIUS_KEY
 
 This writes `.env` with the Helius key, an optional watchlist, and paper-trading defaults. The default mode is **paper trading** — no real funds are at risk.
 
+If you don't know which pools to watch, also set `ENABLE_POOL_DISCOVERY=true` in `.env` so the agent can find candidates on its own.
+
 ### 3. Start
 
 ```bash

--- a/marketplaces/hermes/SKILL.md
+++ b/marketplaces/hermes/SKILL.md
@@ -76,13 +76,12 @@ The CLI is fully functional without the cloud API. Do not assume `prism register
 | Command | Purpose |
 |---|---|
 | `prism dev` | Start the trading engine |
-| `prism status` | Check current state |
 | `prism setup` | Interactive `.env` wizard |
 | `prism register` | Create a cloud account (optional) |
 | `prism whoami` | Show cloud account info (requires `prism register`) |
 | `prism backtest` | Run a historical simulation |
 | `prism update` | Check for and apply updates |
-| `prism feedback "<msg>"` | File structured feedback to the project |
+| `prism issue "<msg>"` | File a GitHub issue (auto-deduped) |
 | `prism wallet {generate,import,show}` | Manage the local Solana keypair |
 | `prism link-telegram` | Link the cloud account to `@prism_agent_bot` |
 

--- a/marketplaces/hermes/SKILL.md
+++ b/marketplaces/hermes/SKILL.md
@@ -38,13 +38,6 @@ curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/s
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-For a pinned release tarball (faster, no git history, reproducible):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz bash
-export PATH="$HOME/.local/bin:$PATH"
-```
-
 ### 2. Configure
 
 ```bash

--- a/marketplaces/hermes/SKILL.md
+++ b/marketplaces/hermes/SKILL.md
@@ -116,5 +116,5 @@ tail -n 20 logs/audit-trail.jsonl   # should show scan cycle decisions
 ## Uninstall
 
 ```bash
-rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id
+rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id ~/.config/prism/credentials.json ~/.config/prism/wallet.json
 ```

--- a/marketplaces/hermes/SKILL.md
+++ b/marketplaces/hermes/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: prism-install
+description: Install and configure Prism liquidity agent for Meteora DLMM pools
+version: 1.0.0
+author: irfndi
+license: MIT
+metadata:
+  hermes:
+    tags: [defi, solana, trading, liquidity, meteora, dlmm]
+    related_skills: [prism-rebalance, prism-backtest]
+    category: software-development
+---
+
+# Prism Install
+
+Use this skill when the user wants to install Prism for automated liquidity management on Solana.
+
+## When to Use
+
+- User asks to install a trading bot or liquidity agent
+- User wants to automate Meteora DLMM positions
+- User wants to earn fees from Solana DeFi pools
+- User mentions `prism`, `prism-liquidity-agent`, or `@irfndi/prism-liquidity-agent`
+
+## Prerequisites
+
+- Bun 1.2+ (auto-installed if missing)
+- Helius API key (get one at https://helius.dev)
+
+## Installation Steps
+
+### 1. Install Prism
+
+The one-liner installer handles Bun (installs if missing), clones the repo, installs dependencies, runs postinstall, and writes a `prism` wrapper to `~/.local/bin/`.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+For a pinned release tarball (faster, no git history, reproducible):
+
+```bash
+PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz \
+  curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+### 2. Configure
+
+```bash
+prism setup --non-interactive --helius-key=$HELIUS_KEY
+```
+
+This writes `.env` with the Helius key, an optional watchlist, and paper-trading defaults. The default mode is **paper trading** — no real funds are at risk.
+
+### 3. Start
+
+```bash
+prism dev
+```
+
+Decisions are logged to `logs/audit-trail.jsonl`. To stop, send SIGINT (Ctrl+C).
+
+## Three Layers (CLI is the only required one)
+
+The CLI is fully functional without the cloud API. Do not assume `prism register` is required — it isn't.
+
+| Layer | Purpose | Required? |
+|---|---|---|
+| CLI (local) | Runs the trading engine, persists positions to SQLite | **Yes** |
+| API (cloud) | Cloud account, whoami, subscription, issue filing | No |
+| Telegram (chat) | Monitor and control the agent from `@prism_agent_bot` | No |
+
+## Available Commands
+
+| Command | Purpose |
+|---|---|
+| `prism dev` | Start the trading engine |
+| `prism status` | Check current state |
+| `prism setup` | Interactive `.env` wizard |
+| `prism register` | Create a cloud account (optional) |
+| `prism whoami` | Show cloud account info (requires `prism register`) |
+| `prism backtest` | Run a historical simulation |
+| `prism update` | Check for and apply updates |
+| `prism feedback "<msg>"` | File structured feedback to the project |
+| `prism wallet {generate,import,show}` | Manage the local Solana keypair |
+| `prism link-telegram` | Link the cloud account to `@prism_agent_bot` |
+
+## Common Mistakes
+
+1. **Running `bun run dev` instead of `prism dev`.** `prism dev` goes through the CLI wrapper that resolves the install root and respects config. `bun run dev` bypasses that and may write `.env` to the wrong directory.
+2. **Manually editing `.env`.** Use `prism setup` to update config. Hand-edits work but skip validation.
+3. **Assuming `prism register` is required.** Skip it for local-only setups.
+4. **Setting `PAPER_TRADING=false` without a wallet.** Live mode requires `WALLET_PRIVATE_KEY` in `.env`. Use `prism wallet generate` to create one.
+5. **Forgetting to export `PATH`.** After the one-liner install, `~/.local/bin` must be on `PATH` for the `prism` wrapper to be found.
+
+## Troubleshooting
+
+- If Bun not found: `curl -fsSL https://bun.sh/install | bash`
+- If sqlite-vec fails: Engine uses system SQLite automatically
+- If ONNX error: Fallback embeddings enabled (`EMBEDDINGS_BACKEND=fallback` is the default)
+- If `prism: command not found`: `export PATH="$HOME/.local/bin:$PATH"`
+- If Helius 401/403: Re-run `prism setup --non-interactive --helius-key=$NEW_KEY`
+- If engine starts but makes no decisions: Set `ENABLE_POOL_DISCOVERY=true` in `.env`
+
+## Verify Installation
+
+```bash
+prism --version       # should print 0.0.2 or later
+prism dev &           # start engine in background
+sleep 30
+tail -n 20 logs/audit-trail.jsonl   # should show scan cycle decisions
+```
+
+## Uninstall
+
+```bash
+rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id
+```

--- a/marketplaces/openclaw/SKILL.md
+++ b/marketplaces/openclaw/SKILL.md
@@ -1,0 +1,96 @@
+# Prism Liquidity Agent
+
+Install and run Prism for automated Meteora DLMM rebalancing on Solana.
+
+## When This Skill Activates
+
+- User wants to install a Solana liquidity trading agent
+- User wants to automate Meteora DLMM pool rebalancing
+- User wants to earn fees from concentrated-liquidity pools on Solana
+- User mentions `prism`, `prism-liquidity-agent`, or `@irfndi/prism-liquidity-agent`
+
+## Installation
+
+The one-liner installer handles Bun (installs if missing), clones the repo, installs dependencies, runs postinstall, and writes a `prism` wrapper to `~/.local/bin/`.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+For a pinned release tarball:
+
+```bash
+PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz \
+  curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Configuration
+
+```bash
+prism setup --non-interactive --helius-key=$HELIUS_KEY
+```
+
+This writes `.env` with the Helius key, an optional watchlist, and paper-trading defaults. The default mode is **paper trading** — no real funds are at risk.
+
+## Start Trading
+
+```bash
+prism dev
+```
+
+Decisions are logged to `logs/audit-trail.jsonl`. To stop, send SIGINT (Ctrl+C).
+
+## Available Commands
+
+- `prism status` — Check agent status
+- `prism positions` — List open positions
+- `prism backtest` — Run backtest
+- `prism update` — Check for updates
+- `prism feedback "<msg>"` — File structured feedback
+- `prism register` — Create a cloud account (optional)
+- `prism wallet {generate,import,show}` — Manage the local Solana keypair
+- `prism link-telegram` — Link to `@prism_agent_bot`
+
+## Three Layers (CLI is the only required one)
+
+The CLI is fully functional without the cloud API. Do not assume `prism register` is required — it isn't.
+
+| Layer | Purpose | Required? |
+|---|---|---|
+| CLI (local) | Runs the trading engine | **Yes** |
+| API (cloud) | Cloud account, whoami, subscription | No |
+| Telegram (chat) | Monitor from `@prism_agent_bot` | No |
+
+## Common Mistakes
+
+1. Running `bun run dev` instead of `prism dev` — `prism dev` respects the install root.
+2. Manually editing `.env` — use `prism setup`.
+3. Assuming `prism register` is required — it isn't.
+4. Setting `PAPER_TRADING=false` without a wallet — use `prism wallet generate` first.
+5. Forgetting to export `PATH` after install.
+
+## Troubleshooting
+
+- `prism: command not found` → `export PATH="$HOME/.local/bin:$PATH"`
+- `Bun not found` → installer auto-installs; check `$HOME/.bun/bin`
+- `sqlite-vec` fails on Linux → engine falls back to system `libsqlite3.so` automatically
+- `BigInt` serialization error → set `EMBEDDINGS_BACKEND=fallback` in `.env` (default)
+- Helius 401/403 → re-run `prism setup` with a valid key
+- Engine starts but makes no decisions → set `ENABLE_POOL_DISCOVERY=true` in `.env`
+
+## Verify Installation
+
+```bash
+prism --version       # should print 0.0.2 or later
+prism dev &           # start engine in background
+sleep 30
+tail -n 20 logs/audit-trail.jsonl
+```
+
+## Uninstall
+
+```bash
+rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id
+```

--- a/marketplaces/openclaw/SKILL.md
+++ b/marketplaces/openclaw/SKILL.md
@@ -21,8 +21,7 @@ export PATH="$HOME/.local/bin:$PATH"
 For a pinned release tarball:
 
 ```bash
-PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz \
-  curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
@@ -44,11 +43,10 @@ Decisions are logged to `logs/audit-trail.jsonl`. To stop, send SIGINT (Ctrl+C).
 
 ## Available Commands
 
-- `prism status` — Check agent status
-- `prism positions` — List open positions
+- `prism whoami` — Show current account
 - `prism backtest` — Run backtest
 - `prism update` — Check for updates
-- `prism feedback "<msg>"` — File structured feedback
+- `prism issue "<msg>"` — File a GitHub issue
 - `prism register` — Create a cloud account (optional)
 - `prism wallet {generate,import,show}` — Manage the local Solana keypair
 - `prism link-telegram` — Link to `@prism_agent_bot`

--- a/marketplaces/openclaw/SKILL.md
+++ b/marketplaces/openclaw/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: prism-install
+description: Install and run Prism for automated Meteora DLMM rebalancing on Solana
+---
+
 # Prism Liquidity Agent
 
 Install and run Prism for automated Meteora DLMM rebalancing on Solana.

--- a/marketplaces/openclaw/SKILL.md
+++ b/marketplaces/openclaw/SKILL.md
@@ -26,7 +26,7 @@ export PATH="$HOME/.local/bin:$PATH"
 For a pinned release tarball:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/download/v0.0.2/prism-v0.0.2.tar.gz bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 

--- a/marketplaces/openclaw/SKILL.md
+++ b/marketplaces/openclaw/SKILL.md
@@ -95,5 +95,5 @@ tail -n 20 logs/audit-trail.jsonl
 ## Uninstall
 
 ```bash
-rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id
+rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id ~/.config/prism/credentials.json ~/.config/prism/wallet.json
 ```

--- a/marketplaces/openclaw/SKILL.md
+++ b/marketplaces/openclaw/SKILL.md
@@ -23,13 +23,6 @@ curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/s
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-For a pinned release tarball:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/download/v0.0.2/prism-v0.0.2.tar.gz bash
-export PATH="$HOME/.local/bin:$PATH"
-```
-
 ## Configuration
 
 ```bash

--- a/marketplaces/opencode/SKILL.md
+++ b/marketplaces/opencode/SKILL.md
@@ -26,7 +26,7 @@ export PATH="$HOME/.local/bin:$PATH"
 For a pinned release tarball (faster, no git history, reproducible):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-v0.0.2.tar.gz bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/download/v0.0.2/prism-v0.0.2.tar.gz bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 

--- a/marketplaces/opencode/SKILL.md
+++ b/marketplaces/opencode/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: prism-install
+description: Install, configure, and run the Prism liquidity agent for automated Meteora DLMM rebalancing on Solana
+---
+
+# Prism Install
+
+Use this skill when an agent needs to set up or operate the Prism liquidity agent for automated Meteora DLMM rebalancing on Solana.
+
+## When to Use
+
+- User asks to install a Solana liquidity agent, trading bot, or DLMM rebalancer
+- User wants to automate Meteora DLMM pool positions
+- User wants to earn fees from concentrated-liquidity pools without manual management
+- User mentions `prism`, `prism-liquidity-agent`, or `@irfndi/prism-liquidity-agent`
+
+## Installation
+
+The one-liner installer handles Bun (installs if missing), clones the repo, installs dependencies, runs postinstall, and writes a `prism` wrapper to `~/.local/bin/`.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+For a pinned release tarball (faster, no git history, reproducible):
+
+```bash
+PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz \
+  curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Configuration
+
+Non-interactive (for agents):
+
+```bash
+prism setup --non-interactive --helius-key=$HELIUS_KEY
+```
+
+Interactive (for humans):
+
+```bash
+prism setup
+```
+
+This writes `.env` with the Helius key, an optional watchlist, and paper-trading defaults. The default mode is **paper trading** — no real funds are at risk.
+
+## Start Trading
+
+```bash
+prism dev
+```
+
+Decisions are logged to `logs/audit-trail.jsonl`. To stop, send SIGINT (Ctrl+C).
+
+## Available Commands
+
+| Command | Purpose |
+|---|---|
+| `prism dev` | Start the trading engine |
+| `prism status` | Check current state |
+| `prism setup` | Interactive `.env` wizard |
+| `prism register` | Create a cloud account (optional) |
+| `prism whoami` | Show cloud account info (requires `prism register`) |
+| `prism backtest` | Run a historical simulation |
+| `prism update` | Check for and apply updates |
+| `prism feedback "<msg>"` | File structured feedback to the project |
+| `prism wallet {generate,import,show}` | Manage the local Solana keypair |
+| `prism link-telegram` | Link the cloud account to `@prism_agent_bot` |
+
+## Three Layers (CLI is the only required one)
+
+The CLI is fully functional without the cloud API. Do not assume `prism register` is required — it isn't.
+
+| Layer | Purpose | Required? |
+|---|---|---|
+| CLI (local) | Runs the trading engine, persists positions to SQLite | **Yes** |
+| API (cloud) | Cloud account, whoami, subscription, issue filing | No |
+| Telegram (chat) | Monitor and control the agent from `@prism_agent_bot` | No |
+
+## Common Mistakes
+
+1. **Running `bun run dev` instead of `prism dev`.** `prism dev` goes through the CLI wrapper that resolves the install root and respects config. `bun run dev` bypasses that.
+2. **Manually editing `.env`.** Use `prism setup` to update config.
+3. **Assuming `prism register` is required.** Skip it for local-only setups.
+4. **Setting `PAPER_TRADING=false` without a wallet.** Live mode requires `WALLET_PRIVATE_KEY`. Use `prism wallet generate` to create one.
+5. **Forgetting to export `PATH`.** After the one-liner install, `~/.local/bin` must be on `PATH`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `prism: command not found` | `~/.local/bin` not on PATH | `export PATH="$HOME/.local/bin:$PATH"` |
+| `Bun not found` during install | Bun not installed | Installer auto-installs Bun; check `$HOME/.bun/bin` |
+| `sqlite-vec` fails on Linux | Bundled SQLite lacks extensions | Engine falls back to system `libsqlite3.so` automatically |
+| `BigInt` serialization error from embeddings | ONNX runtime issue in Node.js | Set `EMBEDDINGS_BACKEND=fallback` in `.env` (default) |
+| Helius 401/403 | Invalid API key | Re-run `prism setup --non-interactive --helius-key=$NEW_KEY` |
+| Engine starts but makes no decisions | Empty watchlist and `ENABLE_POOL_DISCOVERY=false` | Set `ENABLE_POOL_DISCOVERY=true` in `.env` |
+
+## Verify Installation
+
+```bash
+prism --version       # should print 0.0.2 or later
+prism dev &           # start engine in background
+sleep 30
+tail -n 20 logs/audit-trail.jsonl   # should show scan cycle decisions
+```
+
+## Uninstall
+
+```bash
+rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id
+```

--- a/marketplaces/opencode/SKILL.md
+++ b/marketplaces/opencode/SKILL.md
@@ -26,8 +26,7 @@ export PATH="$HOME/.local/bin:$PATH"
 For a pinned release tarball (faster, no git history, reproducible):
 
 ```bash
-PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz \
-  curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 

--- a/marketplaces/opencode/SKILL.md
+++ b/marketplaces/opencode/SKILL.md
@@ -23,13 +23,6 @@ curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/s
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-For a pinned release tarball (faster, no git history, reproducible):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/download/v0.0.2/prism-v0.0.2.tar.gz bash
-export PATH="$HOME/.local/bin:$PATH"
-```
-
 ## Configuration
 
 Non-interactive (for agents):

--- a/marketplaces/opencode/SKILL.md
+++ b/marketplaces/opencode/SKILL.md
@@ -46,6 +46,8 @@ prism setup
 
 This writes `.env` with the Helius key, an optional watchlist, and paper-trading defaults. The default mode is **paper trading** — no real funds are at risk.
 
+If you don't know which pools to watch, also set `ENABLE_POOL_DISCOVERY=true` in `.env` so the agent can find candidates on its own.
+
 ## Start Trading
 
 ```bash

--- a/marketplaces/opencode/SKILL.md
+++ b/marketplaces/opencode/SKILL.md
@@ -26,7 +26,7 @@ export PATH="$HOME/.local/bin:$PATH"
 For a pinned release tarball (faster, no git history, reproducible):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-latest.tar.gz bash
+curl -fsSL https://raw.githubusercontent.com/irfndi/prism-liquidity-agent/main/scripts/install.sh | PRISM_TARBALL_URL=https://github.com/irfndi/prism-liquidity-agent/releases/latest/download/prism-v0.0.2.tar.gz bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
@@ -59,13 +59,12 @@ Decisions are logged to `logs/audit-trail.jsonl`. To stop, send SIGINT (Ctrl+C).
 | Command | Purpose |
 |---|---|
 | `prism dev` | Start the trading engine |
-| `prism status` | Check current state |
 | `prism setup` | Interactive `.env` wizard |
 | `prism register` | Create a cloud account (optional) |
 | `prism whoami` | Show cloud account info (requires `prism register`) |
 | `prism backtest` | Run a historical simulation |
 | `prism update` | Check for and apply updates |
-| `prism feedback "<msg>"` | File structured feedback to the project |
+| `prism issue "<msg>"` | File a GitHub issue (auto-deduped) |
 | `prism wallet {generate,import,show}` | Manage the local Solana keypair |
 | `prism link-telegram` | Link the cloud account to `@prism_agent_bot` |
 
@@ -110,5 +109,5 @@ tail -n 20 logs/audit-trail.jsonl   # should show scan cycle decisions
 ## Uninstall
 
 ```bash
-rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id
+rm -rf ~/.prism ~/.local/bin/prism ~/.config/prism/agent-id ~/.config/prism/install-id ~/.config/prism/credentials.json ~/.config/prism/wallet.json
 ```


### PR DESCRIPTION
## Summary

Partial implementation of issue #33 — publishes Prism installation skills to the **4 Markdown-based agent harnesses** out of the 10 target marketplaces. The remaining 6 (MCP server, OpenAI GPTs, AutoGPT, LangChain, CrewAI, Dify, Flowise) require separate code packages and are tracked in `marketplaces/README.md` as "Not started".

## What's included (4 atomic commits)

| # | Commit | What |
|---|---|---|
| 1 | `feat(skills): add prism-install skill in acpx format` | `.agents/skills/prism-install.md` (121 lines, plain Markdown matching the existing `dlmm-rebalancer.md` format) |
| 2 | `feat(skills): add OpenCode and OpenClaw marketplace skill files` | `marketplaces/opencode/SKILL.md` (115 lines, YAML frontmatter) + `marketplaces/openclaw/SKILL.md` (96 lines, plain Markdown) |
| 3 | `feat(skills): add Hermes marketplace skill file` | `marketplaces/hermes/SKILL.md` (120 lines, rich YAML frontmatter with metadata.hermes tags) |
| 4 | `docs: add agent skills section to docs and marketplaces/README` | `marketplaces/README.md` (94 lines, status table for all 10 marketplaces) + `docs/agent-harness.md` (new "Skills" section) |

## Why only 4 of 10

The 6 not done are full separate projects:
- **MCP server** (Claude Desktop) — new `prism-mcp-server` npm package
- **OpenAI GPTs** — UI-only submission, can't be automated from repo
- **AutoGPT / LangChain / CrewAI** — each needs a separate PyPI package
- **Dify / Flowise** — each needs a platform-specific plugin format and submission

The 4 ready harnesses (OpenCode, OpenClaw, Hermes, acpx) cover all major agent ecosystems that use Markdown skills. Users can copy-paste the skill files to their local directory in seconds.

## Files added (6, 561 lines total)

```
.agents/skills/prism-install.md         (new, 121 lines)
marketplaces/README.md                 (new,  94 lines)
marketplaces/opencode/SKILL.md         (new, 115 lines)
marketplaces/openclaw/SKILL.md         (new,  96 lines)
marketplaces/hermes/SKILL.md           (new, 120 lines)
docs/agent-harness.md                   (modified, +15 lines)
```

## Verification

- `bun run lint` clean
- All content is plain Markdown / YAML frontmatter — no code changes
- Install URLs use the actual GitHub raw URL (not the fictional `prism.run` vanity URL from issue #33)
- Each skill file has a "Verify Installation" section so users can confirm it works

## What's NOT in this PR

- The 6 code-based marketplaces (MCP server, OpenAI GPTs, AutoGPT, LangChain, CrewAI, Dify, Flowise) — tracked in `marketplaces/README.md` as "Not started". Each is a multi-day project on its own.
- A `prism-rebalance` skill (mentioned in the issue's example structure) — that's a separate skill for trading operations, not installation. Out of scope for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Prism liquidity agent installation guides for OpenCode, OpenClaw, and Hermes marketplaces.
  * Updated marketplace status and skill discovery documentation.
  * Added troubleshooting, verification, and configuration instructions for Prism agent setup.
  * Updated agent harness documentation with skill mapping and discovery information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->