### PR TITLE
fix(install): harden installer against empty env, missing bun, lockfile v2

### DIFF
--- a/bench/install.test.sh
+++ b/bench/install.test.sh
@@ -253,6 +253,48 @@ scenario_s6() {
   esac
 }
 
+scenario_s7() {
+  bold "S7: install.sh survives unset HOME under set -u (no \$HOME crash)"
+  local tmp; tmp="$(mktemp -d -t prism-s7-XXXXXX)"
+  local out; out="$tmp/out.log"
+  env -i PATH="/usr/bin:/bin" \
+    bash "$INSTALL_SH" >"$out" 2>&1
+  local body; body="$(cat "$out")"
+  case "$body" in
+    *"HOME: unbound variable"*|*"HOME: parameter null or not set"*)
+      FAIL=$((FAIL + 1))
+      FAILED_NAMES+=("S7: HOME unset does not crash")
+      printf "  %s S7: HOME unset does not crash\n" "$(red FAIL)"
+      printf "       body: %s\n" "${body:0:300}"
+      ;;
+    *)
+      PASS=$((PASS + 1))
+      printf "  %s HOME unset does not crash on \$HOME\n" "$(green PASS)"
+      ;;
+  esac
+  rm -rf "$tmp"
+}
+
+scenario_s8() {
+  bold "S8: install.sh defensively reads \$PATH (no bare \$PATH under set -u)"
+  local body; body="$(cat "$INSTALL_SH")"
+  local matched=0
+  case "$body" in
+    *'${PATH:-}'*) matched=1 ;;
+  esac
+  case "$body" in
+    *'IFS=:'*'read -r -a _path_entries <<<"${PATH:-}"'*) matched=1 ;;
+  esac
+  if [ "$matched" -eq 1 ]; then
+    PASS=$((PASS + 1))
+    printf "  %s PATH read uses defensive \${PATH:-}\n" "$(green PASS)"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("S8: PATH defensive read present")
+    printf "  %s S8: PATH defensive read present\n" "$(red FAIL)"
+  fi
+}
+
 # ---- Main ----
 echo ""
 bold "Install script test suite"
@@ -265,6 +307,8 @@ scenario_s3
 scenario_s4
 scenario_s5
 scenario_s6
+scenario_s7
+scenario_s8
 
 echo ""
 if [ "$FAIL" -eq 0 ]; then

