### PR TITLE
fix(rebalance): fix broken simulateRebalance IL heuristic and OOR tracking

### DIFF
--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -422,16 +422,20 @@ export const AdapterLive = Layer.effect(
 
       simulateRebalance: (poolAddress, newLowerBinId, newUpperBinId) =>
         Effect.gen(function* () {
-          const binArray = yield* api.getBinArray(poolAddress);
-          const activeBin = binArray.bins.find((b) => b.binId === binArray.activeBinId);
+          const pool = yield* api.getPoolState(poolAddress);
 
-          if (!activeBin) {
-            return { estimatedIlUsd: 0, estimatedFeesUsd: 0, netBenefitUsd: 0 };
-          }
+          const rangeWidth = Math.max(newUpperBinId - newLowerBinId, 0);
 
-          const rangeWidth = newUpperBinId - newLowerBinId;
-          const estimatedFeesUsd = (rangeWidth / 40) * 10;
-          const estimatedIlUsd = rangeWidth > 30 ? rangeWidth * 0.5 : 0;
+          // Fee estimate: proportional to pool's 24h fees, scaled by our range width
+          // A narrower range captures fewer fees but is more capital-efficient.
+          const feeCaptureRatio = Math.min(rangeWidth / 100, 1.0);
+          const estimatedFeesUsd = pool.fees24hUsd * feeCaptureRatio;
+
+          // IL estimate for rebalancing: small fixed cost (tx fees + temporary IL).
+          // The old heuristic (rangeWidth * 0.5) was wrong — rebalancing to center
+          // on the active bin eliminates OOR IL, it doesn't create new IL.
+          const estimatedIlUsd = 0.5;
+
           const netBenefitUsd = estimatedFeesUsd - estimatedIlUsd;
 
           return { estimatedIlUsd, estimatedFeesUsd, netBenefitUsd };

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -289,6 +289,23 @@ export const program = Effect.gen(function* () {
 
       let decision: AgentDecision | null = null;
 
+      // OOR tracking must run before EXIT conditions so that out-of-range
+      // cycle counts accumulate even when fee/IL triggers an EXIT.
+      const pos = trackedPositions.get(poolAddress);
+      const hasPosition = !!pos;
+      if (hasPosition) {
+        const inRange = pool.activeBinId >= pos.lowerBinId && pool.activeBinId <= pos.upperBinId;
+        if (!inRange) {
+          if (pos.outOfRangeSince === null) {
+            pos.outOfRangeSince = Date.now();
+          }
+          pos.oorCycleCount++;
+        } else {
+          pos.outOfRangeSince = null;
+          pos.oorCycleCount = 0;
+        }
+      }
+
       // EXIT conditions (capital protection)
       if (tvlVelocity < -config.tvlDropExitPct) {
         decision = {
@@ -322,7 +339,6 @@ export const program = Effect.gen(function* () {
 
       // Trailing exit (profit protection)
       if (!decision) {
-        const pos = trackedPositions.get(poolAddress);
         if (pos) {
           const estimatedValue = estimatePositionValue(pos, pool);
           pos.currentValueUsd = estimatedValue;
@@ -346,8 +362,6 @@ export const program = Effect.gen(function* () {
 
       // REBALANCE check
       if (!decision) {
-        const pos = trackedPositions.get(poolAddress);
-        const hasPosition = !!pos;
         const currentLowerBinId = pos?.lowerBinId ?? pool.activeBinId - 20;
         const currentUpperBinId = pos?.upperBinId ?? pool.activeBinId + 20;
         const positionCenter = (currentLowerBinId + currentUpperBinId) / 2;
@@ -356,21 +370,7 @@ export const program = Effect.gen(function* () {
         const lastRebal = pos?.lastRebalanceAt ?? 0;
         const timeSinceRebal = Date.now() - lastRebal;
 
-        // Out-of-range tracking
-        if (hasPosition) {
-          const inRange = pool.activeBinId >= pos.lowerBinId && pool.activeBinId <= pos.upperBinId;
-          if (!inRange) {
-            if (pos.outOfRangeSince === null) {
-              pos.outOfRangeSince = Date.now();
-            }
-            pos.oorCycleCount++;
-          } else {
-            pos.outOfRangeSince = null;
-            pos.oorCycleCount = 0;
-          }
-        }
-
-        const oorGraceExpired = hasPosition && pos.oorCycleCount >= config.oorGracePeriodCycles;
+        const oorGraceExpired = hasPosition && pos && pos.oorCycleCount >= config.oorGracePeriodCycles;
 
         if (
           hasPosition &&


### PR DESCRIPTION
## Problem

The engine was not automatically rebalancing positions that went out of range (OOR). Two related bugs caused this:

### Bug 1: simulateRebalance returned negative net benefit for all typical ranges

The IL heuristic in `adapter-service.ts:434` was:
```typescript
const estimatedIlUsd = rangeWidth > 30 ? rangeWidth * 0.5 : 0;
```

For typical bin ranges (40-50 bins):
- Width 40: IL = , fees =  → net = -
- Width 50: IL = , fees = .50 → net = -.50

The default `MIN_REBALANCE_NET_BENEFIT_USD` is . Since net benefit was **always negative** for typical ranges, the REBALANCE decision was **never made**, even when drift exceeded 200%.

The heuristic was conceptually wrong: rebalancing to center on the active bin **eliminates** OOR IL, it doesn't create new IL proportional to range width.

### Bug 2: OOR cycle counts never incremented when fee/IL < 0.5 triggered EXIT

The OOR tracking block (`program.ts:360-371`) was inside `if (!decision)`. When an EXIT condition fired first (e.g., fee/IL < 0.5, which is guaranteed when OOR because no fees are earned), the OOR tracking was **skipped entirely**. This meant:
- `oorCycleCount` never incremented
- `oorGraceExpired` (requires 3 cycles) was always false
- The grace period mechanism was completely broken for positions that triggered EXIT

## Changes

| File | Change |
|------|--------|
| `engine/adapter-service.ts` | Replaced broken IL heuristic with realistic model: fees ∝ pool.fees24hUsd × rangeWidth, IL = fixed /bin/zsh.50 tx cost |
| `engine/program.ts` | Moved OOR tracking before EXIT conditions so cycle counts accumulate regardless of decision |

## Verification

- `bun run lint` → clean (tsc + oxlint)
- `bun run test` → 114/114 passed
- Example: pool with `fees24hUsd = `, rangeWidth = 40
  - Old netBenefit = - (REBALANCE blocked)
  - New netBenefit = ~.50 (REBALANCE allowed)

Fixes the reported issue where positions go OOR but the engine never rebalances.

## Summary by Sourcery

Fix automatic rebalancing and out-of-range tracking so positions correctly rebalance when going OOR and the grace period behaves as intended.

Bug Fixes:
- Correct simulateRebalance fee/IL heuristics so net benefit is realistically estimated and rebalances are no longer always blocked for typical ranges.
- Ensure out-of-range cycle counts and grace period tracking run independently of EXIT decisions so OOR positions correctly progress through their lifecycle.