### PR TITLE
fix(referral): remove dead credit methods (getUserCredits, addCredits, deductCredits)

### DIFF
--- a/engine/referral-service.ts
+++ b/engine/referral-service.ts
@@ -54,33 +54,9 @@ const applyReferralImpl = (
 const getReferralCountImpl = (_userId: string): Effect.Effect<number, Error> =>
   Effect.succeed(0);
 
-const getUserCreditsImpl = (_userId: string): Effect.Effect<number, Error> =>
-  Effect.succeed(0);
-
-const addCreditsImpl = (
-  userId: string,
-  amount: number,
-  reason: string,
-): Effect.Effect<void, Error> =>
-  Effect.sync(() => {
-    console.info("Added credits", { userId, amount, reason });
-  });
-
-const deductCreditsImpl = (
-  userId: string,
-  amount: number,
-  reason: string,
-): Effect.Effect<void, Error> =>
-  Effect.sync(() => {
-    console.info("Deducted credits", { userId, amount, reason });
-  });
-
 export const ReferralLive = Layer.succeed(ReferralService, {
   generateCode: generateCodeImpl,
   validateCode: validateCodeImpl,
   applyReferral: applyReferralImpl,
   getReferralCount: getReferralCountImpl,
-  getUserCredits: getUserCreditsImpl,
-  addCredits: addCreditsImpl,
-  deductCredits: deductCreditsImpl,
 } satisfies ReferralApi);

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -561,17 +561,6 @@ export interface ReferralApi {
   readonly validateCode: (code: string) => Effect.Effect<{ valid: boolean; referrerId?: string }, Error>;
   readonly applyReferral: (code: string, refereeId: string) => Effect.Effect<void, Error>;
   readonly getReferralCount: (userId: string) => Effect.Effect<number, Error>;
-  readonly getUserCredits: (userId: string) => Effect.Effect<number, Error>;
-  readonly addCredits: (
-    userId: string,
-    amount: number,
-    reason: string,
-  ) => Effect.Effect<void, Error>;
-  readonly deductCredits: (
-    userId: string,
-    amount: number,
-    reason: string,
-  ) => Effect.Effect<void, Error>;
 }
 
 export class ReferralService extends Context.Tag("ReferralService")<


### PR DESCRIPTION
## Summary

Removes three dead methods from the `ReferralService` that were left orphaned after PR #52 removed the credit-discount system.

## Context

PR #52 ("resolve dimensional mismatch in credit discount allocation") removed the entire credit discount code path from `engine/program.ts`. However, the supporting service methods remained:

- `getUserCredits` — no longer called from `program.ts` (was the stale-snapshot fix)
- `addCredits` — never called outside the service implementation
- `deductCredits` — no longer called from `program.ts` (was the platform-fee discount path)

Kilo code review on PR #52 explicitly identified this as a follow-up cleanup.

## Changes

| File | Change |
|------|--------|
| `engine/referral-service.ts` | Removed `getUserCreditsImpl`, `addCreditsImpl`, `deductCreditsImpl` and their entries in `ReferralLive` |
| `engine/services.ts` | Removed `getUserCredits`, `addCredits`, `deductCredits` from `ReferralApi` interface |

Net: **-35 lines**, no behavior change, no test changes (no tests covered these stubs).

## Verification

- `bun run lint` → clean (tsc + oxlint)
- `bun run test` → 114/114 passed
- Grep for removed names → 0 matches
- `lsp_diagnostics` → clean on both files

## Summary by Sourcery

Enhancements:
- Clean up dead referral credit methods and their wiring from the ReferralService implementation and ReferralApi interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the referral service to focus exclusively on referral code operations. Credit management functionality has been separated from the referral service interface and should be accessed through alternative methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->