--- a/bench/install.test.sh
+++ b/bench/install.test.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# bash test for scripts/install.sh — 5 fixes for the install script.
+# Run with: bash bench/install.test.sh
+# Returns 0 only if all scenarios PASS; 1 if any fail.
+set -u
+
+# Locate the script under test. Tests live in bench/, script is in scripts/.
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+POSTINSTALL_JS="$REPO_ROOT/scripts/postinstall.js"
+
+if [ ! -f "$INSTALL_SH" ]; then
+  echo "FATAL: $INSTALL_SH not found" >&2
+  exit 2
+fi
+
+# ---- Test harness ----
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+red()   { printf '\033[31m%s\033[0m' "$*"; }
+green() { printf '\033[32m%s\033[0m' "$*"; }
+bold()  { printf '\033[1m%s\033[0m' "$*"; }
+
+assert_eq() {
+  # assert_eq <name> <expected> <actual>
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    printf "  %s %s\n" "$(green PASS)" "$name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+    printf "  %s %s\n" "$(red FAIL)" "$name"
+    printf "       expected: %q\n" "$expected"
+    printf "       actual:   %q\n" "$actual"
+  fi
+}
+
+assert_contains() {
+  # assert_contains <name> <needle> <haystack>
+  local name="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*)
+      PASS=$((PASS + 1))
+      printf "  %s %s\n" "$(green PASS)" "$name"
+      ;;
+    *)
+      FAIL=$((FAIL + 1))
+      FAILED_NAMES+=("$name")
+      printf "  %s %s\n" "$(red FAIL)" "$name"
+      printf "       expected to contain: %q\n" "$needle"
+      printf "       haystack (first 300 chars):\n       %s\n" "${haystack:0:300}"
+      ;;
+  esac
+}
+
+assert_not_contains() {
+  # assert_not_contains <name> <forbidden> <haystack>
+  local name="$1" forbidden="$2" haystack="$3"
+  case "$haystack" in
+    *"$forbidden"*)
+      FAIL=$((FAIL + 1))
+      FAILED_NAMES+=("$name")
+      printf "  %s %s\n" "$(red FAIL)" "$name"
+      printf "       should NOT contain: %q\n" "$forbidden"
+      printf "       haystack (first 300 chars):\n       %s\n" "${haystack:0:300}"
+      ;;
+    *)
+      PASS=$((PASS + 1))
+      printf "  %s %s\n" "$(green PASS)" "$name"
+      ;;
+  esac
+}
+
+# ---- Helpers ----
+
+# Run install.sh under a controlled env and capture output + exit code.
+# Strips PRISM_* env vars so S1 is reproducible.
+run_install_clean() {
+  # Usage: run_install_clean [extra env=value ...]
+  local tmp; tmp="$(mktemp -d -t prism-install-test-XXXXXX)"
+  local out; out="$tmp/out.log"
+  # shellcheck disable=SC2086
+  env -i HOME="$tmp/home" PATH="/usr/bin:/bin" \
+    "$@" \
+    bash "$INSTALL_SH" >"$out" 2>&1
+  local rc=$?
+  printf '%s' "$out" >/dev/null
+  RC=$rc
+  OUT_FILE="$out"
+  TMP_DIR="$tmp"
+}
+
+# ---- S1: Unbound variable fix ----
+# Sourcing install.sh with PRISM_SKIP_AUTO_TARBALL unset must not crash.
+scenario_s1() {
+  bold "S1: install.sh tolerates unset PRISM_SKIP_AUTO_TARBALL under set -u"
+  local tmp; tmp="$(mktemp -d -t prism-s1-XXXXXX)"
+  local out; out="$tmp/out.log"
+  # Run the install script with a clean env so PRISM_SKIP_AUTO_TARBALL is unset.
+  # We use `bash` so set -u propagates. We expect a non-crash on the env-var read.
+  env -i HOME="$tmp/home" PATH="/usr/bin:/bin" \
+    bash "$INSTALL_SH" >"$out" 2>&1
+  local rc=$?
+  local body; body="$(cat "$out")"
+  # The actual fix should let the script reach bun install (or fail later for
+  # a non-env reason). What we are SURE is broken in the old code is the
+  # explicit "unbound variable" error. Assert it does NOT appear.
+  assert_not_contains "no 'unbound variable' error" "unbound variable" "$body"
+  rm -rf "$tmp"
+}
+
+# ---- S2: Bun auto-install code path exists ----
+scenario_s2() {
+  bold "S2: install.sh has an ensure_bun() path that installs bun.sh"
+  # The fix must include a function or block that, when bun is missing,
+  # fetches from bun.sh. We assert the install script contains the
+  # canonical bun installer URL.
+  local body; body="$(cat "$INSTALL_SH")"
+  assert_contains "references bun.sh installer" "bun.sh/install" "$body"
+  assert_contains "checks command -v bun" "command -v bun" "$body"
+}
+
+# ---- S3: Bun version check ----
+scenario_s3() {
+  bold "S3: install.sh rejects bun < 1.4.0 (lockfile v2 requires it)"
+  # We use a stub PATH that points to a directory containing a fake `bun`
+  # binary that prints a too-old version. Expect a non-zero exit and an
+  # error message that mentions the minimum version.
+  local tmp; tmp="$(mktemp -d -t prism-s3-XXXXXX)"
+  mkdir -p "$tmp/bin"
+  cat >"$tmp/bin/bun" <<'EOF'
+#!/usr/bin/env bash
+# Fake bun that reports an old version.
+if [ "$1" = "--version" ]; then echo "1.2.3"; exit 0; fi
+echo "fake bun" >&2
+exit 0
+EOF
+  chmod +x "$tmp/bin/bun"
+  local out; out="$tmp/out.log"
+  env -i HOME="$tmp/home" PATH="$tmp/bin:/usr/bin:/bin" \
+    bash "$INSTALL_SH" >"$out" 2>&1
+  local rc=$?
+  local body; body="$(cat "$out")"
+  # We don't require a specific error wording — only that the script did
+  # NOT silently proceed (i.e. it either reported a clear version error
+  # or the failure was for another reason that includes a minimum version
+  # reference). And critically, it did NOT call real `bun install`.
+  local matched=0
+  case "$body" in
+    *"bun version"*|*"bun-version"*|*"Bun 1.4"*|*"requires Bun 1.4"*|*"minimum bun"*|*"minimum version"*) matched=1 ;;
+  esac
+  case "$body" in
+    *"1.4.0"*) matched=1 ;;
+  esac
+  case "$body" in
+    *"too old"*) matched=1 ;;
+  esac
+  case "$body" in
+    *"upgrade"*"bun"*) matched=1 ;;
+  esac
+  if [ "$matched" -eq 1 ]; then
+    PASS=$((PASS + 1))
+    printf "  %s bun-version-mismatch message present\n" "$(green PASS)"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("S3: bun < 1.4.0 is rejected with a clear message")
+    printf "  %s S3: bun < 1.4.0 is rejected with a clear message\n" "$(red FAIL)"
+    printf "       body (first 400):\n       %s\n" "${body:0:400}"
+  fi
+  rm -rf "$tmp"
+}
+
+# ---- S4: End-of-install verification (bun --version, prism --version) ----
+scenario_s4() {
+  bold "S4: install.sh runs bun --version and prism --version at the end"
+  local body; body="$(cat "$INSTALL_SH")"
+  # The end-of-install verification must invoke both binaries explicitly.
+  # Allow any path, any quoting, but the literals must be present.
+  case "$body" in
+    *"bun --version"*)
+      PASS=$((PASS + 1))
+      printf "  %s calls 'bun --version' at end of install\n" "$(green PASS)"
+      ;;
+    *)
+      FAIL=$((FAIL + 1))
+      FAILED_NAMES+=("S4: bun --version check at end")
+      printf "  %s S4: bun --version check at end\n" "$(red FAIL)"
+      ;;
+  esac
+  case "$body" in
+    *"--version"*"prism"*"--version"*|*"prism --version"*)
+      PASS=$((PASS + 1))
+      printf "  %s calls 'prism --version' at end of install\n" "$(green PASS)"
+      ;;
+    *)
+      FAIL=$((FAIL + 1))
+      FAILED_NAMES+=("S4: prism --version check at end")
+      printf "  %s S4: prism --version check at end\n" "$(red FAIL)"
+      ;;
+  esac
+}
+
+# ---- S5: PATH reminder is concrete ----
+scenario_s5() {
+  bold "S5: install.sh emits a concrete PATH reminder command"
+  local body; body="$(cat "$INSTALL_SH")"
+  # The reminder must include an actual export PATH= line that the user
+  # can copy-paste. Just printing "add to PATH" is not enough.
+  case "$body" in
+    *"export PATH"*)
+      PASS=$((PASS + 1))
+      printf "  %s PATH reminder includes 'export PATH' command\n" "$(green PASS)"
+      ;;
+    *)
+      FAIL=$((FAIL + 1))
+      FAILED_NAMES+=("S5: export PATH reminder present")
+      printf "  %s S5: export PATH reminder present\n" "$(red FAIL)"
+      ;;
+  esac
+  # And: after install, the script should warn (not silently fail) if the
+  # wrapper location is not on PATH. The source uses $BIN_DIR which
+  # expands to ~/.local/bin at runtime — check the literal variable.
+  case "$body" in
+    *'$BIN_DIR'*|*"\$BIN_DIR"*)
+      PASS=$((PASS + 1))
+      printf "  %s PATH reminder references \$BIN_DIR wrapper path\n" "$(green PASS)"
+      ;;
+    *)
+      FAIL=$((FAIL + 1))
+      FAILED_NAMES+=("S5: PATH reminder references BIN_DIR")
+      printf "  %s S5: PATH reminder references BIN_DIR\n" "$(red FAIL)"
+      ;;
+  esac
+}
+
+scenario_s6() {
+  bold "S6: install.sh has defensive default assignment for PRISM_SKIP_AUTO_TARBALL"
+  local body; body="$(cat "$INSTALL_SH")"
+  case "$body" in
+    *'PRISM_SKIP_AUTO_TARBALL="${PRISM_SKIP_AUTO_TARBALL:-}"'*|*'PRISM_SKIP_AUTO_TARBALL="${PRISM_SKIP_AUTO_TARBALL:-'*)
+      PASS=$((PASS + 1))
+      printf "  %s defensive default assignment present\n" "$(green PASS)"
+      ;;
+    *)
+      FAIL=$((FAIL + 1))
+      FAILED_NAMES+=("S6: defensive default assignment present")
+      printf "  %s S6: defensive default assignment present\n" "$(red FAIL)"
+      ;;
+  esac
+}
+
+# ---- Main ----
+echo ""
+bold "Install script test suite"
+echo "  install.sh: $INSTALL_SH"
+echo ""
+
+scenario_s1
+scenario_s2
+scenario_s3
+scenario_s4
+scenario_s5
+scenario_s6
+
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  bold "$(green "All $PASS assertions passed.")"
+  exit 0
+else
+  bold "$(red "$FAIL of $((PASS+FAIL)) assertions failed:")"
+  for n in "${FAILED_NAMES[@]}"; do
+    printf "  - %s\n" "$n"
+  done
+  exit 1
+fi

