### PR TITLE
fix(paper): allow paper mode to exit live positions via PAPER_MODE_EXIT_LIVE

### DIFF
--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -71,6 +71,7 @@ function buildLayer(
     githubToken,
     githubRepo,
     feedbackOptOut: optOut,
+    paperModeExitLive: false,
   });
   const baseLayer = Layer.merge(mockConfig, DbLive(":memory:"));
   return Layer.provide(FeedbackLive, baseLayer) as Layer.Layer<FeedbackService, never, never>;

--- a/cli/dev.ts
+++ b/cli/dev.ts
@@ -2,9 +2,18 @@ import { Command } from "commander";
 import { spawn } from "child_process";
 import { pingInstall, readCredentials } from "./api.js";
 
+interface DevCommandOptions {
+  exitLive: boolean;
+}
+
 export const devCommand = new Command("dev")
   .description("Start the trading agent")
-  .action(() => {
+  .option(
+    "--exit-live",
+    "Execute live on-chain EXIT transactions even in paper mode (requires wallet — sends real transactions)",
+    false,
+  )
+  .action((options: DevCommandOptions) => {
     pingInstall("dev_start");
 
     const creds = readCredentials();
@@ -19,11 +28,20 @@ export const devCommand = new Command("dev")
       process.exit(1);
     }
 
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      PRISM_ALLOW_DIRECT: "true",
+    };
+    if (options.exitLive) {
+      console.warn("⚠️  PAPER_MODE_EXIT_LIVE enabled — paper mode will execute live transactions for EXIT");
+      env.PAPER_MODE_EXIT_LIVE = "true";
+    }
+
     console.log("Starting Prism trading agent...");
     const child = spawn("bun", ["run", "dev"], {
       stdio: "inherit",
       shell: false,
-      env: { ...process.env, PRISM_ALLOW_DIRECT: "true" },
+      env,
     });
 
     child.on("exit", (code) => {

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -42,6 +42,8 @@ export interface AppConfig {
   readonly githubToken: string;
   readonly githubRepo: string;
   readonly feedbackOptOut: boolean;
+  // Allow paper mode to exit live positions (opt-in escape hatch)
+  readonly paperModeExitLive: boolean;
 }
 
 export class ConfigService extends Context.Tag("ConfigService")<ConfigService, AppConfig>() {}
@@ -148,6 +150,9 @@ const loadConfig = Effect.gen(function* () {
   const feedbackOptOut = yield* Config.boolean("PRISM_FEEDBACK_OPT_OUT").pipe(
     Effect.orElseSucceed(() => false),
   );
+  const paperModeExitLive = yield* Config.boolean("PAPER_MODE_EXIT_LIVE").pipe(
+    Effect.orElseSucceed(() => false),
+  );
 
   const watchlistPools = watchlistPoolsRaw
     .split(",")
@@ -192,6 +197,7 @@ const loadConfig = Effect.gen(function* () {
     githubToken,
     githubRepo,
     feedbackOptOut,
+    paperModeExitLive,
   };
 
   return cfg;

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -573,6 +573,12 @@ export const program = Effect.gen(function* () {
       } else if (decision.action === "EXIT") {
         const pos = trackedPositions.get(decision.poolAddress);
         if (pos?.positionPubKey) {
+          if (config.paperModeExitLive) {
+            console.warn(
+              `[PAPER] PAPER_MODE_EXIT_LIVE is enabled — executing live EXIT for ${decision.poolAddress}`,
+            );
+            return yield* executeLive(decision, pool);
+          }
           // Live position — paper trading must not "exit" it without an on-chain tx.
           // Skip and warn so the user can switch to live mode to actually close it.
           console.warn(


### PR DESCRIPTION
## Problem

When a user switches from live trading to paper mode (or updates the engine while a live position exists), the engine detects the live position and tries to EXIT it. However, paper mode refuses to execute on-chain transactions, causing an endless loop:

```
[PAPER] Would execute { action: "EXIT", pool: "5rCf1DM..." }
[PAPER] Skipping EXIT for 5rCf1DM... — this is a live position
```

The position is stranded and the engine cannot make progress.

## Solution

Add an opt-in escape hatch: `PAPER_MODE_EXIT_LIVE` (default false).

When enabled, paper mode delegates EXIT decisions for live positions to the live execution path, which performs the actual on-chain close transaction.

## Changes

| File | Change |
|------|--------|
| `engine/config-service.ts` | Added `paperModeExitLive: boolean` config (env: `PAPER_MODE_EXIT_LIVE`, default false) |
| `engine/program.ts` | `executePaper` checks `config.paperModeExitLive` — when true, delegates live EXIT to `executeLive` |
| `cli/dev.ts` | Added `--exit-live` flag that sets `PAPER_MODE_EXIT_LIVE=true` in child process env |
| `bench/feedback-service.test.ts` | Added missing `paperModeExitLive` to mock config |

## Usage

```bash
# CLI flag
prism dev --exit-live

# Or env variable
PAPER_MODE_EXIT_LIVE=true prism dev
```

## Safety

- **Default is false** — paper mode still protects live positions by default
- **Explicit opt-in required** — user must deliberately enable the flag
- **Warning logged** when active: "PAPER_MODE_EXIT_LIVE is enabled — executing live EXIT"
- Only affects EXIT, not ENTER or REBALANCE

Fixes #56.

## Summary by Sourcery

Add an opt-in configuration and CLI flag to allow paper mode to exit live positions by delegating EXIT actions to the live execution path when explicitly enabled.

New Features:
- Introduce PAPER_MODE_EXIT_LIVE config flag to control whether paper mode may exit live positions.
- Add --exit-live CLI option to enable PAPER_MODE_EXIT_LIVE when starting the dev trading agent.

Bug Fixes:
- Prevent the engine from getting stuck when a live position exists in paper mode by optionally allowing EXIT actions to execute via the live path.

Enhancements:
- Extend configuration service and related tests to include the new paperModeExitLive option and default it to false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--exit-live` CLI flag to enable live position exits during paper-trading mode.

* **Tests**
  * Updated test configuration for feedback service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->