### PR TITLE
fix: allow CLI-spawned engine to bypass direct execution guard

### DIFF
--- a/cli/dev.ts
+++ b/cli/dev.ts
@@ -23,6 +23,7 @@ export const devCommand = new Command("dev")
     const child = spawn("bun", ["run", "dev"], {
       stdio: "inherit",
       shell: false,
+      env: { ...process.env, PRISM_ALLOW_DIRECT: "true" },
     });
 
     child.on("exit", (code) => {


### PR DESCRIPTION
## Critical P1 Fix

Oracle verification of PR #52 identified that the guard in `engine/index.ts` (added in PR #49) was blocking the CLI-spawned engine process.

## The Bug

1. `cli/dev.ts:23` spawns `bun run dev` **without** `PRISM_ALLOW_DIRECT=true`
2. `bun run dev` resolves to `bun run --watch engine/index.ts` (per `package.json`)
3. In the child process, `process.argv[1]` is `engine/index.ts`
4. The guard matches, and since `PRISM_ALLOW_DIRECT` is not set → `process.exit(1)`

**Result**: `prism dev` — the documented primary command — fails immediately.

## The Fix

Pass `PRISM_ALLOW_DIRECT=true` in the child process environment:

```typescript
const child = spawn("bun", ["run", "dev"], {
  stdio: "inherit",
  shell: false,
  env: { ...process.env, PRISM_ALLOW_DIRECT: "true" },
});
```

This signals that the execution is sanctioned by the CLI, not a direct user invocation.

## Impact

This was flagged as P1 in PR #49 review and was never addressed in PRs #50, #51, or #52. Without this fix, `prism dev` is broken for all users.

## Verification
- `bun run lint` ✅ clean
- `bun run test` ✅ 114/114 passed

## Related
- PR #49 (original guard added)
- PRs #50, #51, #52 (Oracle fixes)
- Oracle verification session: ses_163b3deebffeMHA8Bn8P445hbx

## Summary by Sourcery

Bug Fixes:
- Ensure the CLI-spawned engine process bypasses the direct-execution guard by setting the appropriate environment variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development startup process environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->