--- a/bench/install.test.sh
+++ b/bench/install.test.sh
@@ -295,6 +295,43 @@ scenario_s8() {
   fi
 }
 
+scenario_s9() {
+  bold "S9: PATH reminder heredoc uses \${SHELL_NAME}rc (no undefined SHELL_NAMERC)"
+  local body; body="$(cat "$INSTALL_SH")"
+  case "$body" in
+    *'SHELL_NAMERC'*)
+      FAIL=$((FAIL + 1))
+      FAILED_NAMES+=("S9: no undefined SHELL_NAMERC reference")
+      printf "  %s S9: no undefined SHELL_NAMERC reference\n" "$(red FAIL)"
+      ;;
+    *)
+      PASS=$((PASS + 1))
+      printf "  %s no undefined SHELL_NAMERC reference\n" "$(green PASS)"
+      ;;
+  esac
+}
+
+scenario_s10() {
+  bold "S10: ensure_bun() sets BUN_INSTALLED_BUN_SH=1 on fresh install"
+  local body; body="$(cat "$INSTALL_SH")"
+  local init_ok=0
+  local set_ok=0
+  case "$body" in
+    *'BUN_INSTALLED_BUN_SH=0'*) init_ok=1 ;;
+  esac
+  case "$body" in
+    *'BUN_INSTALLED_BUN_SH=1'*) set_ok=1 ;;
+  esac
+  if [ "$init_ok" -eq 1 ] && [ "$set_ok" -eq 1 ]; then
+    PASS=$((PASS + 1))
+    printf "  %s BUN_INSTALLED_BUN_SH initialised at 0 and set to 1 on fresh install\n" "$(green PASS)"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("S10: BUN_INSTALLED_BUN_SH wiring")
+    printf "  %s S10: BUN_INSTALLED_BUN_SH wiring (init=%d, set=%d)\n" "$(red FAIL)" "$init_ok" "$set_ok"
+  fi
+}
+
 # ---- Main ----
 echo ""
 bold "Install script test suite"
@@ -309,6 +346,8 @@ scenario_s5
 scenario_s6
 scenario_s7
 scenario_s8
+scenario_s9
+scenario_s10
 
 echo ""
 if [ "$FAIL" -eq 0 ]; then

--- a/bench/install.test.sh
+++ b/bench/install.test.sh
@@ -335,6 +335,23 @@ scenario_s10() {
   fi
 }
 
+scenario_s11() {
+  bold "S11: HOME default is exported so child installers inherit it (P2 review fix)"
+  local body; body="$(cat "$INSTALL_SH")"
+  local matched=0
+  case "$body" in
+    *'export HOME="${HOME:-/tmp}"'*|*'export HOME="${HOME:-'*) matched=1 ;;
+  esac
+  if [ "$matched" -eq 1 ]; then
+    PASS=$((PASS + 1))
+    printf "  %s HOME is exported (so curl | bash inherits the /tmp fallback)\n" "$(green PASS)"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("S11: HOME default is exported")
+    printf "  %s S11: HOME default is exported\n" "$(red FAIL)"
+  fi
+}
+
 # ---- Main ----
 echo ""
 bold "Install script test suite"
@@ -351,6 +368,7 @@ scenario_s7
 scenario_s8
 scenario_s9
 scenario_s10
+scenario_s11
 
 echo ""
 if [ "$FAIL" -eq 0 ]; then

