### PR TITLE
feat(mcp-server): add prism-mcp-server for Claude Desktop (issue #33 marketplace #2)

### DIFF
--- a/marketplaces/README.md
+++ b/marketplaces/README.md
@@ -6,10 +6,10 @@ This directory contains Prism installation skills for various agent harness mark
 
 | # | Marketplace | Status | Skill file | Local install path |
 |---|---|---|---|---|
-| 1 | **OpenCode** | ✅ Ready | [`opencode/SKILL.md`](opencode/SKILL.md) | `~/.opencode/skills/prism-install/SKILL.md` |
-| 1b | **OpenClaw** | ✅ Ready | [`openclaw/SKILL.md`](openclaw/SKILL.md) | `~/.openclaw/skills/prism-install/SKILL.md` |
-| 1c | **Hermes** | ✅ Ready | [`hermes/SKILL.md`](hermes/SKILL.md) | `~/.hermes/skills/software-development/prism-install/SKILL.md` |
-| 1d | **acpx / custom** | ✅ Ready | [`.agents/skills/prism-install.md`](../.agents/skills/prism-install.md) | `~/.agents/skills/prism-install.md` |
+| 1 | **OpenCode** | ⏳ Pending | (added in PR #40, not in this branch) | `~/.opencode/skills/prism-install/SKILL.md` |
+| 1b | **OpenClaw** | ⏳ Pending | (added in PR #40, not in this branch) | `~/.openclaw/skills/prism-install/SKILL.md` |
+| 1c | **Hermes** | ⏳ Pending | (added in PR #40, not in this branch) | `~/.hermes/skills/software-development/prism-install/SKILL.md` |
+| 1d | **acpx / custom** | ⏳ Pending | (added in PR #40, not in this branch) | `~/.agents/skills/prism-install.md` |
 | 2 | Claude Desktop (MCP) | ✅ Ready | [`../mcp-server/README.md`](../mcp-server/README.md) | Configure in `claude_desktop_config.json` |
 | 3 | OpenAI GPTs | ❌ Not started | — | Requires OpenAI GPT Store submission (UI-only) |
 | 4 | AutoGPT | ❌ Not started | — | Requires `autogpt-prism` PyPI package |

--- a/marketplaces/README.md
+++ b/marketplaces/README.md
@@ -1,0 +1,101 @@
+# Agent Marketplace Skills
+
+This directory contains Prism installation skills for various agent harness marketplaces. Issue #33 tracked the full plan; this file documents the current status.
+
+## Status by Marketplace
+
+| # | Marketplace | Status | Skill file | Local install path |
+|---|---|---|---|---|
+| 1 | **OpenCode** | ✅ Ready | [`opencode/SKILL.md`](opencode/SKILL.md) | `~/.opencode/skills/prism-install/SKILL.md` |
+| 1b | **OpenClaw** | ✅ Ready | [`openclaw/SKILL.md`](openclaw/SKILL.md) | `~/.openclaw/skills/prism-install/SKILL.md` |
+| 1c | **Hermes** | ✅ Ready | [`hermes/SKILL.md`](hermes/SKILL.md) | `~/.hermes/skills/software-development/prism-install/SKILL.md` |
+| 1d | **acpx / custom** | ✅ Ready | [`.agents/skills/prism-install.md`](../.agents/skills/prism-install.md) | `~/.agents/skills/prism-install.md` |
+| 2 | Claude Desktop (MCP) | ✅ Ready | [`../mcp-server/README.md`](../mcp-server/README.md) | Configure in `claude_desktop_config.json` |
+| 3 | OpenAI GPTs | ❌ Not started | — | Requires OpenAI GPT Store submission (UI-only) |
+| 4 | AutoGPT | ❌ Not started | — | Requires `autogpt-prism` PyPI package |
+| 5 | LangChain | ❌ Not started | — | Requires `langchain-prism` PyPI package |
+| 6 | CrewAI | ❌ Not started | — | Requires `crewai-prism` PyPI package |
+| 7 | Dify | ❌ Not started | — | Requires Dify marketplace submission |
+| 8 | Flowise | ❌ Not started | — | Requires Flowise custom-node npm package |
+| 9 | ChatGPT Plugins (legacy) | ❌ Not started | — | Deprecated; OpenAI GPTs is the successor |
+| 10 | Custom agent harnesses | ✅ Ready | Same as 1d (acpx) | See [docs/agent-harness.md](../docs/agent-harness.md) |
+
+## What's Done (5/10)
+
+- **4 Markdown-based harnesses** (OpenCode, OpenClaw, Hermes, acpx) — copy-paste-ready skill files
+- **Claude Desktop (MCP)** — standalone `prism-mcp-server` npm package with 4 tools (status, positions, whoami, backtest)
+
+## What's Not Done (5/10)
+
+The remaining five harnesses require code packages or platform submissions that are each multi-day projects:
+
+- **OpenAI GPTs** — UI-only submission to the GPT Store; can't be automated from this repo
+- **AutoGPT / LangChain / CrewAI** — each needs a separate PyPI package with a Python class wrapping the CLI
+- **Dify / Flowise** — each needs a platform-specific plugin format and submission
+
+These are tracked in the issue #33 phased plan. None of them block the core install path (the 5 ready harnesses cover all major agent ecosystems).
+
+## How to Use
+
+### Install via the ready skill files
+
+For each ready Markdown marketplace, copy the SKILL.md to the local path shown in the table above:
+
+```bash
+# OpenCode
+mkdir -p ~/.opencode/skills/prism-install
+cp marketplaces/opencode/SKILL.md ~/.opencode/skills/prism-install/SKILL.md
+
+# OpenClaw
+mkdir -p ~/.openclaw/skills/prism-install
+cp marketplaces/openclaw/SKILL.md ~/.openclaw/skills/prism-install/SKILL.md
+
+# Hermes (under software-development category)
+mkdir -p ~/.hermes/skills/software-development/prism-install
+cp marketplaces/hermes/SKILL.md ~/.hermes/skills/software-development/prism-install/SKILL.md
+
+# acpx / custom
+mkdir -p ~/.agents/skills
+cp .agents/skills/prism-install.md ~/.agents/skills/prism-install.md
+```
+
+After copying, restart your agent harness so it picks up the new skill.
+
+### Configure the MCP server (Claude Desktop)
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "prism": {
+      "command": "node",
+      "args": ["/absolute/path/to/mcp-server/dist/index.js"],
+      "env": {
+        "PRISM_BIN": "/absolute/path/to/prism",
+        "SQLITE_DB_PATH": "/absolute/path/to/prism.db"
+      }
+    }
+  }
+}
+```
+
+See [`../mcp-server/README.md`](../mcp-server/README.md) for the full configuration guide.
+
+## Adding a New Marketplace
+
+If you want to add a marketplace that isn't listed:
+
+1. Create a new subdirectory under `marketplaces/<harness-name>/`
+2. Write a `SKILL.md` matching that harness's discovery format
+3. Add a row to the status table above with the local install path
+4. Open a PR
+
+The content can be adapted from the existing four skill files — the install/configure/start/troubleshooting sections are universal.
+
+## See Also
+
+- [Issue #33](https://github.com/irfndi/prism-liqudity-agent/issues/33) — original phased plan
+- [`docs/agent-harness.md`](../docs/agent-harness.md) — full agent integration guide
+- [`.agents/skills/`](../.agents/skills/) — the project's own skill directory (acpx format)
+- [`dlmm-rebalancer`](../.agents/skills/dlmm-rebalancer.md) — strategy-level reasoning skill

--- a/marketplaces/README.md
+++ b/marketplaces/README.md
@@ -95,7 +95,7 @@ The content can be adapted from the existing four skill files — the install/co
 
 ## See Also
 
-- [Issue #33](https://github.com/irfndi/prism-liqudity-agent/issues/33) — original phased plan
+- [Issue #33](https://github.com/irfndi/prism-liquidity-agent/issues/33) — original phased plan
 - [`docs/agent-harness.md`](../docs/agent-harness.md) — full agent integration guide
 - [`.agents/skills/`](../.agents/skills/) — the project's own skill directory (acpx format)
 - [`dlmm-rebalancer`](../.agents/skills/dlmm-rebalancer.md) — strategy-level reasoning skill

--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.log
+.env
+.env.local
+*.tsbuildinfo

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -147,11 +147,20 @@ No data is sent to external services. The server is a stdio-only process that on
 
 ```bash
 cd mcp-server
-npm install
-npm run dev      # tsc --watch
-npm run build    # tsc
-npm test         # bun test test/
+npm install                    # installs deps + builds better-sqlite3 native binding
+npm run dev                    # tsc --watch
+npm run build                  # tsc
+npm test                       # node --import tsx --test test/*.test.ts
 ```
+
+### Build requirement: better-sqlite3 native binding
+
+`better-sqlite3` is a native module that needs to be compiled for the target Node.js version. The `npm install` step should automatically download a prebuilt binary, but on very new Node.js versions (e.g., v26) or systems without build tools, the build may fall back to compiling from source, which requires:
+- macOS: Xcode Command Line Tools (`xcode-select --install`)
+- Linux: Python 3, make, g++
+- Windows: windows-build-tools
+
+If `npm test` fails with `node-gyp` errors, run `npm rebuild better-sqlite3` to force a rebuild, or use a Node.js version with available prebuilds (v18-v22 are well-supported).
 
 ## Future work (not in this package)
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,166 @@
+# prism-mcp-server
+
+Model Context Protocol (MCP) server that exposes Prism liquidity agent commands as tools for Claude Desktop and other MCP clients.
+
+## What it does
+
+Exposes 4 tools to any MCP-compatible client (Claude Desktop, Claude Code, Cursor, etc.):
+
+| Tool | What it does |
+|---|---|
+| `prism_status` | Reads the SQLite DB to return position count, total deposited/current value (USD), and the last 3 audit entries |
+| `prism_positions` | Lists all active positions (excludes paper-exited ones) with tokens, range, deposited/current value, and out-of-range cycle count |
+| `prism_whoami` | Shows cloud account info (requires `prism register` first) |
+| `prism_backtest` | Runs a backtest — `synthetic` (default, deterministic mock) or `replay` (reads from prism.db snapshots) |
+
+## Install
+
+### From npm (once published)
+
+```bash
+npm install -g prism-mcp-server
+```
+
+### From the repo (current state)
+
+```bash
+cd mcp-server
+npm install
+npm run build
+```
+
+This produces `mcp-server/dist/index.js` — the stdio MCP server entry point.
+
+## Configure Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "prism": {
+      "command": "node",
+      "args": ["/absolute/path/to/prism-liquidity-agent/mcp-server/dist/index.js"],
+      "env": {
+        "PRISM_BIN": "/absolute/path/to/prism",
+        "SQLITE_DB_PATH": "/absolute/path/to/prism.db"
+      }
+    }
+  }
+}
+```
+
+Notes:
+- `PRISM_BIN` is the absolute path to the `prism` wrapper. If you used the one-liner installer, this is `~/.local/bin/prism`.
+- `SQLITE_DB_PATH` is the absolute path to `prism.db`. If omitted, the server tries `./prism.db` relative to its CWD.
+- If `prism` is on your `PATH` and `prism.db` is in the server's CWD, you can omit both `env` entries.
+
+Restart Claude Desktop. The `prism` server will appear in the MCP tools list with the 4 tools above.
+
+## Verify the server starts
+
+```bash
+# Should hang waiting for stdio input (Ctrl+C to exit)
+node /absolute/path/to/mcp-server/dist/index.js
+```
+
+If it crashes immediately, check:
+1. `PRISM_BIN` points to a working `prism` binary — test with `$(PRISM_BIN) --version`
+2. `SQLITE_DB_PATH` points to a readable SQLite file (or omit to use `./prism.db`)
+3. `better-sqlite3` native binding is built — run `npm rebuild better-sqlite3` in the mcp-server directory
+
+## Tool details
+
+### `prism_status`
+
+No parameters. Returns:
+
+```json
+{
+  "running": true,
+  "dbPath": "./prism.db",
+  "positionCount": 2,
+  "totalDepositedUsd": 1500.00,
+  "totalCurrentValueUsd": 1620.50,
+  "lastAudit": [
+    {
+      "timestamp": "2026-06-03T15:00:00.000Z",
+      "action": "ENTER",
+      "pool": "Pool...",
+      "reasoning": "Fee/IL ratio 1.8 above threshold",
+      "paperTrading": true
+    }
+  ]
+}
+```
+
+If the SQLite DB doesn't exist (agent hasn't run yet), returns `{ running: false, message: "..." }`.
+
+### `prism_positions`
+
+No parameters. Returns an array of active positions:
+
+```json
+[
+  {
+    "pool": "Pool...",
+    "tokens": "SOL/USDC",
+    "depositedUsd": 1000.00,
+    "currentValueUsd": 1080.20,
+    "range": { "lower": 4980, "upper": 5020, "active": 5005 },
+    "outOfRangeCycleCount": 0,
+    "lastRebalanceAt": null
+  }
+]
+```
+
+### `prism_whoami`
+
+No parameters. Shells out to `prism whoami`. Returns the CLI's stdout on success, or a structured `{ registered: false, message: "..." }` if not registered.
+
+### `prism_backtest`
+
+Parameters:
+- `source` (enum, default `synthetic`): `synthetic` for deterministic mock data, `replay` for on-chain snapshots from `prism.db`
+- `days` (int 1-365, default 7): number of days to backtest
+- `pools` (array of strings, optional, replay only): pool addresses to backtest
+
+Returns the CLI's stdout. Errors include the exit code and stderr.
+
+## How it finds the Prism binary
+
+Resolution order:
+1. `PRISM_BIN` env var (absolute path)
+2. `~/.local/bin/prism` (default one-liner install location)
+3. `~/.bun/bin/prism` (Bun global install location)
+4. `prism` on `PATH`
+
+If none of these resolve, the tool calls will fail with a clear error message.
+
+## Security
+
+The MCP server runs locally and only exposes read-only operations (SQLite is opened in readonly mode). The `prism_whoami` and `prism_backtest` tools spawn the Prism CLI as a subprocess with a 30-120 second timeout.
+
+No data is sent to external services. The server is a stdio-only process that only responds to the local MCP client.
+
+## Development
+
+```bash
+cd mcp-server
+npm install
+npm run dev      # tsc --watch
+npm run build    # tsc
+npm test         # bun test test/
+```
+
+## Future work (not in this package)
+
+- **Resource providers** for pool metadata, audit log history, etc.
+- **Sampling support** for tool-driven LLM completions
+- **HTTP transport** (currently stdio only) for remote MCP clients
+- **Prompts** for common Prism workflows (install, diagnose, backtest)
+- **OAuth** for multi-user setups
+
+## License
+
+MIT — same as the main Prism project.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -65,7 +65,7 @@ node /absolute/path/to/mcp-server/dist/index.js
 ```
 
 If it crashes immediately, check:
-1. `PRISM_BIN` points to a working `prism` binary — test with `$(PRISM_BIN) --version`
+1. `PRISM_BIN` points to a working `prism` binary — test with `$PRISM_BIN --version`
 2. `SQLITE_DB_PATH` points to a readable SQLite file (or omit to use `./prism.db`)
 3. `better-sqlite3` native binding is built — run `npm rebuild better-sqlite3` in the mcp-server directory
 

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,0 +1,1209 @@
+{
+  "name": "prism-mcp-server",
+  "version": "0.0.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "prism-mcp-server",
+      "version": "0.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "zod": "^3.25.0"
+      },
+      "bin": {
+        "prism-mcp-server": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -19,9 +19,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "better-sqlite3": "^11.0.0",
     "zod": "^3.25.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "typescript": "^5.4.0"
   },

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -15,7 +15,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "bun test test/"
+    "test": "node --import tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.4.0"
   },
   "engines": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "prism-mcp-server",
+  "version": "0.0.2",
+  "description": "Model Context Protocol (MCP) server that exposes Prism liquidity agent commands as tools for Claude Desktop and other MCP clients",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "prism-mcp-server": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "test": "bun test test/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.4.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "prism",
+    "solana",
+    "dlmm",
+    "liquidity",
+    "trading",
+    "agent"
+  ]
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -15,7 +15,10 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "node --import tsx --test test/*.test.ts"
+    "test": "node --import tsx --test test/*.test.ts",
+    "lint": "oxlint src test",
+    "format": "oxfmt --write src test",
+    "format:check": "oxfmt --check src test"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp-server/src/exec.ts
+++ b/mcp-server/src/exec.ts
@@ -1,0 +1,66 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_BUFFER = 10 * 1024 * 1024;
+
+function findPrismBinary(): string {
+  if (process.env.PRISM_BIN) {
+    return process.env.PRISM_BIN;
+  }
+  const home = homedir();
+  const candidates = [
+    join(home, ".local", "bin", "prism"),
+    join(home, ".bun", "bin", "prism"),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return "prism";
+}
+
+export interface PrismExecResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export async function runPrism(
+  args: ReadonlyArray<string>,
+  options: { timeoutMs?: number } = {},
+): Promise<PrismExecResult> {
+  const bin = findPrismBinary();
+  const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  try {
+    const result = await execFileAsync(bin, [...args], {
+      timeout,
+      maxBuffer: MAX_BUFFER,
+      env: { ...process.env, FORCE_COLOR: "0" },
+    });
+    return {
+      ok: true,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: 0,
+    };
+  } catch (err) {
+    const e = err as {
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+      code?: number | string;
+      message?: string;
+    };
+    const stdout = e.stdout ? e.stdout.toString() : "";
+    const stderr = e.stderr ? e.stderr.toString() : e.message ?? String(err);
+    const exitCode = typeof e.code === "number" ? e.code : 1;
+    return { ok: false, stdout, stderr, exitCode };
+  }
+}

--- a/mcp-server/src/exec.ts
+++ b/mcp-server/src/exec.ts
@@ -31,6 +31,7 @@ export interface PrismExecResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+  timedOut: boolean;
 }
 
 export async function runPrism(
@@ -50,6 +51,7 @@ export async function runPrism(
       stdout: result.stdout,
       stderr: result.stderr,
       exitCode: 0,
+      timedOut: false,
     };
   } catch (err) {
     const e = err as {
@@ -57,10 +59,13 @@ export async function runPrism(
       stderr?: string | Buffer;
       code?: number | string;
       message?: string;
+      killed?: boolean;
+      signal?: string;
     };
     const stdout = e.stdout ? e.stdout.toString() : "";
     const stderr = e.stderr ? e.stderr.toString() : e.message ?? String(err);
     const exitCode = typeof e.code === "number" ? e.code : 1;
-    return { ok: false, stdout, stderr, exitCode };
+    const timedOut = e.killed === true;
+    return { ok: false, stdout, stderr, exitCode, timedOut };
   }
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./tools.js";
+
+const server = new McpServer({
+  name: "prism-mcp-server",
+  version: "0.0.2",
+});
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,0 +1,243 @@
+import { Database } from "better-sqlite3";
+import { existsSync } from "node:fs";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { runPrism } from "./exec.js";
+
+const DEFAULT_DB_PATH = "./prism.db";
+
+function openDb(): Database | null {
+  const dbPath = process.env.SQLITE_DB_PATH ?? DEFAULT_DB_PATH;
+  if (!existsSync(dbPath)) {
+    return null;
+  }
+  const Database = require("better-sqlite3");
+  return new Database(dbPath, { readonly: true, fileMustExist: true });
+}
+
+function formatPosition(row: Record<string, unknown>): string {
+  const pool = String(row.pool_address);
+  const tokens = `${row.token_x_symbol ?? "?"}/${row.token_y_symbol ?? "?"}`;
+  const deposited = Number(row.deposited_usd ?? 0).toFixed(2);
+  const current = Number(row.current_value_usd ?? 0).toFixed(2);
+  const range = `[${row.lower_bin_id ?? "?"}..${row.upper_bin_id ?? "?"}]`;
+  return `${pool} ${tokens} deposited=$${deposited} current=$${current} range=${range}`;
+}
+
+function registerPrismStatus(server: McpServer): void {
+  server.tool(
+    "prism_status",
+    "Get the current status of the Prism trading agent. Returns position count, " +
+      "total deposited/current value, and the last 3 audit entries. Returns an empty status " +
+      "object if the SQLite database does not exist (no agent has run yet).",
+    {},
+    async () => {
+      const db = openDb();
+      if (db === null) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                { running: false, message: "No SQLite database found. Run `prism dev` at least once to create one." },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+      try {
+        const positionCount = (
+          db.prepare("SELECT COUNT(*) as n FROM positions WHERE paper_exited_at IS NULL").get() as { n: number }
+        ).n;
+        const totals = db
+          .prepare(
+            "SELECT COALESCE(SUM(deposited_usd), 0) as total_deposited, " +
+              "COALESCE(SUM(current_value_usd), 0) as total_current " +
+              "FROM positions WHERE paper_exited_at IS NULL",
+          )
+          .get() as { total_deposited: number; total_current: number };
+        const lastAudit = db
+          .prepare(
+            "SELECT timestamp, action, pool_address, reasoning, paper_trading " +
+              "FROM audit ORDER BY timestamp DESC LIMIT 3",
+          )
+          .all() as Array<{
+            timestamp: number;
+            action: string;
+            pool_address: string;
+            reasoning: string;
+            paper_trading: number;
+          }>;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  running: true,
+                  dbPath: process.env.SQLITE_DB_PATH ?? DEFAULT_DB_PATH,
+                  positionCount,
+                  totalDepositedUsd: totals.total_deposited,
+                  totalCurrentValueUsd: totals.total_current,
+                  lastAudit: lastAudit.map((a) => ({
+                    timestamp: new Date(a.timestamp).toISOString(),
+                    action: a.action,
+                    pool: a.pool_address,
+                    reasoning: a.reasoning,
+                    paperTrading: a.paper_trading === 1,
+                  })),
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } finally {
+        db.close();
+      }
+    },
+  );
+}
+
+function registerPrismPositions(server: McpServer): void {
+  server.tool(
+    "prism_positions",
+    "List all active positions tracked by the Prism agent. Excludes paper-exited positions. " +
+      "Returns an empty array if the SQLite database does not exist.",
+    {},
+    async () => {
+      const db = openDb();
+      if (!db) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify([], null, 2),
+            },
+          ],
+        };
+      }
+      try {
+        const rows = db
+          .prepare(
+            "SELECT pool_address, token_x_symbol, token_y_symbol, " +
+              "deposited_usd, current_value_usd, lower_bin_id, upper_bin_id, " +
+              "active_bin_id, oor_cycle_count, last_rebalance_at " +
+              "FROM positions WHERE paper_exited_at IS NULL " +
+              "ORDER BY deposited_usd DESC",
+          )
+          .all() as Array<Record<string, unknown>>;
+        const positions = rows.map((r) => ({
+          pool: r.pool_address,
+          tokens: `${r.token_x_symbol}/${r.token_y_symbol}`,
+          depositedUsd: Number(r.deposited_usd),
+          currentValueUsd: Number(r.current_value_usd),
+          range: { lower: r.lower_bin_id, upper: r.upper_bin_id, active: r.active_bin_id },
+          outOfRangeCycleCount: r.oor_cycle_count,
+          lastRebalanceAt: r.last_rebalance_at
+            ? new Date(Number(r.last_rebalance_at)).toISOString()
+            : null,
+        }));
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(positions, null, 2),
+            },
+          ],
+        };
+      } finally {
+        db.close();
+      }
+    },
+  );
+}
+
+function registerPrismWhoami(server: McpServer): void {
+  server.tool(
+    "prism_whoami",
+    "Show the current Prism cloud account info. Requires `prism register` to have been run first. " +
+      "Returns an error message if not registered.",
+    {},
+    async () => {
+      const result = await runPrism(["whoami"]);
+      if (!result.ok && result.exitCode !== 0) {
+        if (result.stderr.includes("Not registered") || result.stderr.includes("Run 'prism register'")) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  { registered: false, message: "Not registered. Run 'prism register' first." },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error running \`prism whoami\` (exit ${result.exitCode}):\n${result.stderr}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+      return {
+        content: [{ type: "text", text: result.stdout }],
+      };
+    },
+  );
+}
+
+function registerPrismBacktest(server: McpServer): void {
+  server.tool(
+    "prism_backtest",
+    "Run a Prism backtest. By default uses synthetic data for 7 days. " +
+      "Set `source` to `replay` and provide `dbPath` + `days` + `pools` to replay on-chain snapshots.",
+    {
+      source: z.enum(["synthetic", "replay"]).default("synthetic").describe(
+        "Data source: 'synthetic' (default) generates deterministic mock data; 'replay' reads from prism.db snapshots.",
+      ),
+      days: z.number().int().min(1).max(365).default(7).describe("Number of days to backtest (1-365)."),
+      pools: z
+        .array(z.string())
+        .optional()
+        .describe("Pool addresses to backtest (replay mode only). If empty, uses all pools with snapshots."),
+    },
+    async ({ source, days, pools }) => {
+      const args = ["backtest", "--source", source, "--days", String(days)];
+      if (source === "replay" && pools && pools.length > 0) {
+        args.push("--pools", ...pools);
+      }
+      const result = await runPrism(args, { timeoutMs: 120_000 });
+      if (!result.ok) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error running \`prism backtest\` (exit ${result.exitCode}):\n${result.stderr || result.stdout}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+      return {
+        content: [{ type: "text", text: result.stdout }],
+      }
+    },
+  );
+}
+
+export function registerAllTools(server: McpServer): void {
+  registerPrismStatus(server);
+  registerPrismPositions(server);
+  registerPrismWhoami(server);
+  registerPrismBacktest(server);
+}

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,4 +1,4 @@
-import { Database } from "better-sqlite3";
+import Database from "better-sqlite3";
 import { existsSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -6,12 +6,11 @@ import { runPrism } from "./exec.js";
 
 const DEFAULT_DB_PATH = "./prism.db";
 
-function openDb(): Database | null {
+function openDb(): InstanceType<typeof Database> | null {
   const dbPath = process.env.SQLITE_DB_PATH ?? DEFAULT_DB_PATH;
   if (!existsSync(dbPath)) {
     return null;
   }
-  const Database = require("better-sqlite3");
   return new Database(dbPath, { readonly: true, fileMustExist: true });
 }
 

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -14,15 +14,6 @@ function openDb(): InstanceType<typeof Database> | null {
   return new Database(dbPath, { readonly: true, fileMustExist: true });
 }
 
-function formatPosition(row: Record<string, unknown>): string {
-  const pool = String(row.pool_address);
-  const tokens = `${row.token_x_symbol ?? "?"}/${row.token_y_symbol ?? "?"}`;
-  const deposited = Number(row.deposited_usd ?? 0).toFixed(2);
-  const current = Number(row.current_value_usd ?? 0).toFixed(2);
-  const range = `[${row.lower_bin_id ?? "?"}..${row.upper_bin_id ?? "?"}]`;
-  return `${pool} ${tokens} deposited=$${deposited} current=$${current} range=${range}`;
-}
-
 function registerPrismStatus(server: McpServer): void {
   server.tool(
     "prism_status",
@@ -94,6 +85,20 @@ function registerPrismStatus(server: McpServer): void {
             },
           ],
         };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                { error: `Failed to read SQLite database: ${err instanceof Error ? err.message : String(err)}` },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: true,
+        };
       } finally {
         db.close();
       }
@@ -148,6 +153,20 @@ function registerPrismPositions(server: McpServer): void {
             },
           ],
         };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                { error: `Failed to read positions: ${err instanceof Error ? err.message : String(err)}` },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: true,
+        };
       } finally {
         db.close();
       }
@@ -178,11 +197,14 @@ function registerPrismWhoami(server: McpServer): void {
             ],
           };
         }
+        const detail = result.timedOut
+          ? `Command timed out after 30s:\n${result.stderr}`
+          : `Error running \`prism whoami\` (exit ${result.exitCode}):\n${result.stderr}`;
         return {
           content: [
             {
               type: "text",
-              text: `Error running \`prism whoami\` (exit ${result.exitCode}):\n${result.stderr}`,
+              text: detail,
             },
           ],
           isError: true,
@@ -214,15 +236,18 @@ function registerPrismBacktest(server: McpServer): void {
     async ({ source, days, pools }) => {
       const args = ["backtest", "--source", source, "--days", String(days)];
       if (source === "replay" && pools && pools.length > 0) {
-        args.push("--pools", ...pools);
+        args.push("--pools", pools.join(","));
       }
       const result = await runPrism(args, { timeoutMs: 120_000 });
       if (!result.ok) {
+        const detail = result.timedOut
+          ? `Backtest timed out after 120s:\n${result.stderr || result.stdout}`
+          : `Error running \`prism backtest\` (exit ${result.exitCode}):\n${result.stderr || result.stdout}`;
         return {
           content: [
             {
               type: "text",
-              text: `Error running \`prism backtest\` (exit ${result.exitCode}):\n${result.stderr || result.stdout}`,
+              text: detail,
             },
           ],
           isError: true,

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -163,7 +163,7 @@ function registerPrismWhoami(server: McpServer): void {
     {},
     async () => {
       const result = await runPrism(["whoami"]);
-      if (!result.ok && result.exitCode !== 0) {
+      if (!result.ok) {
         if (result.stderr.includes("Not registered") || result.stderr.includes("Run 'prism register'")) {
           return {
             content: [
@@ -199,7 +199,8 @@ function registerPrismBacktest(server: McpServer): void {
   server.tool(
     "prism_backtest",
     "Run a Prism backtest. By default uses synthetic data for 7 days. " +
-      "Set `source` to `replay` and provide `dbPath` + `days` + `pools` to replay on-chain snapshots.",
+      "Set `source` to `replay` and provide `days` + optionally `pools` to replay on-chain snapshots. " +
+      "Note: the `pools` parameter is only used when `source` is `replay`; it is ignored otherwise.",
     {
       source: z.enum(["synthetic", "replay"]).default("synthetic").describe(
         "Data source: 'synthetic' (default) generates deterministic mock data; 'replay' reads from prism.db snapshots.",
@@ -208,7 +209,7 @@ function registerPrismBacktest(server: McpServer): void {
       pools: z
         .array(z.string())
         .optional()
-        .describe("Pool addresses to backtest (replay mode only). If empty, uses all pools with snapshots."),
+        .describe("Pool addresses to backtest (replay mode only — ignored if source is 'synthetic'). If empty, uses all pools with snapshots."),
     },
     async ({ source, days, pools }) => {
       const args = ["backtest", "--source", source, "--days", String(days)];
@@ -229,7 +230,7 @@ function registerPrismBacktest(server: McpServer): void {
       }
       return {
         content: [{ type: "text", text: result.stdout }],
-      }
+      };
     },
   );
 }

--- a/mcp-server/test/tools.test.ts
+++ b/mcp-server/test/tools.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { runPrism } from "../src/exec.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAllTools } from "../src/tools.js";
+
+// ─── runPrism() ──────────────────────────────────────────────────────────────
+
+describe("runPrism", () => {
+  let workDir: string;
+  let fakePrism: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "prism-mcp-test-"));
+    fakePrism = join(workDir, "prism");
+    writeFileSync(
+      fakePrism,
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then
+  echo "prism 0.0.2 (test stub)"
+  exit 0
+fi
+if [ "$1" = "whoami" ]; then
+  echo "User ID: test-user-123"
+  echo "Tier: free"
+  exit 0
+fi
+if [ "$1" = "fail" ]; then
+  echo "Something went wrong" >&2
+  exit 1
+fi
+echo "unknown command: $1"
+exit 2
+`,
+    );
+    chmodSync(fakePrism, 0o755);
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("runs the prism binary and returns stdout on success", async () => {
+    const result = await runPrism(["--version"], {});
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.ok, true);
+    assert.ok(result.stdout.includes("prism 0.0.2"));
+  });
+
+  it("returns ok=false with stderr on non-zero exit", async () => {
+    const prevBin = process.env.PRISM_BIN;
+    process.env.PRISM_BIN = join(workDir, "failing-prism");
+    writeFileSync(
+      join(workDir, "failing-prism"),
+      `#!/usr/bin/env bash
+echo "Something went wrong" >&2
+exit 1
+`,
+    );
+    chmodSync(join(workDir, "failing-prism"), 0o755);
+    try {
+      const result = await runPrism(["fail"], {});
+      assert.equal(result.ok, false);
+      assert.equal(result.exitCode, 1);
+      assert.ok(result.stderr.includes("Something went wrong"));
+    } finally {
+      if (prevBin === undefined) delete process.env.PRISM_BIN;
+      else process.env.PRISM_BIN = prevBin;
+    }
+  });
+
+  it("finds the binary via PRISM_BIN env var", async () => {
+    const prevBin = process.env.PRISM_BIN;
+    process.env.PRISM_BIN = fakePrism;
+    try {
+      const result = await runPrism(["whoami"], {});
+      assert.equal(result.ok, true);
+      assert.ok(result.stdout.includes("test-user-123"));
+    } finally {
+      if (prevBin === undefined) delete process.env.PRISM_BIN;
+      else process.env.PRISM_BIN = prevBin;
+    }
+  });
+
+  it("returns ok=false when the binary cannot be found", async () => {
+    const prevBin = process.env.PRISM_BIN;
+    process.env.PRISM_BIN = "/nonexistent/path/to/prism";
+    try {
+      const result = await runPrism(["--version"], {});
+      assert.equal(result.ok, false);
+      assert.notEqual(result.exitCode, 0);
+    } finally {
+      if (prevBin === undefined) delete process.env.PRISM_BIN;
+      else process.env.PRISM_BIN = prevBin;
+    }
+  });
+});
+
+// ─── DB-backed tools ──────────────────────────────────────────────────────────
+
+const SCHEMA_SQL = `
+  CREATE TABLE positions (
+    pool_address TEXT PRIMARY KEY,
+    position_pubkey TEXT,
+    deposited_usd REAL,
+    current_value_usd REAL,
+    token_x_symbol TEXT,
+    token_y_symbol TEXT,
+    active_bin_id INTEGER,
+    lower_bin_id INTEGER,
+    upper_bin_id INTEGER,
+    timestamp INTEGER,
+    out_of_range_since INTEGER,
+    oor_cycle_count INTEGER DEFAULT 0,
+    last_fee_claim_at INTEGER DEFAULT 0,
+    trailing_stop_threshold REAL,
+    highest_value_usd REAL,
+    last_rebalance_at INTEGER DEFAULT 0,
+    paper_exited_at INTEGER
+  );
+  CREATE TABLE audit (
+    id TEXT PRIMARY KEY,
+    timestamp INTEGER,
+    cycle_id TEXT,
+    pool_address TEXT,
+    action TEXT,
+    confidence REAL,
+    reasoning TEXT,
+    metrics_json TEXT,
+    risk_result_json TEXT,
+    executed INTEGER,
+    paper_trading INTEGER,
+    tx_signature TEXT,
+    error TEXT
+  );
+`;
+
+function setupTestDb(workDir: string): string {
+  const dbPath = join(workDir, "test.db");
+  const db = new Database(dbPath);
+  db.exec(SCHEMA_SQL);
+  return dbPath;
+}
+
+function seedPositions(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.prepare(
+    `INSERT INTO positions (pool_address, deposited_usd, current_value_usd,
+      token_x_symbol, token_y_symbol, active_bin_id, lower_bin_id, upper_bin_id,
+      timestamp, out_of_range_since, oor_cycle_count, last_fee_claim_at,
+      trailing_stop_threshold, highest_value_usd, last_rebalance_at, paper_exited_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "PoolActive1", 1000, 1050, "SOL", "USDC", 5000, 4980, 5020,
+    Date.now(), null, 0, Date.now(), null, 1050, 0, null,
+  );
+  db.prepare(
+    `INSERT INTO positions (pool_address, deposited_usd, current_value_usd,
+      token_x_symbol, token_y_symbol, active_bin_id, lower_bin_id, upper_bin_id,
+      timestamp, out_of_range_since, oor_cycle_count, last_fee_claim_at,
+      trailing_stop_threshold, highest_value_usd, last_rebalance_at, paper_exited_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "PoolExited", 500, 500, "SOL", "USDC", 5000, 4980, 5020,
+    Date.now(), null, 0, Date.now(), null, 500, 0, Date.now() - 3600_000,
+  );
+  db.close();
+}
+
+function seedAudit(dbPath: string): void {
+  const db = new Database(dbPath);
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO audit (id, timestamp, cycle_id, pool_address, action, confidence, reasoning, metrics_json, risk_result_json, executed, paper_trading, tx_signature, error) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run("a1", now - 2000, "cycle-1", "PoolActive1", "HOLD", 0.8, "Within range", null, null, 1, 1, null, null);
+  db.prepare(
+    `INSERT INTO audit (id, timestamp, cycle_id, pool_address, action, confidence, reasoning, metrics_json, risk_result_json, executed, paper_trading, tx_signature, error) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run("a2", now - 1000, "cycle-2", "PoolActive1", "REBALANCE", 0.75, "Drifted 65%", null, null, 1, 1, null, null);
+  db.prepare(
+    `INSERT INTO audit (id, timestamp, cycle_id, pool_address, action, confidence, reasoning, metrics_json, risk_result_json, executed, paper_trading, tx_signature, error) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run("a3", now, "cycle-3", "PoolActive1", "HOLD", 0.85, "Stable", null, null, 1, 1, null, null);
+  db.close();
+}
+
+describe("DB-backed tools", () => {
+  let workDir: string;
+  let prevDbPath: string | undefined;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "prism-mcp-dbt-"));
+    prevDbPath = process.env.SQLITE_DB_PATH;
+  });
+
+  afterEach(() => {
+    if (prevDbPath === undefined) delete process.env.SQLITE_DB_PATH;
+    else process.env.SQLITE_DB_PATH = prevDbPath;
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("prism_status returns running=false when DB does not exist", async () => {
+    process.env.SQLITE_DB_PATH = join(workDir, "nonexistent.db");
+    const result = await runTool("prism_status", {});
+    assert.equal(result.ok, true);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.running, false);
+    assert.ok(parsed.message.includes("No SQLite database found"));
+  });
+
+  it("prism_status returns position count and last audit when DB exists", async () => {
+    const dbPath = setupTestDb(workDir);
+    seedPositions(dbPath);
+    seedAudit(dbPath);
+    process.env.SQLITE_DB_PATH = dbPath;
+
+    const result = await runTool("prism_status", {});
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.running, true);
+    assert.equal(parsed.positionCount, 1);
+    assert.equal(parsed.totalDepositedUsd, 1000);
+    assert.equal(parsed.totalCurrentValueUsd, 1050);
+    assert.equal(parsed.lastAudit.length, 3);
+    assert.equal(parsed.lastAudit[0].action, "HOLD");
+    assert.equal(parsed.lastAudit[1].action, "REBALANCE");
+  });
+
+  it("prism_positions returns empty array when DB does not exist", async () => {
+    process.env.SQLITE_DB_PATH = join(workDir, "nonexistent.db");
+    const result = await runTool("prism_positions", {});
+    assert.equal(result.ok, true);
+    const parsed = JSON.parse(result.text);
+    assert.deepEqual(parsed, []);
+  });
+
+  it("prism_positions excludes paper-exited positions", async () => {
+    const dbPath = setupTestDb(workDir);
+    seedPositions(dbPath);
+    process.env.SQLITE_DB_PATH = dbPath;
+
+    const result = await runTool("prism_positions", {});
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].pool, "PoolActive1");
+  });
+
+  it("prism_positions includes range and out-of-range count", async () => {
+    const dbPath = setupTestDb(workDir);
+    seedPositions(dbPath);
+    process.env.SQLITE_DB_PATH = dbPath;
+
+    const result = await runTool("prism_positions", {});
+    const parsed = JSON.parse(result.text);
+    assert.deepEqual(parsed[0].range, { lower: 4980, upper: 5020, active: 5000 });
+    assert.equal(parsed[0].tokens, "SOL/USDC");
+  });
+});
+
+// ─── Tool registration ────────────────────────────────────────────────────────
+
+describe("tool registration", () => {
+  it("registers all 4 tools on the server", () => {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+    registerAllTools(server);
+    assert.ok(server);
+  });
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface ToolResult {
+  ok: boolean;
+  text: string;
+  isError: boolean;
+}
+
+async function runTool(toolName: string, args: Record<string, unknown>): Promise<ToolResult> {
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  registerAllTools(server);
+  const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+  const { InMemoryTransport } = await import(
+    "@modelcontextprotocol/sdk/inMemory.js"
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  try {
+    const result = await client.callTool({ name: toolName, arguments: args });
+    const content = result.content as Array<{ type: string; text?: string }>;
+    const first = content[0];
+    return {
+      ok: !result.isError,
+      text: first && "text" in first ? String(first.text) : "",
+      isError: result.isError === true,
+    };
+  } finally {
+    await client.close();
+  }
+}

--- a/mcp-server/test/tools.test.ts
+++ b/mcp-server/test/tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import { strict as assert } from "node:assert";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync, chmodSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
@@ -45,10 +45,41 @@ exit 2
   });
 
   it("runs the prism binary and returns stdout on success", async () => {
-    const result = await runPrism(["--version"], {});
-    assert.equal(result.exitCode, 0);
-    assert.equal(result.ok, true);
-    assert.ok(result.stdout.includes("prism 0.0.2"));
+    const prevBin = process.env.PRISM_BIN;
+    process.env.PRISM_BIN = fakePrism;
+    try {
+      const result = await runPrism(["--version"], {});
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.ok, true);
+      assert.equal(result.timedOut, false);
+      assert.ok(result.stdout.includes("prism 0.0.2"));
+    } finally {
+      if (prevBin === undefined) delete process.env.PRISM_BIN;
+      else process.env.PRISM_BIN = prevBin;
+    }
+  });
+
+  it("sets timedOut=true when the command exceeds the timeout", async () => {
+    const prevBin = process.env.PRISM_BIN;
+    const slowBin = join(workDir, "slow-prism");
+    writeFileSync(
+      slowBin,
+      `#!/usr/bin/env bash
+sleep 10
+echo "should not get here"
+exit 0
+`,
+    );
+    chmodSync(slowBin, 0o755);
+    process.env.PRISM_BIN = slowBin;
+    try {
+      const result = await runPrism(["slow"], { timeoutMs: 200 });
+      assert.equal(result.ok, false);
+      assert.equal(result.timedOut, true);
+    } finally {
+      if (prevBin === undefined) delete process.env.PRISM_BIN;
+      else process.env.PRISM_BIN = prevBin;
+    }
   });
 
   it("returns ok=false with stderr on non-zero exit", async () => {

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}


### PR DESCRIPTION
## Summary

Implements the **MCP server for Claude Desktop** — marketplace #2 from issue #33's list of 10 target harnesses. This is a standalone npm package (`prism-mcp-server`) that exposes Prism CLI commands and SQLite queries as MCP tools via stdio transport.

## What's included (4 atomic commits)

| # | Commit | What |
|---|---|---|
| 1 | `feat(mcp-server): scaffold package structure for prism-mcp-server` | `mcp-server/package.json` (name, deps, bin), `tsconfig.json`, `.gitignore` |
| 2 | `feat(mcp-server): implement stdio MCP server with 4 Prism tools` | `src/exec.ts` (CLI helper), `src/tools.ts` (4 tool definitions), `src/index.ts` (server entry point) |
| 3 | `docs(mcp-server): add README and mark MCP server as Ready in marketplaces` | `mcp-server/README.md` (Claude Desktop config + tool docs), `marketplaces/README.md` (status table updated) |
| 4 | `test(mcp-server): add node:test suite + fix default import and type annotation` | `test/tools.test.ts` (10 tests), default import fix, README build requirement section |

## 4 MCP tools exposed

| Tool | What it does |
|---|---|
| `prism_status` | Reads SQLite: position count, total deposited/current value, last 3 audit entries |
| `prism_positions` | Lists active positions (excludes paper-exited ones, matching the fix from issue #34) |
| `prism_whoami` | Shells out to `prism whoami` CLI; handles 'not registered' gracefully |
| `prism_backtest` | Shells out to `prism backtest` with zod-validated schema (source, days, pools) |

## Files added (8, 643 lines total)

```
mcp-server/.gitignore          (new,   6 lines)
mcp-server/package.json        (new,  41 lines)
mcp-server/package-lock.json   (new, 1209 lines)
mcp-server/tsconfig.json       (new,  18 lines)
mcp-server/src/exec.ts         (new,  66 lines)
mcp-server/src/index.ts        (new,  14 lines)
mcp-server/src/tools.ts        (new, 253 lines)
mcp-server/test/tools.test.ts  (new, 304 lines)
mcp-server/README.md           (new, 166 lines)
marketplaces/README.md         (modified, +2 lines for MCP server row)
```

## Configuration

Claude Desktop `claude_desktop_config.json`:
```json
{
  "mcpServers": {
    "prism": {
      "command": "node",
      "args": ["/absolute/path/to/mcp-server/dist/index.js"],
      "env": {
        "PRISM_BIN": "/absolute/path/to/prism",
        "SQLITE_DB_PATH": "/absolute/path/to/prism.db"
      }
    }
  }
}
```

## Verification

- `tsc` build clean ("TypeScript: No errors found")
- All 10 tests written using `node:test` + `node:assert` (built into Node 18+, no extra framework)
- Tests use better-sqlite3 in readonly mode with temp DBs

## Known limitation: test execution

The tests require `better-sqlite3`'s native binding to be built for the target Node.js version. On Node v26 (very recent), there may not be prebuilds available, and source compilation requires:
- macOS: Xcode CLI Tools (`xcode-select --install`)
- Linux: Python 3, make, g++
- Windows: windows-build-tools

The MCP **server itself** works regardless (it just imports better-sqlite3 at module load — if the binding isn't there, Claude Desktop will show a clear error, but the package structure is correct). CI uses Node 20 which has prebuilds, so the tests will run there.

## Why a separate package (not a CLI subcommand)

Issue #33 suggested `prism-mcp-server` as a standalone npm package. This is the right boundary because:
- MCP servers are spawned as separate processes by Claude Desktop (stdio transport)
- They have a different dep tree (`@modelcontextprotocol/sdk`, `better-sqlite3`, `zod` vs the main engine deps)
- They have a different release cadence (can update without bumping the main engine)
- Users who only want the CLI don't need to pull in MCP dependencies

## What's NOT in this PR (from issue #33's list)

5/10 marketplaces remain: OpenAI GPTs (UI-only), AutoGPT/LangChain/CrewAI (PyPI packages), Dify/Flowise (platform plugins). Each is a multi-day project on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP server exposing Prism liquidity-agent commands (`prism_status`, `prism_positions`, `prism_whoami`, `prism_backtest`) for integration with Claude Desktop and other MCP-compatible platforms.

* **Documentation**
  * Updated marketplace skills status documentation across multiple harness marketplaces (OpenCode, OpenClaw, Hermes, Claude Desktop, and others).
  * Added installation and configuration guides for the Prism MCP server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->