### PR TITLE
fix(adapter): surface Meteora API failures instead of silently returning []

### DIFF
--- a/bench/adapter-discover.test.ts
+++ b/bench/adapter-discover.test.ts
@@ -273,45 +273,76 @@ describe("AdapterService.discoverPools", () => {
     }
   });
 
-  it("surfaces an explicit failure when a pool object is missing required fields", async () => {
+  it("drops pool objects with invalid shape and returns the valid ones (with a logged warning)", async () => {
     const restore = mockFetch(
       (async () =>
         new Response(
-          JSON.stringify([
-            {
-              address: "Pool111111111111111111111111111111111111111",
-            },
-          ]),
+          JSON.stringify({
+            total: 3,
+            pages: 1,
+            current_page: 1,
+            page_size: 3,
+            data: [
+              {
+                address: "PoolValid11111111111111111111111111111111111",
+                token_x: { address: "So11111111111111111111111111111111111111112" },
+                token_y: { address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+                pool_config: { bin_step: 10 },
+                tvl: 200_000,
+                apr: 60,
+                volume: { "24h": 50_000 },
+                fees: { "24h": 500 },
+              },
+              {
+                address: "PoolMissingFields111111111111111111111111111111",
+              },
+              {
+                address: "PoolWrongTypes11111111111111111111111111111111",
+                token_x: { address: "So11111111111111111111111111111111111111112" },
+                token_y: { address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+                pool_config: { bin_step: 10 },
+                tvl: "not a number",
+                apr: 60,
+                volume: { "24h": 50_000 },
+                fees: { "24h": 500 },
+              },
+            ],
+          }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         )) as unknown as typeof fetch,
     );
     try {
       const layer = buildAdapterLayer();
-      await expect(runDiscover(layer)).rejects.toBeDefined();
+      const result = await runDiscover(layer);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.address).toBe("PoolValid11111111111111111111111111111111111");
     } finally {
       restore();
     }
   });
 
-  it("surfaces an explicit failure when a pool object has wrong field types", async () => {
+  it("returns empty array when the envelope itself is valid but ALL pool objects have invalid shape", async () => {
     const restore = mockFetch(
       (async () =>
         new Response(
-          JSON.stringify([
-            {
-              address: "Pool111111111111111111111111111111111111111",
-              base_mint: "So11111111111111111111111111111111111111112",
-              quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-              tvl: "not a number",
-              bin_step: 10,
-            },
-          ]),
-          { status: 200, headers: { "Content-Type": "application/json" } },
+          JSON.stringify({
+            total: 2,
+            pages: 1,
+            current_page: 1,
+            page_size: 2,
+            data: [
+              { address: "Bad1" },
+              { address: "Bad2" },
+            ],
+          }),
+          { status: 200 },
         )) as unknown as typeof fetch,
     );
     try {
       const layer = buildAdapterLayer();
-      await expect(runDiscover(layer)).rejects.toBeDefined();
+      const result = await runDiscover(layer);
+      expect(result).toEqual([]);
     } finally {
       restore();
     }

--- a/bench/adapter-discover.test.ts
+++ b/bench/adapter-discover.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Effect, Layer } from "effect";
+import { AdapterService } from "../engine/services.js";
+import { AdapterLive } from "../engine/adapter-service.js";
+import { ConfigService, type AppConfig } from "../engine/config-service.js";
+import { mockFetch } from "./helpers.js";
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  const base: AppConfig = {
+    walletPrivateKey: "",
+    heliusApiKey: "",
+    solanaRpcUrl: "https://api.mainnet.helius-rpc.com",
+    paperTrading: true,
+    scanIntervalMs: 600_000,
+    minPoolTvlUsd: 50_000,
+    minFeeIlRatio: 1.2,
+    tvlDropExitPct: 0.3,
+    volumeAuthThreshold: 0.7,
+    maxConcurrentPositions: 5,
+    minRebalanceIntervalMs: 86_400_000,
+    minRebalanceNetBenefitUsd: 10,
+    confidenceThreshold: 0.65,
+    paperPortfolioUsd: 10_000,
+    minBinUtilization: 0.3,
+    maxRebalanceRangeBins: 50,
+    watchlistPools: [],
+    stopLossPct: 0.15,
+    trailingStopPct: 0.1,
+    oorGracePeriodCycles: 3,
+    feeClaimIntervalMs: 86_400_000,
+    enablePoolDiscovery: true,
+    discoveryMinTvlUsd: 100_000,
+    discoveryMinFeeRatio: 1.5,
+    deployerBlacklistPath: "",
+    tokenBlacklistPath: "",
+    sqliteDbPath: ":memory:",
+    enableSnapshotCapture: false,
+    autoUpdate: false,
+    updateCheckIntervalMs: 216_000_000,
+    updateChannel: "stable",
+    updateGithubRepo: "irfndi/prism-liquidity-agent",
+    updateAllowDirty: false,
+    forceUpdateEnabled: false,
+    forceUpdateAfterDays: 14,
+    updateR2PublicUrl: "https://r2.prism-agent.com",
+    githubToken: "",
+    githubRepo: "irfndi/prism-liquidity-agent",
+    feedbackOptOut: false,
+    paperModeExitLive: false,
+  };
+  return { ...base, ...overrides };
+}
+
+function buildAdapterLayer(overrides: Partial<AppConfig> = {}): Layer.Layer<AdapterService, never, never> {
+  const configLayer = Layer.succeed(ConfigService, makeConfig(overrides));
+  return Layer.provide(AdapterLive, configLayer) as Layer.Layer<AdapterService, never, never>;
+}
+
+async function runDiscover(layer: Layer.Layer<AdapterService, never, never>) {
+  const program = Effect.gen(function* () {
+    const adapter = yield* AdapterService;
+    return yield* adapter.discoverPools();
+  });
+  return Effect.runPromise(Effect.provide(program, layer));
+}
+
+async function runDiscoverFlip(layer: Layer.Layer<AdapterService, never, never>): Promise<unknown> {
+  const program = Effect.gen(function* () {
+    const adapter = yield* AdapterService;
+    return yield* adapter.discoverPools();
+  });
+  return Effect.runPromise(Effect.flip(Effect.provide(program, layer)));
+}
+
+describe("AdapterService.discoverPools", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns parsed pools when the API responds 200 with valid JSON", async () => {
+    const restore = mockFetch(
+      (async () =>
+        new Response(
+          JSON.stringify([
+            {
+              address: "Pool111111111111111111111111111111111111111",
+              bin_step: 10,
+              base_mint: "So11111111111111111111111111111111111111112",
+              quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+              tvl: 200_000,
+              volume_24h: 50_000,
+              fees_24h: 500,
+              apr: 60,
+            },
+            {
+              address: "Pool222222222222222222222222222222222222222",
+              bin_step: 20,
+              base_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+              quote_mint: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+              tvl: 1_000_000,
+              volume_24h: 200_000,
+              fees_24h: 2_000,
+              apr: 120,
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer({ discoveryMinTvlUsd: 100_000 });
+      const result = await runDiscover(layer);
+      if (Array.isArray(result)) {
+        expect(result).toHaveLength(2);
+        expect(result[0]?.address).toBe("Pool111111111111111111111111111111111111111");
+      } else {
+        expect.fail(`Expected array result, got tagged failure: ${JSON.stringify(result)}`);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces an explicit failure when the API responds 404 (not silently empty)", async () => {
+    const restore = mockFetch((async () => new Response("not found", { status: 404 })) as unknown as typeof fetch);
+    try {
+      const layer = buildAdapterLayer();
+      await expect(runDiscover(layer)).rejects.toBeDefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces an explicit failure when the API responds 500 (not silently empty)", async () => {
+    const restore = mockFetch((async () => new Response("server error", { status: 500 })) as unknown as typeof fetch);
+    try {
+      const layer = buildAdapterLayer();
+      await expect(runDiscover(layer)).rejects.toBeDefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces an explicit failure when the response body is not valid JSON", async () => {
+    const restore = mockFetch(
+      (async () =>
+        new Response("not json at all", { status: 200, headers: { "Content-Type": "text/html" } })) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer();
+      await expect(runDiscover(layer)).rejects.toBeDefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces an explicit failure when the response body is JSON but not an array", async () => {
+    const restore = mockFetch(
+      (async () =>
+        new Response(JSON.stringify({ error: "rate limited" }), { status: 200 })) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer();
+      await expect(runDiscover(layer)).rejects.toBeDefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces an explicit failure when fetch throws a network error", async () => {
+    const restore = mockFetch(
+      (async () => {
+        throw new Error("ENOTFOUND dlmm-api.meteora.ag");
+      }) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer();
+      await expect(runDiscover(layer)).rejects.toBeDefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it("the error carries a typed _tag field DiscoverPoolsError so callers can branch on it", async () => {
+    const restore = mockFetch((async () => new Response("not found", { status: 404 })) as unknown as typeof fetch);
+    try {
+      const layer = buildAdapterLayer();
+      const err = (await runDiscoverFlip(layer)) as { _tag?: string; message?: string };
+      expect(err._tag).toBe("DiscoverPoolsError");
+      expect(typeof err.message).toBe("string");
+      expect((err.message ?? "").toLowerCase()).toContain("404");
+    } finally {
+      restore();
+    }
+  });
+});

--- a/bench/adapter-discover.test.ts
+++ b/bench/adapter-discover.test.ts
@@ -47,6 +47,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     githubRepo: "irfndi/prism-liquidity-agent",
     feedbackOptOut: false,
     paperModeExitLive: false,
+    meteoraPoolsUrl: "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
   };
   return { ...base, ...overrides };
 }
@@ -77,32 +78,40 @@ describe("AdapterService.discoverPools", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns parsed pools when the API responds 200 with valid JSON", async () => {
+  it("returns parsed pools when the API responds 200 with the official envelope shape", async () => {
     const restore = mockFetch(
       (async () =>
         new Response(
-          JSON.stringify([
-            {
-              address: "Pool111111111111111111111111111111111111111",
-              bin_step: 10,
-              base_mint: "So11111111111111111111111111111111111111112",
-              quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-              tvl: 200_000,
-              volume_24h: 50_000,
-              fees_24h: 500,
-              apr: 60,
-            },
-            {
-              address: "Pool222222222222222222222222222222222222222",
-              bin_step: 20,
-              base_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-              quote_mint: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-              tvl: 1_000_000,
-              volume_24h: 200_000,
-              fees_24h: 2_000,
-              apr: 120,
-            },
-          ]),
+          JSON.stringify({
+            total: 2,
+            pages: 1,
+            current_page: 1,
+            page_size: 2,
+            data: [
+              {
+                address: "Pool111111111111111111111111111111111111111",
+                name: "SOL-USDC",
+                token_x: { address: "So11111111111111111111111111111111111111112" },
+                token_y: { address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+                pool_config: { bin_step: 10 },
+                tvl: 200_000,
+                apr: 60,
+                volume: { "24h": 50_000 },
+                fees: { "24h": 500 },
+              },
+              {
+                address: "Pool222222222222222222222222222222222222222",
+                name: "USDC-USDT",
+                token_x: { address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+                token_y: { address: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB" },
+                pool_config: { bin_step: 20 },
+                tvl: 1_000_000,
+                apr: 120,
+                volume: { "24h": 200_000 },
+                fees: { "24h": 2_000 },
+              },
+            ],
+          }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         )) as unknown as typeof fetch,
     );
@@ -112,9 +121,36 @@ describe("AdapterService.discoverPools", () => {
       if (Array.isArray(result)) {
         expect(result).toHaveLength(2);
         expect(result[0]?.address).toBe("Pool111111111111111111111111111111111111111");
+        expect(result[0]?.binStep).toBe(10);
+        expect(result[0]?.tokenX).toBe("So11111111111111111111111111111111111111112");
+        expect(result[0]?.tokenY).toBe("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+        expect(result[0]?.volume24hUsd).toBe(50_000);
+        expect(result[0]?.fees24hUsd).toBe(500);
+        expect(result[0]?.tvlUsd).toBe(200_000);
+        expect(result[0]?.apr).toBe(60);
       } else {
         expect.fail(`Expected array result, got tagged failure: ${JSON.stringify(result)}`);
       }
+    } finally {
+      restore();
+    }
+  });
+
+  it("rejects a flat array response (the legacy /pair/all shape) as a non-envelope", async () => {
+    const restore = mockFetch(
+      (async () =>
+        new Response(
+          JSON.stringify([
+            { address: "Pool1", bin_step: 10, base_mint: "X", quote_mint: "Y", tvl: 1000, volume_24h: 1, fees_24h: 1, apr: 1 },
+          ]),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer();
+      const err = (await runDiscoverFlip(layer)) as { _tag?: string; message?: string };
+      expect(err._tag).toBe("DiscoverPoolsError");
+      expect(err.message?.toLowerCase()).toContain("envelope");
     } finally {
       restore();
     }
@@ -188,6 +224,94 @@ describe("AdapterService.discoverPools", () => {
       expect(err._tag).toBe("DiscoverPoolsError");
       expect(typeof err.message).toBe("string");
       expect((err.message ?? "").toLowerCase()).toContain("404");
+    } finally {
+      restore();
+    }
+  });
+
+  it("uses the URL from config.meteoraPoolsUrl (not a hardcoded process.env read)", async () => {
+    let requestedUrl = "";
+    const restore = mockFetch(
+      (async (input: unknown) => {
+        requestedUrl = String(input);
+        return new Response(
+          JSON.stringify({ total: 0, pages: 0, current_page: 1, page_size: 0, data: [] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer({
+        meteoraPoolsUrl: "https://my-mock-api.example.com/pools",
+      });
+      await runDiscover(layer);
+      expect(requestedUrl).toBe("https://my-mock-api.example.com/pools");
+    } finally {
+      restore();
+    }
+  });
+
+  it("falls back to the default URL when config.meteoraPoolsUrl is an empty string", async () => {
+    let requestedUrl = "";
+    const restore = mockFetch(
+      (async (input: unknown) => {
+        requestedUrl = String(input);
+        return new Response(
+          JSON.stringify({ total: 0, pages: 0, current_page: 1, page_size: 0, data: [] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer({ meteoraPoolsUrl: "" });
+      await runDiscover(layer);
+      expect(requestedUrl).toBe(
+        "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces an explicit failure when a pool object is missing required fields", async () => {
+    const restore = mockFetch(
+      (async () =>
+        new Response(
+          JSON.stringify([
+            {
+              address: "Pool111111111111111111111111111111111111111",
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer();
+      await expect(runDiscover(layer)).rejects.toBeDefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces an explicit failure when a pool object has wrong field types", async () => {
+    const restore = mockFetch(
+      (async () =>
+        new Response(
+          JSON.stringify([
+            {
+              address: "Pool111111111111111111111111111111111111111",
+              base_mint: "So11111111111111111111111111111111111111112",
+              quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+              tvl: "not a number",
+              bin_step: 10,
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer();
+      await expect(runDiscover(layer)).rejects.toBeDefined();
     } finally {
       restore();
     }

--- a/bench/adapter-discover.test.ts
+++ b/bench/adapter-discover.test.ts
@@ -3,6 +3,8 @@ import { Effect, Layer } from "effect";
 import { AdapterService } from "../engine/services.js";
 import { AdapterLive } from "../engine/adapter-service.js";
 import { ConfigService, type AppConfig } from "../engine/config-service.js";
+import { AuditLive } from "../engine/audit-service.js";
+import { DbLive } from "../engine/db-service.js";
 import { mockFetch } from "./helpers.js";
 
 function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
@@ -54,7 +56,11 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
 
 function buildAdapterLayer(overrides: Partial<AppConfig> = {}): Layer.Layer<AdapterService, never, never> {
   const configLayer = Layer.succeed(ConfigService, makeConfig(overrides));
-  return Layer.provide(AdapterLive, configLayer) as Layer.Layer<AdapterService, never, never>;
+  // AuditLive requires DbService — use Layer.provide (not merge) so the dep
+  // is wired transitively into the merged harness below.
+  const auditLayer = Layer.provide(AuditLive, DbLive(":memory:"));
+  const withDeps = Layer.provide(AdapterLive, Layer.merge(configLayer, auditLayer));
+  return withDeps as Layer.Layer<AdapterService, never, never>;
 }
 
 async function runDiscover(layer: Layer.Layer<AdapterService, never, never>) {
@@ -160,7 +166,9 @@ describe("AdapterService.discoverPools", () => {
     const restore = mockFetch((async () => new Response("not found", { status: 404 })) as unknown as typeof fetch);
     try {
       const layer = buildAdapterLayer();
-      await expect(runDiscover(layer)).rejects.toBeDefined();
+      const err = (await runDiscoverFlip(layer)) as { _tag?: string; message?: string };
+      expect(err._tag).toBe("DiscoverPoolsError");
+      expect(err.message?.toLowerCase()).toContain("404");
     } finally {
       restore();
     }
@@ -170,7 +178,9 @@ describe("AdapterService.discoverPools", () => {
     const restore = mockFetch((async () => new Response("server error", { status: 500 })) as unknown as typeof fetch);
     try {
       const layer = buildAdapterLayer();
-      await expect(runDiscover(layer)).rejects.toBeDefined();
+      const err = (await runDiscoverFlip(layer)) as { _tag?: string; message?: string };
+      expect(err._tag).toBe("DiscoverPoolsError");
+      expect(err.message?.toLowerCase()).toContain("500");
     } finally {
       restore();
     }
@@ -183,7 +193,9 @@ describe("AdapterService.discoverPools", () => {
     );
     try {
       const layer = buildAdapterLayer();
-      await expect(runDiscover(layer)).rejects.toBeDefined();
+      const err = (await runDiscoverFlip(layer)) as { _tag?: string; message?: string };
+      expect(err._tag).toBe("DiscoverPoolsError");
+      expect(err.message?.toLowerCase()).toContain("json");
     } finally {
       restore();
     }
@@ -196,7 +208,9 @@ describe("AdapterService.discoverPools", () => {
     );
     try {
       const layer = buildAdapterLayer();
-      await expect(runDiscover(layer)).rejects.toBeDefined();
+      const err = (await runDiscoverFlip(layer)) as { _tag?: string; message?: string };
+      expect(err._tag).toBe("DiscoverPoolsError");
+      expect(err.message?.toLowerCase()).toContain("envelope");
     } finally {
       restore();
     }
@@ -210,7 +224,9 @@ describe("AdapterService.discoverPools", () => {
     );
     try {
       const layer = buildAdapterLayer();
-      await expect(runDiscover(layer)).rejects.toBeDefined();
+      const err = (await runDiscoverFlip(layer)) as { _tag?: string; message?: string };
+      expect(err._tag).toBe("DiscoverPoolsError");
+      expect(err.message?.toLowerCase()).toContain("network error");
     } finally {
       restore();
     }
@@ -329,7 +345,7 @@ describe("AdapterService.discoverPools", () => {
     }
   });
 
-  it("returns empty array when the envelope itself is valid but ALL pool objects have invalid shape", async () => {
+  it("fails with DiscoverPoolsError when the envelope is valid but ALL pool objects have invalid shape (P2 schema-error guard)", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const restore = mockFetch(
       (async () =>
@@ -346,13 +362,37 @@ describe("AdapterService.discoverPools", () => {
     );
     try {
       const layer = buildAdapterLayer();
-      const result = await runDiscover(layer);
-      expect(result).toEqual([]);
+      const err = (await runDiscoverFlip(layer)) as { _tag?: string; message?: string };
+      expect(err._tag).toBe("DiscoverPoolsError");
+      expect(err.message?.toLowerCase()).toContain("none matched the expected shape");
       const shapeWarn = warnSpy.mock.calls.find(
-        (call) => typeof call[0] === "string" && call[0].includes("some pool objects had invalid shape"),
+        (call) => typeof call[0] === "string" && call[0].includes("ALL pool objects had invalid shape"),
       );
       expect(shapeWarn).toBeDefined();
       expect(shapeWarn?.[1]).toMatchObject({ dropped: 2, kept: 0, total: 2, pages: 1 });
+    } finally {
+      restore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does NOT trigger the all-fail guard when the envelope has an empty data array (zero pools is fine)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const restore = mockFetch(
+      (async () =>
+        new Response(
+          JSON.stringify({ total: 0, pages: 0, current_page: 1, page_size: 0, data: [] }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer();
+      const result = await runDiscover(layer);
+      expect(result).toEqual([]);
+      const allFailWarn = warnSpy.mock.calls.find(
+        (call) => typeof call[0] === "string" && call[0].includes("ALL pool objects had invalid shape"),
+      );
+      expect(allFailWarn).toBeUndefined();
     } finally {
       restore();
       warnSpy.mockRestore();

--- a/bench/adapter-discover.test.ts
+++ b/bench/adapter-discover.test.ts
@@ -358,4 +358,116 @@ describe("AdapterService.discoverPools", () => {
       warnSpy.mockRestore();
     }
   });
+
+  it("drops pools where volume['24h'] is not a number (gap 1 regression)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const restore = mockFetch(
+      (async () =>
+        new Response(
+          JSON.stringify({
+            total: 2,
+            pages: 1,
+            current_page: 1,
+            page_size: 2,
+            data: [
+              {
+                address: "PoolValid11111111111111111111111111111111111",
+                token_x: { address: "So11111111111111111111111111111111111111112" },
+                token_y: { address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+                pool_config: { bin_step: 10 },
+                tvl: 200_000,
+                apr: 60,
+                volume: { "24h": 50_000 },
+                fees: { "24h": 500 },
+              },
+              {
+                address: "PoolBadVolume11111111111111111111111111111111",
+                token_x: { address: "So11111111111111111111111111111111111111112" },
+                token_y: { address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+                pool_config: { bin_step: 10 },
+                tvl: 200_000,
+                apr: 60,
+                volume: { "24h": "not a number" },
+                fees: { "24h": 500 },
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer();
+      const result = await runDiscover(layer);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.address).toBe("PoolValid11111111111111111111111111111111111");
+    } finally {
+      restore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("drops pools where fees['24h'] is not a number (gap 1 regression)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const restore = mockFetch(
+      (async () =>
+        new Response(
+          JSON.stringify({
+            total: 2,
+            pages: 1,
+            current_page: 1,
+            page_size: 2,
+            data: [
+              {
+                address: "PoolValid11111111111111111111111111111111111",
+                token_x: { address: "So11111111111111111111111111111111111111112" },
+                token_y: { address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+                pool_config: { bin_step: 10 },
+                tvl: 200_000,
+                apr: 60,
+                volume: { "24h": 50_000 },
+                fees: { "24h": 500 },
+              },
+              {
+                address: "PoolBadFees111111111111111111111111111111111",
+                token_x: { address: "So11111111111111111111111111111111111111112" },
+                token_y: { address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+                pool_config: { bin_step: 10 },
+                tvl: 200_000,
+                apr: 60,
+                volume: { "24h": 50_000 },
+                fees: { "24h": null },
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer();
+      const result = await runDiscover(layer);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.address).toBe("PoolValid11111111111111111111111111111111111");
+    } finally {
+      restore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("maps an AbortError from fetch to a DiscoverPoolsError (gap 2 fetch timeout)", async () => {
+    const restore = mockFetch(
+      (async () => {
+        const err = new Error("The operation was aborted");
+        err.name = "AbortError";
+        throw err;
+      }) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildAdapterLayer();
+      const err = (await runDiscoverFlip(layer)) as { _tag?: string; message?: string };
+      expect(err._tag).toBe("DiscoverPoolsError");
+      expect(err.message?.toLowerCase()).toContain("network error");
+    } finally {
+      restore();
+    }
+  });
 });

--- a/bench/adapter-discover.test.ts
+++ b/bench/adapter-discover.test.ts
@@ -274,6 +274,7 @@ describe("AdapterService.discoverPools", () => {
   });
 
   it("drops pool objects with invalid shape and returns the valid ones (with a logged warning)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const restore = mockFetch(
       (async () =>
         new Response(
@@ -317,12 +318,19 @@ describe("AdapterService.discoverPools", () => {
       expect(Array.isArray(result)).toBe(true);
       expect(result).toHaveLength(1);
       expect(result[0]?.address).toBe("PoolValid11111111111111111111111111111111111");
+      const shapeWarn = warnSpy.mock.calls.find(
+        (call) => typeof call[0] === "string" && call[0].includes("some pool objects had invalid shape"),
+      );
+      expect(shapeWarn).toBeDefined();
+      expect(shapeWarn?.[1]).toMatchObject({ dropped: 2, kept: 1, total: 3, pages: 1 });
     } finally {
       restore();
+      warnSpy.mockRestore();
     }
   });
 
   it("returns empty array when the envelope itself is valid but ALL pool objects have invalid shape", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const restore = mockFetch(
       (async () =>
         new Response(
@@ -331,10 +339,7 @@ describe("AdapterService.discoverPools", () => {
             pages: 1,
             current_page: 1,
             page_size: 2,
-            data: [
-              { address: "Bad1" },
-              { address: "Bad2" },
-            ],
+            data: [{ address: "Bad1" }, { address: "Bad2" }],
           }),
           { status: 200 },
         )) as unknown as typeof fetch,
@@ -343,8 +348,14 @@ describe("AdapterService.discoverPools", () => {
       const layer = buildAdapterLayer();
       const result = await runDiscover(layer);
       expect(result).toEqual([]);
+      const shapeWarn = warnSpy.mock.calls.find(
+        (call) => typeof call[0] === "string" && call[0].includes("some pool objects had invalid shape"),
+      );
+      expect(shapeWarn).toBeDefined();
+      expect(shapeWarn?.[1]).toMatchObject({ dropped: 2, kept: 0, total: 2, pages: 1 });
     } finally {
       restore();
+      warnSpy.mockRestore();
     }
   });
 });

--- a/bench/auto-update.test.ts
+++ b/bench/auto-update.test.ts
@@ -58,6 +58,8 @@ function buildLayer(
     githubRepo: "",
     feedbackOptOut: false,
     paperModeExitLive: false,
+    meteoraPoolsUrl:
+      "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
   });
   return Layer.merge(mockConfig, DbLive(":memory:"));
 }

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -74,6 +74,8 @@ function buildLayer(
     githubRepo,
     feedbackOptOut: optOut,
     paperModeExitLive: false,
+    meteoraPoolsUrl:
+      "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
   });
   const baseLayer = Layer.merge(mockConfig, DbLive(":memory:"));
   return Layer.provide(FeedbackLive, baseLayer) as Layer.Layer<FeedbackService, never, never>;

--- a/bench/revenue-config-service.test.ts
+++ b/bench/revenue-config-service.test.ts
@@ -51,6 +51,8 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     githubRepo: "",
     feedbackOptOut: false,
     paperModeExitLive: false,
+    meteoraPoolsUrl:
+      "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
     ...overrides,
   };
 }

--- a/bench/revenue-split.test.ts
+++ b/bench/revenue-split.test.ts
@@ -51,6 +51,8 @@ function buildLayer() {
     githubRepo: "",
     feedbackOptOut: false,
     paperModeExitLive: false,
+    meteoraPoolsUrl:
+      "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
   });
   const baseLayer = Layer.merge(mockConfig, DbLive(":memory:"));
   return Layer.merge(Layer.provide(AuditLive, DbLive(":memory:")), baseLayer);

--- a/bench/screener-discover.test.ts
+++ b/bench/screener-discover.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Effect, Layer } from "effect";
+import {
+  ConfigService,
+  type AppConfig,
+} from "../engine/config-service.js";
+import {
+  AdapterService,
+  AuditService,
+  ScreenerService,
+  StrategyService,
+} from "../engine/services.js";
+import { AdapterLive } from "../engine/adapter-service.js";
+import { StrategyLive } from "../engine/strategy-service.js";
+import { AuditLive } from "../engine/audit-service.js";
+import { DbLive } from "../engine/db-service.js";
+import { ScreenerLive } from "../engine/screener-service.js";
+import { DiscoverPoolsError } from "../engine/errors.js";
+import { mockFetch } from "./helpers.js";
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    walletPrivateKey: "",
+    heliusApiKey: "",
+    solanaRpcUrl: "https://api.mainnet.helius-rpc.com",
+    paperTrading: true,
+    scanIntervalMs: 600_000,
+    minPoolTvlUsd: 50_000,
+    minFeeIlRatio: 1.2,
+    tvlDropExitPct: 0.3,
+    volumeAuthThreshold: 0.7,
+    maxConcurrentPositions: 5,
+    minRebalanceIntervalMs: 86_400_000,
+    minRebalanceNetBenefitUsd: 10,
+    confidenceThreshold: 0.65,
+    paperPortfolioUsd: 10_000,
+    minBinUtilization: 0.3,
+    maxRebalanceRangeBins: 50,
+    watchlistPools: [],
+    stopLossPct: 0.15,
+    trailingStopPct: 0.1,
+    oorGracePeriodCycles: 3,
+    feeClaimIntervalMs: 86_400_000,
+    enablePoolDiscovery: true,
+    discoveryMinTvlUsd: 100_000,
+    discoveryMinFeeRatio: 1.5,
+    deployerBlacklistPath: "",
+    tokenBlacklistPath: "",
+    sqliteDbPath: ":memory:",
+    enableSnapshotCapture: false,
+    autoUpdate: false,
+    updateCheckIntervalMs: 216_000_000,
+    updateChannel: "stable",
+    updateGithubRepo: "irfndi/prism-liquidity-agent",
+    updateAllowDirty: false,
+    forceUpdateEnabled: false,
+    forceUpdateAfterDays: 14,
+    updateR2PublicUrl: "https://r2.prism-agent.com",
+    githubToken: "",
+    githubRepo: "irfndi/prism-liquidity-agent",
+    feedbackOptOut: false,
+    paperModeExitLive: false,
+    meteoraPoolsUrl:
+      "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
+  };
+}
+
+function buildScreenerLayer(
+  overrides: Partial<AppConfig> = {},
+  adapterFailure: "discoverPoolsError" | "otherError" | null = null,
+): Layer.Layer<ScreenerService, never, never> {
+  const configLayer = Layer.succeed(ConfigService, makeConfig(overrides));
+  const dbLayer = DbLive(":memory:");
+  const auditLayer = Layer.provide(AuditLive, dbLayer);
+  const strategyLayer = Layer.provide(
+    StrategyLive,
+    Layer.merge(configLayer, auditLayer),
+  );
+  const adapterLayer: Layer.Layer<AdapterService, never, never> = (() => {
+    if (adapterFailure === "discoverPoolsError") {
+      return Layer.succeed(AdapterService, {
+        hasWallet: () => false,
+        getWalletAddress: () => null,
+        getWalletBalanceUsd: () => Effect.never,
+        getNativeSolBalance: () => Effect.never,
+        getPoolState: () => Effect.never,
+        getBinArray: () => Effect.never,
+        getPositions: () => Effect.never,
+        getAllWalletPositions: () => Effect.never,
+        simulateRebalance: () => Effect.never,
+        enterPosition: () => Effect.never,
+        exitPosition: () => Effect.never,
+        rebalancePosition: () => Effect.never,
+        claimFees: () => Effect.never,
+        discoverPools: () =>
+          Effect.fail(
+            new DiscoverPoolsError({
+              message: "Meteora API returned HTTP 404. Pool discovery disabled.",
+              url: "https://dlmm.datapi.meteora.ag/pools",
+              status: 404,
+            }),
+          ),
+        reportFeeCollection: () => Effect.never,
+        swapUSDCForSOL: () => Effect.never,
+        reportRevenue: () => Effect.never,
+      } as never);
+    }
+    if (adapterFailure === "otherError") {
+      return Layer.succeed(AdapterService, {
+        hasWallet: () => false,
+        getWalletAddress: () => null,
+        getWalletBalanceUsd: () => Effect.never,
+        getNativeSolBalance: () => Effect.never,
+        getPoolState: () => Effect.never,
+        getBinArray: () => Effect.never,
+        getPositions: () => Effect.never,
+        getAllWalletPositions: () => Effect.never,
+        simulateRebalance: () => Effect.never,
+        enterPosition: () => Effect.never,
+        exitPosition: () => Effect.never,
+        rebalancePosition: () => Effect.never,
+        claimFees: () => Effect.never,
+        discoverPools: () => Effect.fail(new Error("totally unrelated: out of memory")),
+        reportFeeCollection: () => Effect.never,
+        swapUSDCForSOL: () => Effect.never,
+        reportRevenue: () => Effect.never,
+      } as never);
+    }
+    return Layer.provide(AdapterLive, configLayer);
+  })();
+  const allDeps = Layer.merge(configLayer, Layer.merge(adapterLayer, strategyLayer));
+  return Layer.provide(
+    ScreenerLive({
+      minTvlUsd: 100_000,
+      minFeeRatio: 1.5,
+      volumeAuthThreshold: 0.7,
+      minBinUtilization: 0.3,
+    }),
+    allDeps,
+  ) as Layer.Layer<ScreenerService, never, never>;
+}
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("ScreenerService.screenPools", () => {
+  it("catches DiscoverPoolsError and falls back to watchlist-only mode (returns [])", async () => {
+    const layer = buildScreenerLayer({}, "discoverPoolsError");
+    const program = Effect.gen(function* () {
+      const screener = yield* ScreenerService;
+      return yield* screener.screenPools();
+    });
+    const screened = await Effect.runPromise(Effect.provide(program, layer));
+    expect(Array.isArray(screened)).toBe(true);
+    expect(screened).toHaveLength(0);
+  });
+
+  it("rethrows errors that are NOT DiscoverPoolsError (does not silently swallow them)", async () => {
+    const layer = buildScreenerLayer({}, "otherError");
+    const program = Effect.gen(function* () {
+      const screener = yield* ScreenerService;
+      return yield* screener.screenPools();
+    });
+    await expect(
+      Effect.runPromise(Effect.provide(program, layer)),
+    ).rejects.toThrow(/out of memory/);
+  });
+
+  it("returns empty array on a JSON parse error (DiscoverPoolsError from JSON failure)", async () => {
+    const restore = mockFetch(
+      (async () =>
+        new Response("not json at all", { status: 200 })) as unknown as typeof fetch,
+    );
+    try {
+      const layer = buildScreenerLayer();
+      const program = Effect.gen(function* () {
+        const screener = yield* ScreenerService;
+        return yield* screener.screenPools();
+      });
+      const screened = await Effect.runPromise(Effect.provide(program, layer));
+      expect(screened).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/bench/update-check.test.ts
+++ b/bench/update-check.test.ts
@@ -57,6 +57,8 @@ function buildLayer(
     githubRepo: "",
     feedbackOptOut: false,
     paperModeExitLive: false,
+    meteoraPoolsUrl:
+      "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
   });
   return Layer.merge(mockConfig, DbLive(":memory:"));
 }

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -32,6 +32,119 @@ const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
 const logger = createLogger("adapter-service");
 
+// ─── Meteora DLMM Data API response shape ────────────────────────────────────
+// Mirrors the schema in https://dlmm.datapi.meteora.ag/openapi.json (the file
+// at /openapi.json on the host is 404, but the live /pools endpoint and the
+// docs at docs.meteora.ag/developer-guides/dlmm/api-reference/ confirm this).
+// TimeWindowData is keyed by window string ("30m", "1h", "24h", ...) so we
+// use a Record at the type level.
+
+interface MeteoraTimeWindowData {
+  readonly "30m": number;
+  readonly "1h": number;
+  readonly "2h": number;
+  readonly "4h": number;
+  readonly "12h": number;
+  readonly "24h": number;
+  readonly [window: string]: number;
+}
+
+interface MeteoraTokenMetrics {
+  readonly address: string;
+  readonly name: string;
+  readonly symbol: string;
+  readonly decimals: number;
+  readonly is_verified: boolean;
+  readonly holders: number;
+  readonly freeze_authority_disabled: boolean;
+  readonly total_supply: number;
+  readonly price: number;
+  readonly market_cap: number;
+}
+
+interface MeteoraPoolConfig {
+  readonly bin_step: number;
+  readonly base_fee_pct: number;
+  readonly max_fee_pct: number;
+  readonly protocol_fee_pct: number;
+  readonly collect_fee_mode: number;
+}
+
+interface MeteoraPool {
+  readonly address: string;
+  readonly name: string;
+  readonly token_x: MeteoraTokenMetrics;
+  readonly token_y: MeteoraTokenMetrics;
+  readonly reserve_x: string;
+  readonly reserve_y: string;
+  readonly token_x_amount: number;
+  readonly token_y_amount: number;
+  readonly created_at: number;
+  readonly reward_mint_x: string;
+  readonly reward_mint_y: string;
+  readonly pool_config: MeteoraPoolConfig;
+  readonly dynamic_fee_pct: number;
+  readonly tvl: number;
+  readonly current_price: number;
+  readonly apr: number;
+  readonly apy: number;
+  readonly has_farm: boolean;
+  readonly farm_apr: number;
+  readonly farm_apy: number;
+  readonly volume: MeteoraTimeWindowData;
+  readonly fees: MeteoraTimeWindowData;
+  readonly protocol_fees: MeteoraTimeWindowData;
+  readonly fee_tvl_ratio: MeteoraTimeWindowData;
+  readonly cumulative_metrics: { readonly volume: number; readonly fees: number };
+  readonly is_blacklisted: boolean;
+  readonly tags: ReadonlyArray<string>;
+  readonly launchpad: string | null;
+}
+
+interface MeteoraPoolsEnvelope {
+  readonly total: number;
+  readonly pages: number;
+  readonly current_page: number;
+  readonly page_size: number;
+  readonly data: ReadonlyArray<MeteoraPool>;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isPoolsEnvelope(v: unknown): v is MeteoraPoolsEnvelope {
+  if (!isObject(v)) return false;
+  if (typeof v["total"] !== "number") return false;
+  if (typeof v["pages"] !== "number") return false;
+  if (typeof v["current_page"] !== "number") return false;
+  if (typeof v["page_size"] !== "number") return false;
+  if (!Array.isArray(v["data"])) return false;
+  return true;
+}
+
+function isValidPoolShape(v: unknown): v is MeteoraPool {
+  if (!isObject(v)) return false;
+  if (typeof v["address"] !== "string") return false;
+  if (typeof v["tvl"] !== "number") return false;
+  if (typeof v["apr"] !== "number") return false;
+  if (!isObject(v["token_x"]) || typeof (v["token_x"] as Record<string, unknown>)["address"] !== "string") return false;
+  if (!isObject(v["token_y"]) || typeof (v["token_y"] as Record<string, unknown>)["address"] !== "string") return false;
+  if (!isObject(v["pool_config"])) return false;
+  const cfg = v["pool_config"] as Record<string, unknown>;
+  if (typeof cfg["bin_step"] !== "number") return false;
+  if (!isObject(v["volume"])) return false;
+  if (!isObject(v["fees"])) return false;
+  return true;
+}
+
+function describe(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return `array(length=${v.length})`;
+  if (typeof v === "object") return `object(keys=${Object.keys(v as object).slice(0, 5).join(",")})`;
+  return typeof v;
+}
+
 // ─── Install ID helper (engine-safe mirror of cli/install-id.ts) ───────────
 
 const INSTALL_ID_FILE = path.join(os.homedir(), ".config", "prism", "install-id");
@@ -1006,7 +1119,9 @@ export const AdapterLive = Layer.effect(
 
       discoverPools: () =>
         Effect.gen(function* () {
-          const url = process.env.METEORA_POOLS_URL ?? "https://dlmm-api.meteora.ag/pair/all";
+          const url =
+            config.meteoraPoolsUrl ||
+            "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc";
           const res = yield* Effect.tryPromise({
             try: () => fetch(url),
             catch: (cause) =>
@@ -1038,36 +1153,33 @@ export const AdapterLive = Layer.effect(
                 cause,
               }),
           });
-          if (!Array.isArray(parsed)) {
+          if (!isPoolsEnvelope(parsed)) {
             return yield* Effect.fail(
               new DiscoverPoolsError({
-                message: `Meteora API returned non-array payload (${typeof parsed}) from ${url}`,
+                message: `Meteora API returned non-envelope payload (${describe(parsed)}) from ${url}`,
                 url,
               }),
             );
           }
-          const pairs = parsed as ReadonlyArray<{
-            address: string;
-            bin_step: number;
-            base_mint: string;
-            quote_mint: string;
-            tvl: number;
-            volume_24h: number;
-            fees_24h: number;
-            apr: number;
-          }>;
-
-          return pairs
+          const { data, total, pages } = parsed;
+          const valid = data.filter(isValidPoolShape);
+          if (valid.length < data.length) {
+            logger.warn(
+              "Pool discovery: some pool objects had invalid shape and were dropped",
+              { dropped: data.length - valid.length, kept: valid.length, total, pages },
+            );
+          }
+          return valid
             .filter((p) => p.tvl >= config.discoveryMinTvlUsd)
             .map((p) => ({
               address: p.address,
               tvlUsd: p.tvl,
-              volume24hUsd: p.volume_24h,
-              fees24hUsd: p.fees_24h,
+              volume24hUsd: p.volume["24h"] ?? 0,
+              fees24hUsd: p.fees["24h"] ?? 0,
               apr: p.apr,
-              binStep: p.bin_step,
-              tokenX: p.base_mint,
-              tokenY: p.quote_mint,
+              binStep: p.pool_config.bin_step,
+              tokenX: p.token_x.address,
+              tokenY: p.token_y.address,
             }))
             .slice(0, 50);
         }),

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -1175,6 +1175,21 @@ export const AdapterLive = Layer.effect(
           }
           const { data, total, pages } = parsed;
           const valid = data.filter(isValidPoolShape);
+          if (data.length > 0 && valid.length === 0) {
+            // Every row failed shape validation: almost always a schema change
+            // upstream, not random data noise. Fail loud so the regression is
+            // visible instead of silently masking it as an empty result.
+            logger.warn(
+              "Pool discovery: ALL pool objects had invalid shape; treating as a schema error",
+              { dropped: data.length, kept: 0, total, pages },
+            );
+            return yield* Effect.fail(
+              new DiscoverPoolsError({
+                message: `Meteora API returned ${data.length} pool rows but none matched the expected shape. Likely a schema change. Pool discovery disabled for this cycle.`,
+                url,
+              }),
+            );
+          }
           if (valid.length < data.length) {
             logger.warn(
               "Pool discovery: some pool objects had invalid shape and were dropped",

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -134,7 +134,11 @@ function isValidPoolShape(v: unknown): v is MeteoraPool {
   const cfg = v["pool_config"] as Record<string, unknown>;
   if (typeof cfg["bin_step"] !== "number") return false;
   if (!isObject(v["volume"])) return false;
+  const vol = v["volume"] as Record<string, unknown>;
+  if (typeof vol["24h"] !== "number") return false;
   if (!isObject(v["fees"])) return false;
+  const fees = v["fees"] as Record<string, unknown>;
+  if (typeof fees["24h"] !== "number") return false;
   return true;
 }
 
@@ -1123,7 +1127,15 @@ export const AdapterLive = Layer.effect(
             config.meteoraPoolsUrl ||
             "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc";
           const res = yield* Effect.tryPromise({
-            try: () => fetch(url),
+            try: async () => {
+              const controller = new AbortController();
+              const timeout = setTimeout(() => controller.abort(), 10_000);
+              try {
+                return await fetch(url, { signal: controller.signal });
+              } finally {
+                clearTimeout(timeout);
+              }
+            },
             catch: (cause) =>
               new DiscoverPoolsError({
                 message: `Network error fetching ${url}: ${String(cause)}`,
@@ -1174,8 +1186,8 @@ export const AdapterLive = Layer.effect(
             .map((p) => ({
               address: p.address,
               tvlUsd: p.tvl,
-              volume24hUsd: p.volume["24h"] ?? 0,
-              fees24hUsd: p.fees["24h"] ?? 0,
+              volume24hUsd: p.volume["24h"],
+              fees24hUsd: p.fees["24h"],
               apr: p.apr,
               binStep: p.pool_config.bin_step,
               tokenX: p.token_x.address,

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -18,6 +18,7 @@ import { Context, Effect, Layer } from "effect";
 import { AdapterService, type AdapterApi } from "./services.js";
 import { ConfigService } from "./config-service.js";
 import { AdapterError } from "./errors.js";
+import { DiscoverPoolsError } from "./errors.js";
 import { createLogger } from "./logger.js";
 import type { BinArray, BinData, PoolState, Position } from "./types.js";
 import bs58 from "bs58";
@@ -1005,8 +1006,47 @@ export const AdapterLive = Layer.effect(
 
       discoverPools: () =>
         Effect.gen(function* () {
-          const res = yield* Effect.tryPromise(() => fetch("https://dlmm-api.meteora.ag/pair/all"));
-          const pairs = (yield* Effect.tryPromise(() => res.json())) as ReadonlyArray<{
+          const url = process.env.METEORA_POOLS_URL ?? "https://dlmm-api.meteora.ag/pair/all";
+          const res = yield* Effect.tryPromise({
+            try: () => fetch(url),
+            catch: (cause) =>
+              new DiscoverPoolsError({
+                message: `Network error fetching ${url}: ${String(cause)}`,
+                url,
+                cause,
+              }),
+          });
+          if (!res.ok) {
+            logger.warn("Pool discovery: Meteora API returned non-OK", {
+              url,
+              status: res.status,
+            });
+            return yield* Effect.fail(
+              new DiscoverPoolsError({
+                message: `Meteora API returned HTTP ${res.status} for ${url}. Pool discovery disabled for this cycle.`,
+                url,
+                status: res.status,
+              }),
+            );
+          }
+          const parsed: unknown = yield* Effect.tryPromise({
+            try: () => res.json(),
+            catch: (cause) =>
+              new DiscoverPoolsError({
+                message: `Invalid JSON from ${url}: ${String(cause)}`,
+                url,
+                cause,
+              }),
+          });
+          if (!Array.isArray(parsed)) {
+            return yield* Effect.fail(
+              new DiscoverPoolsError({
+                message: `Meteora API returned non-array payload (${typeof parsed}) from ${url}`,
+                url,
+              }),
+            );
+          }
+          const pairs = parsed as ReadonlyArray<{
             address: string;
             bin_step: number;
             base_mint: string;
@@ -1030,7 +1070,7 @@ export const AdapterLive = Layer.effect(
               tokenY: p.quote_mint,
             }))
             .slice(0, 50);
-        }).pipe(Effect.catchAll(() => Effect.succeed([]))),
+        }),
 
       swapUSDCForSOL: (minSolThreshold = 0.05, swapAmountUSDC = 1.0) =>
         Effect.gen(function* () {

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -48,7 +48,8 @@ export interface AppConfig {
   // Allow paper mode to exit live positions (opt-in escape hatch)
   readonly paperModeExitLive: boolean;
   // Meteora DLMM pool-discovery API URL. Override with METEORA_POOLS_URL
-  // env var; falls back to the legacy public endpoint if unset/empty.
+  // env var; falls back to the official DLMM Data API (dlmm.datapi.meteora.ag)
+  // if the env var is unset or empty.
   readonly meteoraPoolsUrl: string;
 }
 

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -47,6 +47,9 @@ export interface AppConfig {
   readonly feedbackOptOut: boolean;
   // Allow paper mode to exit live positions (opt-in escape hatch)
   readonly paperModeExitLive: boolean;
+  // Meteora DLMM pool-discovery API URL. Override with METEORA_POOLS_URL
+  // env var; falls back to the legacy public endpoint if unset/empty.
+  readonly meteoraPoolsUrl: string;
 }
 
 export class ConfigService extends Context.Tag("ConfigService")<ConfigService, AppConfig>() {}
@@ -160,6 +163,12 @@ const loadConfig = Effect.gen(function* () {
   const paperModeExitLive = yield* Config.boolean("PAPER_MODE_EXIT_LIVE").pipe(
     Effect.orElseSucceed(() => false),
   );
+  const meteoraPoolsUrlRaw = yield* Config.string("METEORA_POOLS_URL").pipe(
+    Effect.orElseSucceed(() => ""),
+  );
+  const meteoraPoolsUrl =
+    meteoraPoolsUrlRaw ||
+    "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc";
 
   const watchlistPools = watchlistPoolsRaw
     .split(",")
@@ -207,6 +216,7 @@ const loadConfig = Effect.gen(function* () {
     githubRepo,
     feedbackOptOut,
     paperModeExitLive,
+    meteoraPoolsUrl,
   };
 
   return cfg;

--- a/engine/errors.ts
+++ b/engine/errors.ts
@@ -35,3 +35,10 @@ export class AuditError extends Data.TaggedError("AuditError")<{
   readonly message: string;
   readonly cause?: unknown;
 }> {}
+
+export class DiscoverPoolsError extends Data.TaggedError("DiscoverPoolsError")<{
+  readonly message: string;
+  readonly url: string;
+  readonly status?: number;
+  readonly cause?: unknown;
+}> {}

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -13,6 +13,7 @@ import { RevenueConfigServiceLive } from "./revenue-config-service.js";
 import { ReferralLive } from "./referral-service.js";
 import { checkForAutoUpdate } from "./update-check.js";
 import type { PositionRecord } from "./db-service.js";
+import { DiscoverPoolsError } from "./errors.js";
 import {
   AdapterService,
   StrategyService,
@@ -28,6 +29,7 @@ import {
   type AdapterApi,
   type DbApi,
   type MemoryApi,
+  type ScreenedPool,
 } from "./services.js";
 import type { AgentDecision, AgentCycle, PoolState } from "./types.js";
 import { randomUUID } from "crypto";
@@ -265,7 +267,20 @@ export const program = Effect.gen(function* () {
   let poolsToScan = [...config.watchlistPools];
 
   if (config.enablePoolDiscovery) {
-    const screened = yield* screener.screenPools().pipe(Effect.catchAll(() => Effect.succeed([])));
+    const screened = yield* screener.screenPools().pipe(
+      Effect.catchAll((err) => {
+        if (err instanceof DiscoverPoolsError || (err as { _tag?: string })?._tag === "DiscoverPoolsError") {
+          console.warn(
+            "Pool discovery failed; falling back to watchlist-only mode:",
+            err instanceof Error ? err.message : String(err),
+          );
+          return Effect.succeed([] as ReadonlyArray<ScreenedPool>);
+        }
+        // Non-discovery error: let it propagate so the cycle fails loudly
+        // instead of silently masking bugs as an empty discovery result.
+        return Effect.fail(err);
+      }),
+    );
     if (screened.length > 0) {
       console.info(`Discovered ${screened.length} candidate pools`);
       const top3 = screened.slice(0, 3);

--- a/engine/screener-service.ts
+++ b/engine/screener-service.ts
@@ -1,8 +1,9 @@
 import { Context, Effect, Layer } from "effect";
 import { ScreenerService, type ScreenerApi, type ScreenedPool } from "./services.js";
-import { AdapterService } from "./services.js";
+import { AdapterService, type DiscoveredPool } from "./services.js";
 import { StrategyService } from "./services.js";
 import { createLogger } from "./logger.js";
+import { DiscoverPoolsError } from "./errors.js";
 
 const logger = createLogger("screener");
 
@@ -23,24 +24,16 @@ export const ScreenerLive = (screenerConfig: ScreenerConfig) =>
       const api: ScreenerApi = {
         screenPools: () =>
           Effect.gen(function* () {
-            const pools = yield* adapter.discoverPools().pipe(
+            const pools: ReadonlyArray<DiscoveredPool> = yield* adapter.discoverPools().pipe(
               Effect.catchAll((err) => {
-                logger.warn(
-                  "Pool discovery failed; falling back to watchlist-only mode:",
-                  err.message,
-                );
-                return Effect.succeed(
-                  [] as ReadonlyArray<{
-                    address: string;
-                    tvlUsd: number;
-                    volume24hUsd: number;
-                    fees24hUsd: number;
-                    apr: number;
-                    binStep: number;
-                    tokenX: string;
-                    tokenY: string;
-                  }>,
-                );
+                if (err instanceof DiscoverPoolsError || (err as { _tag?: string })?._tag === "DiscoverPoolsError") {
+                  logger.warn(
+                    "Pool discovery failed; falling back to watchlist-only mode:",
+                    err.message,
+                  );
+                  return Effect.succeed([] as ReadonlyArray<DiscoveredPool>);
+                }
+                return Effect.fail(err);
               }),
             );
             const screened: ScreenedPool[] = [];

--- a/engine/screener-service.ts
+++ b/engine/screener-service.ts
@@ -2,6 +2,9 @@ import { Context, Effect, Layer } from "effect";
 import { ScreenerService, type ScreenerApi, type ScreenedPool } from "./services.js";
 import { AdapterService } from "./services.js";
 import { StrategyService } from "./services.js";
+import { createLogger } from "./logger.js";
+
+const logger = createLogger("screener");
 
 export interface ScreenerConfig {
   readonly minTvlUsd: number;
@@ -20,7 +23,26 @@ export const ScreenerLive = (screenerConfig: ScreenerConfig) =>
       const api: ScreenerApi = {
         screenPools: () =>
           Effect.gen(function* () {
-            const pools = yield* adapter.discoverPools();
+            const pools = yield* adapter.discoverPools().pipe(
+              Effect.catchAll((err) => {
+                logger.warn(
+                  "Pool discovery failed; falling back to watchlist-only mode:",
+                  err.message,
+                );
+                return Effect.succeed(
+                  [] as ReadonlyArray<{
+                    address: string;
+                    tvlUsd: number;
+                    volume24hUsd: number;
+                    fees24hUsd: number;
+                    apr: number;
+                    binStep: number;
+                    tokenX: string;
+                    tokenY: string;
+                  }>,
+                );
+              }),
+            );
             const screened: ScreenedPool[] = [];
 
             for (const pool of pools) {

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -24,6 +24,17 @@ import type {
 
 // ─── Adapter Service ─────────────────────────────────────────────────────────
 
+export interface DiscoveredPool {
+  readonly address: string;
+  readonly tvlUsd: number;
+  readonly volume24hUsd: number;
+  readonly fees24hUsd: number;
+  readonly apr: number;
+  readonly binStep: number;
+  readonly tokenX: string;
+  readonly tokenY: string;
+}
+
 export interface AdapterApi {
   readonly hasWallet: () => boolean;
   readonly getWalletAddress: () => string | null;
@@ -102,19 +113,7 @@ export interface AdapterApi {
     },
     unknown
   >;
-  readonly discoverPools: () => Effect.Effect<
-    ReadonlyArray<{
-      address: string;
-      tvlUsd: number;
-      volume24hUsd: number;
-      fees24hUsd: number;
-      apr: number;
-      binStep: number;
-      tokenX: string;
-      tokenY: string;
-    }>,
-    DiscoverPoolsError
-  >;
+  readonly discoverPools: () => Effect.Effect<ReadonlyArray<DiscoveredPool>, DiscoverPoolsError>;
   readonly reportFeeCollection: (event: {
     poolAddress: string;
     positionPubkey: string;

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -16,6 +16,7 @@ import type {
   AdapterError,
   AuditError,
   BlacklistError,
+  DiscoverPoolsError,
   MemoryError,
   RiskError,
   ScreenerError,
@@ -112,7 +113,7 @@ export interface AdapterApi {
       tokenX: string;
       tokenY: string;
     }>,
-    unknown
+    DiscoverPoolsError
   >;
   readonly reportFeeCollection: (event: {
     poolAddress: string;


### PR DESCRIPTION
## Summary

This PR does **two things at once** because the original report was
symptomatic of a much bigger bug:

1. **Surface Meteora API failures as a typed `DiscoverPoolsError`** instead of silently returning `[]` (the original PR's headline fix).
2. **Switch the agent to the official Meteora DLMM Data API** at `dlmm.datapi.meteora.ag` — the URL the agent was using (`dlmm-api.meteora.ag/pair/all`) was both **unmaintained (404)** AND had a **completely wrong response shape** (flat snake-case array vs the documented paginated envelope with nested `token_x` / `pool_config` / `volume.<window>` objects).

The PR also addresses **all 5 review comments** from Sourcery + Kilo.

---

## Root-cause reframe (per the official Meteora docs)

PR review pointed out the adapter was reading `process.env` directly. While investigating where the URL _should_ point, I pulled Meteora's llms.txt index at `https://docs.meteora.ag/llms.txt` and confirmed:

- `dlmm-api.meteora.ag/pair/all` is **not in the Meteora GitHub org** (verified domain holder of `meteora.ag`) and returns **404 for every path**.
- The official **DLMM Data API** is at `https://dlmm.datapi.meteora.ag` (documented at `docs.meteora.ag/developer-guides/dlmm/api-reference/overview.md`).
- The new endpoint returns a **paginated envelope** `{ total, pages, current_page, page_size, data: [...] }` where each pool has nested `token_x.address`, `pool_config.bin_step`, `volume.<window>`, `fees.<window>`, etc. The old endpoint's flat snake-case fields (`base_mint`, `quote_mint`, `bin_step`, `volume_24h`, `fees_24h`) **do not exist** in the new shape.

The default URL was updated to:
```
https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc
```
1000 non-blacklisted pools, sorted by TVL. `METEORA_POOLS_URL` env var still overrides.

## Manual QA against the REAL official endpoint

```
=== Top 5 pools discovered from official Meteora DLMM Data API ===
[
  { "tvlUsd": 38323220.73, "apr": 0.000256, ..., "binStep": 100,
    "tokenX": "DrZ26cKJ...", "tokenY": "EPjFWdd5..." (USDC) },
  { "tvlUsd": 35516679.41, "apr": 0.0049, ..., "binStep": 50, ... },
  { "tvlUsd": 10397218.40, "apr": 0.025, ..., "binStep": 100, ... },
  { "tvlUsd": 9417706.18, "apr": 0.00018, ..., "binStep": 100, ... },
  { "tvlUsd": 8145348.67, "apr": 0.045, ..., "binStep": 80, ... }
]
```

Realistic TVL, real Solana pool/token addresses, real binSteps — the agent is now actually screening DLMM pools.

## PR review comments addressed

| # | Source | Comment | Fix |
|---|---|---|---|
| 1 | Sourcery | `METEORA_POOLS_URL` bypassed `ConfigService` | Added `meteoraPoolsUrl` to `AppConfig`, loaded via `Config.string` with `:-` fallback, adapter reads `config.meteoraPoolsUrl` (no more `process.env` in the adapter layer) |
| 2 | Sourcery | `Effect.catchAll` in screener swallowed ALL errors | Narrowed to only catch `DiscoverPoolsError` (checked via `instanceof` + `_tag`), rethrows any other error type via `Effect.fail(err)` |
| 3 | Sourcery | Inline pool type in screener-service duplicated `AdapterApi.discoverPools` return type | Extracted to a shared `DiscoveredPool` interface in `engine/services.ts`; both the interface and the screener reference it now |
| 4 | Sourcery | `Array.isArray` was the only shape check | Added `isValidPoolShape` runtime guard (verifies `address`, `token_x.address`, `token_y.address`, `tvl`, `pool_config.bin_step`, `volume`, `fees`) and drops invalid objects with a logged warning. Also added envelope-level validation (`isPoolsEnvelope`) so a missing `data` field is caught |
| 5 | Kilo | `??` didn't guard against empty string | Used `\|\|` in the adapter as defense in depth (so even if a caller passes an empty string directly to the config, the official default is used) |

## Tests

```bash
bash bench/adapter-discover.test.ts  # 12/12 PASS
bash bench/screener-discover.test.ts # 3/3 PASS  (NEW FILE)
bun run test                            # 267/267 PASS (was 252, +15)
bun run lint                            # 0 warnings, 0 errors
```

`bench/adapter-discover.test.ts` (existing, expanded): 12 cases using `mockFetch` to verify the full behavior matrix — 200+envelope, 200+flat-array-rejected, 404, 500, invalid-JSON, non-array, network error, `meteoraPoolsUrl` override, empty-string fallback, missing-fields, wrong-types, and the typed `_tag` field.

`bench/screener-discover.test.ts` (new): 3 cases using a custom mock adapter layer that injects the failure mode:
- Adapter returns `DiscoverPoolsError` → screener returns `[]` and logs warning
- Adapter returns a plain `Error` (NOT `DiscoverPoolsError`) → screener rethrows
- Adapter returns a JSON-parse `DiscoverPoolsError` → screener returns `[]`

The second test is the new regression guard for Sourcery comment #2 — it would fail against the old `Effect.catchAll(() => [])` because that swallowed everything.

## Files changed

| File | Change |
|---|---|
| `engine/config-service.ts` | Added `meteoraPoolsUrl` to `AppConfig` (default = official DLMM Data API URL) |
| `engine/errors.ts` | `DiscoverPoolsError` tagged error (already there from previous commit) |
| `engine/services.ts` | Extracted `DiscoveredPool` interface; updated `AdapterApi.discoverPools` to use it |
| `engine/adapter-service.ts` | Added `MeteoraPoolsEnvelope` / `MeteoraPool` / `MeteoraTimeWindowData` / etc. types; added `isObject`, `isPoolsEnvelope`, `isValidPoolShape`, `describe` helpers; rewrote `discoverPools` to (a) read URL from `config.meteoraPoolsUrl` with `\|\|` empty-string fallback, (b) validate envelope shape, (c) validate per-pool shape, (d) drop invalid pools with warning, (e) map new field names |
| `engine/screener-service.ts` | Use `DiscoveredPool` type; narrow `Effect.catchAll` to `DiscoverPoolsError` only (rethrows others) |
| `bench/adapter-discover.test.ts` | Updated all mocks to the new envelope shape; added tests for envelope rejection, empty-string URL fallback, malformed pool object |
| `bench/screener-discover.test.ts` | NEW FILE — 3 tests covering the screener's error-narrowing behavior |
| `bench/auto-update.test.ts`, `bench/feedback-service.test.ts`, `bench/revenue-config-service.test.ts`, `bench/revenue-split.test.ts`, `bench/update-check.test.ts` | Added `meteoraPoolsUrl` field to each `makeConfig` helper (required after the AppConfig type change) |

## Notes

- The legacy `dlmm-api.meteora.ag/pair/all` endpoint is dead (404 for every path). Meteora's official API uses a different host (`dlmm.datapi.meteora.ag`), a different path (`/pools`), and a different response shape. The agent was using the wrong endpoint with the wrong field names — the new shape matches the docs.
- 30 RPS rate limit on the official API (per docs).
- The `||` empty-string fallback in the adapter is defense-in-depth — `ConfigService` already normalizes the env var to a non-empty value, but a programmatic caller could still pass an empty string directly via `Layer.succeed(ConfigService, { meteoraPoolsUrl: "" })`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable Meteora pools endpoint via `METEORA_POOLS_URL` (with a sensible default when unset).

* **Improvements**
  * Updated pool discovery to use Meteora’s `/pools` API with stricter payload validation, safer network handling, and invalid-row filtering (returning up to 50 pools).
  * When pool discovery fails for the known/expected reason, screening now falls back to watchlist-only instead of failing.

* **Tests**
  * Expanded automated coverage for pool discovery and screening error-handling, plus updated test configuration to include the new endpoint setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->