--- a/bench/install.test.sh
+++ b/bench/install.test.sh
@@ -178,30 +178,33 @@ EOF
 scenario_s4() {
   bold "S4: install.sh runs bun --version and prism --version at the end"
   local body; body="$(cat "$INSTALL_SH")"
-  # The end-of-install verification must invoke both binaries explicitly.
-  # Allow any path, any quoting, but the literals must be present.
+  local bun_ok=0
   case "$body" in
-    *"bun --version"*)
-      PASS=$((PASS + 1))
-      printf "  %s calls 'bun --version' at end of install\n" "$(green PASS)"
-      ;;
-    *)
-      FAIL=$((FAIL + 1))
-      FAILED_NAMES+=("S4: bun --version check at end")
-      printf "  %s S4: bun --version check at end\n" "$(red FAIL)"
-      ;;
+    *'VERIFY_FAILED=0'*'if ! bun --version'*) bun_ok=1 ;;
+  esac
+  if [ "$bun_ok" -eq 1 ]; then
+    PASS=$((PASS + 1))
+    printf "  %s calls 'bun --version' inside verification block\n" "$(green PASS)"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("S4: bun --version in verification block")
+    printf "  %s S4: bun --version in verification block\n" "$(red FAIL)"
+  fi
+  local prism_ok=0
+  case "$body" in
+    *'VERIFY_FAILED=0'*'"$WRAPPER" --version'*) prism_ok=1 ;;
   esac
   case "$body" in
-    *"--version"*"prism"*"--version"*|*"prism --version"*)
-      PASS=$((PASS + 1))
-      printf "  %s calls 'prism --version' at end of install\n" "$(green PASS)"
-      ;;
-    *)
-      FAIL=$((FAIL + 1))
-      FAILED_NAMES+=("S4: prism --version check at end")
-      printf "  %s S4: prism --version check at end\n" "$(red FAIL)"
-      ;;
+    *'VERIFY_FAILED=0'*'$WRAPPER --version'*) prism_ok=1 ;;
   esac
+  if [ "$prism_ok" -eq 1 ]; then
+    PASS=$((PASS + 1))
+    printf "  %s calls 'prism --version' inside verification block\n" "$(green PASS)"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("S4: prism --version in verification block")
+    printf "  %s S4: prism --version in verification block\n" "$(red FAIL)"
+  fi
 }
 
 # ---- S5: PATH reminder is concrete ----

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,10 @@ set -euo pipefail
 MIN_BUN_VERSION="${PRISM_MIN_BUN_VERSION:-1.4.0}"
 
 REPO="${PRISM_REPO:-irfndi/prism-liquidity-agent}"
-HOME="${HOME:-/tmp}"
+# `export HOME` is required so the child bash spawned by the
+# `curl ... | bash` bun installer below inherits the /tmp fallback
+# when the parent shell started with HOME unset.
+export HOME="${HOME:-/tmp}"
 SHELL_NAME="${SHELL##*/}"
 SHELL_NAME="${SHELL_NAME:-sh}"
 INSTALL_DIR="${PRISM_INSTALL_DIR:-$HOME/.prism}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,45 +5,119 @@
 #   PRISM_TARBALL_URL=<url> curl -fsSL .../install.sh | bash
 set -euo pipefail
 
+# Minimum Bun version required by bun.lock v2.
+MIN_BUN_VERSION="${PRISM_MIN_BUN_VERSION:-1.4.0}"
+
 REPO="${PRISM_REPO:-irfndi/prism-liquidity-agent}"
 INSTALL_DIR="${PRISM_INSTALL_DIR:-$HOME/.prism}"
 BIN_DIR="${PRISM_BIN_DIR:-$HOME/.local/bin}"
 TARBALL_URL="${PRISM_TARBALL_URL:-}"
 
-# Auto-detect latest release tarball from GitHub if not explicitly provided
+# Defensive env reads: every ${PRISM_*} / user-supplied var must use
+# ${VAR:-} so `set -u` does not abort the one-liner on a clean shell
+# (issue #1 — previously crashed on unset PRISM_SKIP_AUTO_TARBALL).
+PRISM_SKIP_AUTO_TARBALL="${PRISM_SKIP_AUTO_TARBALL:-}"
+STASH_COUNT=""
+IS_OPTED_OUT=0
+case "$(printf '%s' "${PRISM_FEEDBACK_OPT_OUT:-}" | tr '[:upper:]' '[:lower:]')" in
+  1|true|yes|on) IS_OPTED_OUT=1 ;;
+esac
+
+log_step()  { printf "→ %s\n" "$*"; }
+log_warn()  { printf "⚠ %s\n" "$*"; }
+log_error() { printf "✘ %s\n" "$*" >&2; }
+log_done()  { printf "✓ %s\n" "$*"; }
+
+# Print a version string in a form that can be compared with -ge / sort -V.
+# Strips any pre-release suffix (e.g. "1.4.0-rc.1" -> "1.4.0") and pads to
+# three numeric components.
+normalize_version() {
+  printf '%s' "$1" \
+    | sed -E 's/^v//; s/-[A-Za-z0-9.+].*$//' \
+    | awk -F. '{ printf("%d.%d.%d\n", $1+0, ($2 ? $2 : 0)+0, ($3 ? $3 : 0)+0) }'
+}
+
+version_gte() {
+  # version_gte <installed> <minimum>; returns 0 if installed >= minimum.
+  local installed min
+  installed="$(normalize_version "$1")"
+  min="$(normalize_version "$2")"
+  [ "$(printf '%s\n%s\n' "$installed" "$min" | sort -V | head -n1)" = "$min" ]
+}
+
+# ensure_bun: install Bun if missing, verify version, expose to subshells.
+# Returns 0 on success, non-zero on failure. On any failure, prints an
+# actionable error message — never silently aborts.
+ensure_bun() {
+  if command -v bun >/dev/null 2>&1; then
+    BUN_BIN="$(command -v bun)"
+  else
+    log_step "Bun not found; installing to \$HOME/.bun"
+    if ! curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1; then
+      log_error "Failed to install Bun from bun.sh. Install it manually:"
+      log_error "  curl -fsSL https://bun.sh/install | bash"
+      return 1
+    fi
+    # The official installer writes to $HOME/.bun/bin. Refresh PATH/BUN_INSTALL
+    # in the current shell so subsequent commands in this script can find
+    # `bun` (issue #2 — exported PATH must propagate to subshells below).
+    export BUN_INSTALL="$HOME/.bun"
+    export PATH="$BUN_INSTALL/bin:$PATH"
+    if ! command -v bun >/dev/null 2>&1; then
+      log_error "Bun installer completed but 'bun' is still not on PATH."
+      log_error "Check that \$HOME/.bun/bin is writable and try:"
+      log_error "  export BUN_INSTALL=\"\$HOME/.bun\""
+      log_error "  export PATH=\"\$BUN_INSTALL/bin:\$PATH\""
+      return 1
+    fi
+    BUN_BIN="$(command -v bun)"
+  fi
+
+  local current
+  current="$("$BUN_BIN" --version 2>/dev/null || echo "unknown")"
+  if ! version_gte "$current" "$MIN_BUN_VERSION"; then
+    log_error "Bun $current is installed but >= $MIN_BUN_VERSION is required."
+    log_error "The bun.lock file uses lockfileVersion: 2, which older Bun"
+    log_error "versions cannot parse. Upgrade with:"
+    log_error "  curl -fsSL https://bun.sh/install | bash"
+    return 1
+  fi
+  log_step "Bun $current (>= $MIN_BUN_VERSION) at $BUN_BIN"
+  return 0
+}
+
+# Auto-detect latest release tarball from GitHub if not explicitly provided.
+# Reads PRISM_SKIP_AUTO_TARBALL defensively under set -u.
 if [ -z "$TARBALL_URL" ] && [ -z "$PRISM_SKIP_AUTO_TARBALL" ]; then
-  echo "→ Detecting latest release..."
-  LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null | grep '"tag_name":' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
-  if [ -n "$LATEST_TAG" ]; then
+  log_step "Detecting latest release..."
+  LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null | grep '"tag_name":' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' || true)
+  if [ -n "${LATEST_TAG:-}" ]; then
     TARBALL_URL="https://github.com/$REPO/releases/download/$LATEST_TAG/prism-$LATEST_TAG.tar.gz"
-    echo "→ Latest release: $LATEST_TAG"
+    log_step "Latest release: $LATEST_TAG"
   fi
 fi
 
-echo "→ Installing prism to $INSTALL_DIR"
+log_step "Installing prism to $INSTALL_DIR"
 mkdir -p "$INSTALL_DIR" "$BIN_DIR"
 
-# Detect or install Bun
-BUN_INSTALLED=0
-if ! command -v bun >/dev/null 2>&1; then
-  echo "→ Bun not found; installing to $HOME/.bun"
-  curl -fsSL https://bun.sh/install | bash
-  export PATH="$HOME/.bun/bin:$PATH"
-  BUN_INSTALLED=1
+# Detect or install Bun (issue #2 + #3 — version check is now mandatory).
+if ! ensure_bun; then
+  log_error "Bun is required to install prism. Aborting."
+  exit 1
 fi
 
 if [ -n "$TARBALL_URL" ]; then
-  echo "→ Downloading tarball: $TARBALL_URL"
+  log_step "Downloading tarball: $TARBALL_URL"
   TMP_TARBALL="$(mktemp -t prism-install-XXXXXX.tar.gz)"
   if command -v curl >/dev/null 2>&1; then
     curl -fsSL "$TARBALL_URL" -o "$TMP_TARBALL"
   elif command -v wget >/dev/null 2>&1; then
     wget -q "$TARBALL_URL" -O "$TMP_TARBALL"
   else
-    echo "✘ Neither curl nor wget found; install one and retry" >&2
+    log_error "Neither curl nor wget found; install one and retry"
     exit 1
   fi
-  echo "→ Extracting to $INSTALL_DIR"
+  log_step "Extracting to $INSTALL_DIR"
   rm -rf "$INSTALL_DIR"
   mkdir -p "$INSTALL_DIR"
   tar -xzf "$TMP_TARBALL" -C "$INSTALL_DIR"
@@ -51,7 +125,7 @@ if [ -n "$TARBALL_URL" ]; then
   # Marker so 'prism update' / 'prism --version' can detect a non-git install.
   touch "$INSTALL_DIR/.tarball-install"
 elif [ -d "$INSTALL_DIR/.git" ]; then
-  echo "→ Updating existing install"
+  log_step "Updating existing install"
   # Resolve the default branch once; the symbolic ref can shift between
   # invocations and we want a single consistent value.
   DEFAULT_BRANCH=$(git -C "$INSTALL_DIR" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|origin/||' || echo main)
@@ -60,44 +134,45 @@ elif [ -d "$INSTALL_DIR/.git" ]; then
   if (cd "$INSTALL_DIR" && git pull --ff-only 2>/dev/null); then
     :
   else
-    echo "⚠ Local changes blocked fast-forward; stashing and retrying"
+    log_warn "Local changes blocked fast-forward; stashing and retrying"
     if (cd "$INSTALL_DIR" && git stash && git pull --ff-only && git stash pop); then
       :
     else
       # Count stash entries before the reset so we can warn if any were
       # orphaned by a partial stash/pull/pop chain.
       STASH_COUNT=$(cd "$INSTALL_DIR" && git stash list 2>/dev/null | wc -l | tr -d ' ')
-      echo "→ Update failed; resetting to origin/${DEFAULT_BRANCH}"
+      log_step "Update failed; resetting to origin/${DEFAULT_BRANCH}"
       (cd "$INSTALL_DIR" && git fetch origin && git reset --hard "origin/${DEFAULT_BRANCH}")
       if [ "${STASH_COUNT:-0}" -gt 0 ]; then
-        echo "→ ${STASH_COUNT} stash entry/entries preserved (use 'git stash list' to inspect)"
+        log_step "${STASH_COUNT} stash entry/entries preserved (use 'git stash list' to inspect)"
       fi
     fi
   fi
 elif [ -d "$INSTALL_DIR" ]; then
   # Exists but not a git repo (e.g. partial previous install). Nuke and reclone.
-  echo "→ $INSTALL_DIR exists but is not a git repo; re-cloning"
+  log_step "$INSTALL_DIR exists but is not a git repo; re-cloning"
   rm -rf "$INSTALL_DIR"
   git clone "https://github.com/$REPO.git" "$INSTALL_DIR"
 else
-  echo "→ Cloning $REPO"
+  log_step "Cloning $REPO"
   git clone "https://github.com/$REPO.git" "$INSTALL_DIR"
 fi
 
 # No --frozen-lockfile: an older Bun may fail to parse the current bun.lock
-# and abort the install before dependencies land.
-echo "→ Installing dependencies"
+# and abort the install before dependencies land. ensure_bun() above already
+# rejected Bun < $MIN_BUN_VERSION, so this is safe on supported Bun.
+log_step "Installing dependencies"
 (cd "$INSTALL_DIR" && bun install)
 
-echo "→ Running postinstall setup"
+log_step "Running postinstall setup"
 (cd "$INSTALL_DIR" && bun run setup:env || true)
 
 # Write a wrapper script (not a symlink) so `prism` always runs from
 # $INSTALL_DIR. Symlinking cli/index.ts directly would let prism setup
 # write .env to the caller's cwd (it uses path.resolve('.env')) and let
 # prism dev run `bun run dev` in the wrong directory.
+WRAPPER="$BIN_DIR/prism"
 if [ -w "$BIN_DIR" ]; then
-  WRAPPER="$BIN_DIR/prism"
   # Use a plain `cd` rather than `env -C` for portability (env -C is a
   # non-standard extension, not present on every POSIX env).
   cat > "$WRAPPER" <<EOF
@@ -107,13 +182,26 @@ cd "$INSTALL_DIR" || exit 1
 exec bun "$INSTALL_DIR/cli/index.ts" "\$@"
 EOF
   chmod +x "$WRAPPER"
-  echo "→ Wrote wrapper $BIN_DIR/prism (always runs in $INSTALL_DIR)"
+  log_step "Wrote wrapper $BIN_DIR/prism (always runs in $INSTALL_DIR)"
 else
-  echo "→ $BIN_DIR is not writable; add $INSTALL_DIR/cli to your PATH manually"
+  log_warn "$BIN_DIR is not writable; add $INSTALL_DIR/cli to your PATH manually"
 fi
 
+# Issue #4: PATH reminder. Detect whether the wrapper directory is on
+# PATH in the current shell. If not, print a concrete one-liner the
+# user can copy-paste. We test the literal BIN_DIR path so the hint
+# matches the actual install.
+PATH_HAS_BIN_DIR=0
+IFS=':' read -r -a _path_entries <<<"$PATH"
+for _entry in "${_path_entries[@]}"; do
+  if [ "$_entry" = "$BIN_DIR" ]; then
+    PATH_HAS_BIN_DIR=1
+    break
+  fi
+done
+
 echo ""
-echo "✓ Install complete."
+log_done "Install complete."
 if [ -n "$TARBALL_URL" ]; then
   echo "  - Source:   $INSTALL_DIR (tarball install — upgrade via 'prism update')"
 else
@@ -122,7 +210,7 @@ fi
 echo "  - Run:      $BIN_DIR/prism --version"
 echo ""
 echo "Next steps:"
-if [ "$BUN_INSTALLED" -eq 1 ]; then
+if [ "${BUN_INSTALLED_BUN_SH:-0}" -eq 1 ]; then
   echo "  1. Add to PATH (new shell):  export PATH=\"\$HOME/.bun/bin:$BIN_DIR:\$PATH\""
 else
   echo "  1. Add to PATH if needed:    export PATH=\"$BIN_DIR:\$PATH\""
@@ -131,6 +219,40 @@ echo "  2. Register an account:      prism register"
 echo "  3. Configure:                prism setup --non-interactive --helius-key=your-helius-key"
 echo "  4. Start trading:            prism dev"
 
+if [ "$PATH_HAS_BIN_DIR" -eq 0 ]; then
+  echo ""
+  log_warn "$BIN_DIR is not on your current PATH."
+  log_warn "Run this in a new shell, or persist it in your shell rc:"
+  echo "    echo 'export PATH=\"\$PATH:$BIN_DIR\"' >> \"\$HOME/.${SHELL##*/}rc\""
+  echo "    export PATH=\"\$PATH:$BIN_DIR\""
+fi
+
+# Issue #5: end-of-install verification. Run the two version checks the
+# user actually cares about and surface a friendly error on non-zero.
+echo ""
+log_step "Verifying installation..."
+VERIFY_FAILED=0
+if ! bun --version; then
+  log_error "bun --version failed. PATH may not be set for new shells."
+  log_error "Try:  export PATH=\"\$HOME/.bun/bin:\$PATH\""
+  VERIFY_FAILED=1
+fi
+if [ -x "$WRAPPER" ]; then
+  if ! "$WRAPPER" --version; then
+    log_error "$WRAPPER --version failed. The wrapper exists but prism did not respond."
+    log_error "Try invoking directly:  bun $INSTALL_DIR/cli/index.ts --version"
+    VERIFY_FAILED=1
+  fi
+else
+  log_warn "Wrapper $WRAPPER is not executable; skipping 'prism --version' check."
+fi
+if [ "$VERIFY_FAILED" -ne 0 ]; then
+  log_error "Install completed but verification failed. See messages above."
+  exit 1
+fi
+log_done "Verification passed."
+
+# Anonymous install telemetry (opt-out via PRISM_FEEDBACK_OPT_OUT).
 INSTALL_ID_FILE="$HOME/.config/prism/install-id"
 mkdir -p "$(dirname "$INSTALL_ID_FILE")"
 if [ ! -s "$INSTALL_ID_FILE" ]; then
@@ -147,13 +269,6 @@ if [ ! -s "$INSTALL_ID_FILE" ]; then
   fi
 fi
 INSTALL_ID="$(cat "$INSTALL_ID_FILE" 2>/dev/null || echo "")"
-# Parse PRISM_FEEDBACK_OPT_OUT as a real boolean (case-insensitive
-# 1/true/yes/on). Empty string or "false" both keep telemetry on, which
-# matches what users expect from a .env default of PRISM_FEEDBACK_OPT_OUT=false.
-IS_OPTED_OUT=0
-case "$(printf '%s' "${PRISM_FEEDBACK_OPT_OUT:-}" | tr '[:upper:]' '[:lower:]')" in
-  1|true|yes|on) IS_OPTED_OUT=1 ;;
-esac
 if [ -n "$INSTALL_ID" ] && [ "$IS_OPTED_OUT" -eq 0 ]; then
   PRISM_VERSION="$(bun -e "console.log(require('$INSTALL_DIR/package.json').version)" 2>/dev/null || echo "")"
   PRISM_PLATFORM="$(uname -s | tr A-Z a-z)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,9 @@ set -euo pipefail
 MIN_BUN_VERSION="${PRISM_MIN_BUN_VERSION:-1.4.0}"
 
 REPO="${PRISM_REPO:-irfndi/prism-liquidity-agent}"
+HOME="${HOME:-/tmp}"
+SHELL_NAME="${SHELL##*/}"
+SHELL_NAME="${SHELL_NAME:-sh}"
 INSTALL_DIR="${PRISM_INSTALL_DIR:-$HOME/.prism}"
 BIN_DIR="${PRISM_BIN_DIR:-$HOME/.local/bin}"
 TARBALL_URL="${PRISM_TARBALL_URL:-}"
@@ -192,7 +195,7 @@ fi
 # user can copy-paste. We test the literal BIN_DIR path so the hint
 # matches the actual install.
 PATH_HAS_BIN_DIR=0
-IFS=':' read -r -a _path_entries <<<"$PATH"
+IFS=':' read -r -a _path_entries <<<"${PATH:-}"
 for _entry in "${_path_entries[@]}"; do
   if [ "$_entry" = "$BIN_DIR" ]; then
     PATH_HAS_BIN_DIR=1
@@ -223,7 +226,7 @@ if [ "$PATH_HAS_BIN_DIR" -eq 0 ]; then
   echo ""
   log_warn "$BIN_DIR is not on your current PATH."
   log_warn "Run this in a new shell, or persist it in your shell rc:"
-  echo "    echo 'export PATH=\"\$PATH:$BIN_DIR\"' >> \"\$HOME/.${SHELL##*/}rc\""
+  echo "    echo 'export PATH=\"\$PATH:$BIN_DIR\"' >> \"\$HOME/.$SHELL_NAMERC\""
   echo "    export PATH=\"\$PATH:$BIN_DIR\""
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,6 +15,7 @@ SHELL_NAME="${SHELL_NAME:-sh}"
 INSTALL_DIR="${PRISM_INSTALL_DIR:-$HOME/.prism}"
 BIN_DIR="${PRISM_BIN_DIR:-$HOME/.local/bin}"
 TARBALL_URL="${PRISM_TARBALL_URL:-}"
+BUN_INSTALLED_BUN_SH=0
 
 # Defensive env reads: every ${PRISM_*} / user-supplied var must use
 # ${VAR:-} so `set -u` does not abort the one-liner on a clean shell
@@ -74,6 +75,7 @@ ensure_bun() {
       return 1
     fi
     BUN_BIN="$(command -v bun)"
+    BUN_INSTALLED_BUN_SH=1
   fi
 
   local current
@@ -226,7 +228,7 @@ if [ "$PATH_HAS_BIN_DIR" -eq 0 ]; then
   echo ""
   log_warn "$BIN_DIR is not on your current PATH."
   log_warn "Run this in a new shell, or persist it in your shell rc:"
-  echo "    echo 'export PATH=\"\$PATH:$BIN_DIR\"' >> \"\$HOME/.$SHELL_NAMERC\""
+  echo "    echo 'export PATH=\"\$PATH:$BIN_DIR\"' >> \"\$HOME/.${SHELL_NAME}rc\""
   echo "    export PATH=\"\$PATH:$BIN_DIR\""
 fi
 


### PR DESCRIPTION
## Summary

Hardens \`scripts/install.sh\` against the install-time issues reported by
agent harnesses. Each fix is a separate scenario covered by
\`bench/install.test.sh\` (**14 assertions, all PASS**).

## Issues addressed

| Round | # | Issue | Fix |
|---|---|---|---|
| 1 | 1 | \`PRISM_SKIP_AUTO_TARBALL: unbound variable\` aborts the one-liner under \`set -u\` on a clean shell | Defensive \`PRISM_SKIP_AUTO_TARBALL="\${PRISM_SKIP_AUTO_TARBALL:-}"\` at the top, plus the same treatment for every other user-supplied \`PRISM_*\` var |
| 1 | 2 | Bun install path was inline and silently failed if the curl installer wrote to a non-default path | Extracted \`ensure_bun()\` function: calls the official bun.sh installer, verifies \`command -v bun\` succeeds, sets \`BUN_INSTALL\` + \`PATH\` for subshells, prints installed version |
| 1 | 3 | \`bun.lock\` v2 not parseable by Bun < 1.4.0 but the script proceeded anyway | \`MIN_BUN_VERSION="1.4.0"\` check inside \`ensure_bun()\`. Rejects older Bun with clear upgrade message. Override via \`PRISM_MIN_BUN_VERSION\` env |
| 1 | 4 | PATH reminder was a static hint, not a runtime check | Detects whether \`$BIN_DIR\` is on the current \`PATH\` and emits a concrete \`export PATH=...\` one-liner plus the matching \`echo '...' >> ~/.zshrc\` persistence line |
| 1 | 5 | One-liner printed "Install complete" but never verified bun or prism responded | End-of-install block runs \`bun --version\` and \`$BIN_DIR/prism --version\` and exits non-zero with a friendly remediation message on failure |
| 2 | 6 | \`$HOME\` and \`$PATH\` still read unguarded under \`set -u\` after round 1 | Added \`HOME=\${HOME:-/tmp}\`, \${PATH:-} defensive read at the IFS scan, and pre-computed \`SHELL_NAME=\${SHELL##*/}\` so the PATH reminder heredoc never reads \`$SHELL\` directly |
| 3 | 7 | \`$SHELL_NAMERC\` was a typo in the PATH reminder heredoc that crashed \`set -u\` in the very block meant to fix the user's PATH problem | Renamed to \`\${SHELL_NAME}rc\` (the variable that was already defined) |
| 3 | 8 | \`BUN_INSTALLED_BUN_SH\` was never set to 1, so the "Next steps" PATH hint didn't include \`$HOME/.bun/bin\` after a fresh bun install | Initialized \`BUN_INSTALLED_BUN_SH=0\` at the top and set \`=1\` inside \`ensure_bun()\` after a successful fresh install |
| **5** | **9** | **\`HOME=\${HOME:-/tmp}\` was a non-exported shell variable. The child bash spawned by the bun.sh \`curl | bash\` pipeline saw HOME empty (env -i agent harness) and the installer aborted or wrote to the wrong location** | **Added \`export\` keyword: \`export HOME="\${HOME:-/tmp}"\`** |

## Testing

\`\`\`bash
bash bench/install.test.sh
# All 14 assertions passed.
\`\`\`

Test-first workflow applied across 5 rounds (RED → GREEN → REGRESS):

- **RED (round 1)**: 5 of 9 assertions failed. Confirmed the unbound-variable
  bug on line 14 by running \`env -i HOME=/tmp PATH=/usr/bin:/bin bash
  scripts/install.sh\` — exit code 1.
- **GREEN (round 1)**: all 9 assertions pass.
- **RED (round 2)**: S7 catches a real \`HOME: unbound variable\` crash at
  line 12 — confirmed by reverting the defensive read.
- **GREEN (round 2)**: 11 assertions pass.
- **RED (round 3)**: Oracle identified \`SHELL_NAMERC\` typo + missing
  \`BUN_INSTALLED_BUN_SH=1\` — neither was caught by the prior tests.
- **GREEN (round 3)**: 13 assertions pass.
- **RED (round 4)**: Oracle round 4 noted S4 \`prism --version\` assertion
  could match help text. Tightened S4 to require \`VERIFY_FAILED=0\` +
  literal \`$WRAPPER --version\`.
- **GREEN (round 4)**: 13 assertions pass (S4 strengthened).
- **RED (round 5)**: P2 review found HOME not exported. Confirmed by
  spawning a child bash from a stripped env and observing HOME empty.
- **GREEN (round 5)**: 14 assertions pass.

\`\`\`
$ bun run test
Test Files  26 passed (26)
     Tests  252 passed (252)
$ bun run lint
Found 0 warnings and 0 errors.
\`\`\`

End-to-end manual QA in 5 scenarios:

1. **\`env -i\` (all env unset)**: script no longer aborts; reaches bun check.
2. **Empty env (HOME=/tmp, PATH=/usr/bin:/bin)**: bun 1.3.14 auto-installed
   from bun.sh → correctly rejected with clear upgrade message.
3. **Bun 1.4.0 with file:// tarball**: full install (385 packages, postinstall,
   wrapper) succeeded; \`bun --version\` → 1.4.0; \`prism --version\` → 0.0.17.
4. **Wrapper from foreign CWD**: \`/tmp/.../cwd-test/\$BIN_DIR/prism --version\` → 0.0.17.
5. **PATH reminder block**: both branches exercise end-to-end:
   - BUN_INSTALLED_BUN_SH=0 → \`export PATH="<BIN_DIR>:$PATH"\`
   - BUN_INSTALLED_BUN_SH=1 → \`export PATH="$HOME/.bun/bin:<BIN_DIR>:$PATH"\`
6. **HOME unset (round 5 fix)**: env -i with real bun installer → install
   completes; HOME defaulted to /tmp and exported to child processes.

## Files changed

- \`scripts/install.sh\` — 168 insertions, 39 deletions (across 5 commits)
- \`bench/install.test.sh\` — new, 14 assertions across 11 scenarios

## Notes

- \`MIN_BUN_VERSION\` is overridable per call (default 1.4.0).
- The user's literal fix for #1 was \`PRISM_SKIP_AUTO_TARBALL=\${PRISM_SKIP_AUTO_TARBALL:-false}\`.
  I used \`:-\` (empty default) because \`:-false\` would set the default
  to the literal string "false", and \`[ -z "false" ]\` is FALSE — which
  inverts the auto-detect behavior. The empty default preserves the
  original "auto-detect unless explicitly skipped" semantics.
- \`bash -n\` passes on both files. shellcheck isn't installed in this
  environment, so static lint was limited to bash syntax.
- \`sort -V\` is available on macOS via the Apple-patched BSD sort
  (2.3-Apple); the version comparison works correctly in QA on this
  machine. On Linux, GNU sort has had \`-V\` since coreutils 7.0.
- S8 is a static check rather than a dynamic \`env -i\` run because macOS
  bash populates a default PATH (\`/usr/gnu/bin:/usr/local/bin:/bin:/usr/bin:.\`)
  even with \`env -i\`, so a dynamic check is unreliable on this platform.