### PR TITLE
feat: cloud feedback, price caching, RPC retries, and lockfile detection

### DIFF
--- a/bench/adapter-prices.test.ts
+++ b/bench/adapter-prices.test.ts
@@ -37,18 +37,16 @@ describe("AdapterService price resolution", () => {
   });
 
   it("uses the live Jupiter price for SOL instead of the hardcoded fallback", async () => {
-    const restore = mockFetch(
-      vi.fn(async (url: string | URL | Request) => {
-        const u = url.toString();
-        if (u.includes("price.jup.ag/v6/price") && u.includes(SOL_MINT)) {
-          return new Response(JSON.stringify({ data: { [SOL_MINT]: { price: 200 } } }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        return new Response("unexpected", { status: 500 });
-      }) as unknown as typeof fetch,
-    );
+    const restore = mockFetch((async (url: string | URL | Request) => {
+      const u = url.toString();
+      if (u.includes("price.jup.ag/v6/price") && u.includes(SOL_MINT)) {
+        return new Response(JSON.stringify({ data: { [SOL_MINT]: { price: 200 } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    }) as unknown as typeof fetch);
 
     vi.spyOn(Connection.prototype, "getBalance").mockResolvedValue(1_000_000_000);
     vi.spyOn(Connection.prototype, "getTokenAccountsByOwner").mockResolvedValue({

--- a/bench/adapter-prices.test.ts
+++ b/bench/adapter-prices.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Effect, Layer } from "effect";
+import { Connection, Keypair } from "@solana/web3.js";
+import bs58 from "bs58";
+import { AdapterService } from "../engine/services.js";
+import { AdapterLive } from "../engine/adapter-service.js";
+import { ConfigService } from "../engine/config-service.js";
+import { AuditLive } from "../engine/audit-service.js";
+import { DbLive } from "../engine/db-service.js";
+import { defaultAppConfig, mockFetch } from "./helpers.js";
+
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+
+function buildAdapterLayerWithWallet(): Layer.Layer<AdapterService, never, never> {
+  const walletPrivateKey = bs58.encode(Keypair.generate().secretKey);
+  const configLayer = Layer.succeed(
+    ConfigService,
+    defaultAppConfig({
+      walletPrivateKey,
+      solanaRpcUrl: "https://example.com",
+      sqliteDbPath: ":memory:",
+      autoUpdate: false,
+      updateCheckIntervalMs: 216_000_000,
+    }),
+  );
+  const auditLayer = Layer.provide(AuditLive, DbLive(":memory:"));
+  return Layer.provide(AdapterLive, Layer.merge(configLayer, auditLayer)) as Layer.Layer<
+    AdapterService,
+    never,
+    never
+  >;
+}
+
+describe("AdapterService price resolution", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the live Jupiter price for SOL instead of the hardcoded fallback", async () => {
+    const restore = mockFetch(
+      vi.fn(async (url: string | URL | Request) => {
+        const u = url.toString();
+        if (u.includes("price.jup.ag/v6/price") && u.includes(SOL_MINT)) {
+          return new Response(JSON.stringify({ data: { [SOL_MINT]: { price: 200 } } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response("unexpected", { status: 500 });
+      }) as unknown as typeof fetch,
+    );
+
+    vi.spyOn(Connection.prototype, "getBalance").mockResolvedValue(1_000_000_000);
+    vi.spyOn(Connection.prototype, "getTokenAccountsByOwner").mockResolvedValue({
+      value: [],
+    } as unknown as Awaited<ReturnType<Connection["getTokenAccountsByOwner"]>>);
+
+    try {
+      const layer = buildAdapterLayerWithWallet();
+      const program = Effect.gen(function* () {
+        const adapter = yield* AdapterService;
+        return yield* adapter.getWalletBalanceUsd();
+      }).pipe(Effect.provide(layer));
+
+      const balanceUsd = await Effect.runPromise(program);
+      // 1 SOL at the mocked Jupiter price of $200 (no USDC balance).
+      expect(balanceUsd).toBeCloseTo(200, 1);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/bench/adapter-retry.test.ts
+++ b/bench/adapter-retry.test.ts
@@ -50,7 +50,11 @@ describe("retryWithBackoff", () => {
       }
       return "ok";
     });
-    const result = await retryWithBackoff(fn, { baseDelayMs: 100, maxRetries: 5 });
+    const result = await retryWithBackoff(fn, {
+      baseDelayMs: 100,
+      rateLimitBaseDelayMs: 10,
+      maxRetries: 5,
+    });
     expect(result).toBe("ok");
     expect(fn).toHaveBeenCalledTimes(3);
   });
@@ -59,7 +63,9 @@ describe("retryWithBackoff", () => {
     const fn = vi.fn(async () => {
       throw Object.assign(new Error("rate limited"), { code: 429 });
     });
-    await expect(retryWithBackoff(fn, { maxRetries: 3, baseDelayMs: 10 })).rejects.toThrow();
+    await expect(
+      retryWithBackoff(fn, { maxRetries: 3, baseDelayMs: 10, rateLimitBaseDelayMs: 10 }),
+    ).rejects.toThrow();
     // attempts: 0,1,2,3 = 4 total (maxRetries+1)
     expect(fn).toHaveBeenCalledTimes(4);
   });

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -124,7 +124,7 @@ function buildLayer(
 }
 
 function mockFetch(impl: typeof fetch): void {
-  globalThis.fetch = vi.fn(impl) as unknown as typeof globalThis.fetch;
+  vi.stubGlobal("fetch", vi.fn(impl));
 }
 
 beforeEach(() => {
@@ -136,6 +136,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 // ─── Submission without GITHUB_TOKEN (local-only mode) ─────────────────────
@@ -199,6 +200,21 @@ describe("feedback service — cloud fallback", () => {
     if (result.kind === "cloud") {
       expect(result.id).toBe("cloud-test-id");
     }
+  });
+
+  it("falls back to local storage when the cloud endpoint fails", async () => {
+    mockFetch(
+      (async () => new Response("service unavailable", { status: 500 })) as unknown as typeof fetch,
+    );
+
+    const layer = buildLayer("");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      return yield* fb.submit(makeFeedback({ summary: "Cloud fallback failure test" }));
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.kind).toBe("local_only");
   });
 });
 

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -174,6 +174,34 @@ describe("feedback service — no GITHUB_TOKEN", () => {
   });
 });
 
+// ─── Cloud feedback fallback ───────────────────────────────────────────────
+
+describe("feedback service — cloud fallback", () => {
+  it("submits to the cloud endpoint when GITHUB_TOKEN is unset", async () => {
+    mockFetch(
+      vi.fn(async (url: string | URL | Request) => {
+        const u = url.toString();
+        if (u.includes("/v1/feedback")) {
+          return new Response(JSON.stringify({ id: "cloud-test-id" }), { status: 200 });
+        }
+        return new Response("unexpected", { status: 500 });
+      }) as unknown as typeof fetch,
+    );
+
+    const layer = buildLayer("");
+    const program = Effect.gen(function* () {
+      const fb = yield* FeedbackService;
+      return yield* fb.submit(makeFeedback({ summary: "Cloud fallback success test" }));
+    }).pipe(Effect.provide(layer));
+
+    const result = await Effect.runPromise(program);
+    expect(result.kind).toBe("cloud");
+    if (result.kind === "cloud") {
+      expect(result.id).toBe("cloud-test-id");
+    }
+  });
+});
+
 // ─── Opt-out ───────────────────────────────────────────────────────────────
 
 describe("feedback service — opt-out", () => {

--- a/bench/lockfile.test.ts
+++ b/bench/lockfile.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import {
+  acquireLock,
+  releaseLock,
+  readLockfile,
+  isProcessAlive,
+  findRunningEngineProcess,
+} from "../cli/lockfile.js";
+
+const tmpDir = path.join(os.tmpdir(), `prism-lockfile-test-${Date.now()}`);
+
+function lockPath(name: string): string {
+  return path.join(tmpDir, `${name}.lock`);
+}
+
+describe("lockfile", () => {
+  beforeEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  describe("isProcessAlive", () => {
+    it("returns true for the current process", () => {
+      expect(isProcessAlive(process.pid)).toBe(true);
+    });
+
+    it("returns false for a non-existent process", () => {
+      expect(isProcessAlive(99_999_999)).toBe(false);
+    });
+  });
+
+  describe("readLockfile", () => {
+    it("returns null when the lockfile does not exist", () => {
+      expect(readLockfile(lockPath("missing"))).toBeNull();
+    });
+
+    it("parses a valid lockfile", () => {
+      const file = lockPath("valid");
+      fs.writeFileSync(file, JSON.stringify({ pid: 1234, timestamp: Date.now() }));
+      const lock = readLockfile(file);
+      expect(lock).not.toBeNull();
+      expect(lock!.pid).toBe(1234);
+    });
+
+    it("returns null for malformed lockfile", () => {
+      const file = lockPath("malformed");
+      fs.writeFileSync(file, "not-json");
+      expect(readLockfile(file)).toBeNull();
+    });
+  });
+
+  describe("acquireLock / releaseLock", () => {
+    it("acquires and releases a lock", () => {
+      const file = lockPath("acquire");
+      const first = acquireLock(file);
+      expect(first.acquired).toBe(true);
+
+      const second = acquireLock(file);
+      expect(second.acquired).toBe(false);
+      if (!second.acquired) {
+        expect(second.pid).toBe(process.pid);
+      }
+
+      releaseLock(file);
+      expect(readLockfile(file)).toBeNull();
+    });
+  });
+
+  describe("findRunningEngineProcess", () => {
+    const originalPlatform = process.platform;
+
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    });
+
+    it("returns null on Windows", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      expect(findRunningEngineProcess()).toBeNull();
+    });
+
+    it("returns null when ps cannot be run", () => {
+      const spawner = () => ({ error: new Error("ENOENT") });
+      expect(findRunningEngineProcess(spawner)).toBeNull();
+    });
+
+    it("detects a bun run dev process", () => {
+      const pid = 42_000;
+      const stdout = [
+        "PID ARGS",
+        `${process.pid} bun run test`,
+        `${pid} bun run dev`,
+        `${pid + 1} bun install`,
+      ].join("\n");
+      const spawner = () => ({ stdout });
+
+      const found = findRunningEngineProcess(spawner);
+      expect(found).not.toBeNull();
+      expect(found!.pid).toBe(pid);
+      expect(found!.command).toContain("bun run dev");
+    });
+
+    it("ignores unrelated bun commands", () => {
+      const stdout = [
+        "PID ARGS",
+        `${process.pid} bun run test`,
+        `1234 bun install some-package`,
+        `1235 bun run lint`,
+      ].join("\n");
+      const spawner = () => ({ stdout });
+
+      expect(findRunningEngineProcess(spawner)).toBeNull();
+    });
+  });
+});

--- a/cli/dev.ts
+++ b/cli/dev.ts
@@ -18,17 +18,14 @@ export const devCommand = new Command("dev")
     const creds = readCredentials();
 
     if (!creds) {
-      console.error("Error: Registration required to start the trading agent.");
-      console.error("Run 'prism register' first to create an account.");
-      console.error("");
-      console.error("The trading agent requires a valid API key for:");
-      console.error("  - Subscription/tier management");
-      console.error("  - Referral tracking");
-      console.error("  - Platform fee processing");
-      process.exit(1);
+      console.warn(
+        "Warning: No Prism account found. Run 'prism register' to enable cloud features.",
+      );
+      console.warn("Continuing in local-only mode (paper trading works without registration).");
+      console.warn("");
     }
 
-    await pingInstall("dev_start", { userId: creds.userId });
+    await pingInstall("dev_start", creds ? { userId: creds.userId } : {});
 
     const lock = acquireLock();
     if (!lock.acquired) {

--- a/cli/feedback.ts
+++ b/cli/feedback.ts
@@ -84,12 +84,6 @@ function buildFeedback(opts: SubmitOptions): AgentFeedback {
     category: parseCategory(opts.category, "friction"),
     severity: parseSeverity(opts.severity, "medium"),
     summary: opts.summary,
-    context: {
-      prismVersion: "0.0.0",
-      installMethod: "unknown",
-      platform: "unknown",
-      runtime: "unknown",
-    },
   };
   if (opts.details) {
     Object.assign(feedback, { details: opts.details });

--- a/cli/feedback.ts
+++ b/cli/feedback.ts
@@ -57,8 +57,12 @@ function formatResult(result: FeedbackResult): string {
       return "ℹ Feedback is disabled. Run 'prism feedback enable' to re-enable.";
     case "local_only":
       return `✓ Feedback stored locally (id: ${result.localId}). Set GITHUB_TOKEN to file GitHub issues.`;
+    case "cloud":
+      return `✓ Feedback submitted to Prism cloud (id: ${result.id}).`;
     case "error":
       return `✗ Failed to submit feedback: ${result.error}`;
+    default:
+      return `✗ Unknown feedback result: ${String((result as { kind: string }).kind)}`;
   }
 }
 
@@ -125,10 +129,11 @@ export const feedbackCommand = new Command("feedback")
 Environment:
   GITHUB_TOKEN              Personal access token with 'repo' scope
   GITHUB_REPO               Target repo (default: irfndi/prism-liquidity-agent)
+  PRISM_API_URL             Cloud feedback endpoint override
   PRISM_FEEDBACK_OPT_OUT    Set to 'true' to disable automatic feedback
 
-Requires GITHUB_TOKEN for GitHub Issues filing. Without it, feedback is stored
-locally in ~/.config/prism/agent-id and logged but not uploaded.`,
+Requires GITHUB_TOKEN for GitHub Issues filing. Without it, Prism first tries the
+cloud /v1/feedback endpoint, then falls back to local storage.`,
   );
 
 feedbackCommand
@@ -163,7 +168,9 @@ feedbackCommand
         const recent = yield* feedback.list();
         console.log(`Agent feedback status:`);
         console.log(`  Opt-out:       ${optOut ? "yes" : "no"}`);
-        console.log(`  GITHUB_TOKEN:  ${config.githubToken ? "set" : "UNSET (local-only mode)"}`);
+        console.log(
+          `  GITHUB_TOKEN:  ${config.githubToken ? "set" : "UNSET (cloud/local fallback)"}`,
+        );
         console.log(`  GITHUB_REPO:   ${config.githubRepo}`);
         console.log(`  Total reports: ${recent.length}`);
         if (recent.length > 0) {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -37,6 +37,7 @@ program.addCommand(supportCommand);
 program.addCommand(devCommand);
 program.addCommand(backtestCommand);
 program.addCommand(updateCommand);
+updateCommand.alias("upgrade");
 program.addCommand(versionCommand);
 program.addCommand(feedbackCommand);
 program.addCommand(referralCommand);

--- a/cli/lockfile.ts
+++ b/cli/lockfile.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import os from "os";
+import { spawnSync } from "child_process";
 
 export const LOCKFILE_DIR = path.join(os.homedir(), ".config", "prism");
 export const LOCKFILE_PATH = path.join(LOCKFILE_DIR, "dev.lock");
@@ -54,6 +55,58 @@ export function isProcessAlive(pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+const EXCLUDED_PATTERNS = [
+  "bun install",
+  "bun add",
+  "bun remove",
+  "bun update",
+  "bun test",
+  "bun run test",
+  "bun run lint",
+  "bun run format",
+  "bun run setup",
+  "bun run backtest",
+];
+
+export function findRunningEngineProcess(
+  spawner: (
+    command: string,
+    args: ReadonlyArray<string>,
+    options: { encoding: "utf-8"; shell: false },
+  ) => { readonly stdout?: string | Buffer; readonly error?: Error } = spawnSync,
+): { readonly pid: number; readonly command: string } | null {
+  if (process.platform === "win32") return null;
+  try {
+    const result = spawner("ps", ["-eo", "pid,args"], { encoding: "utf-8", shell: false });
+    if (result.error || !result.stdout) return null;
+    const stdout =
+      typeof result.stdout === "string" ? result.stdout : result.stdout.toString("utf-8");
+    const lines = stdout.trim().split("\n").slice(1);
+    for (const line of lines) {
+      const trimmed = line.trim();
+      const match = trimmed.match(/^(\d+)\s+(.+)$/);
+      if (!match) continue;
+      const pidStr = match[1];
+      const args = match[2];
+      if (pidStr === undefined || args === undefined) continue;
+      const pid = Number.parseInt(pidStr, 10);
+      if (pid === process.pid) continue;
+      if (!args.includes("bun")) continue;
+      if (EXCLUDED_PATTERNS.some((pattern) => args.includes(pattern))) continue;
+      if (
+        args.includes("engine/index.ts") ||
+        args.includes("run dev") ||
+        args.includes("cli/dev.ts")
+      ) {
+        return { pid, command: args };
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }
 
 export function acquireLock(

--- a/cli/lockfile.ts
+++ b/cli/lockfile.ts
@@ -74,12 +74,16 @@ export function findRunningEngineProcess(
   spawner: (
     command: string,
     args: ReadonlyArray<string>,
-    options: { encoding: "utf-8"; shell: false },
+    options: { encoding: "utf-8"; shell: false; timeout?: number },
   ) => { readonly stdout?: string | Buffer; readonly error?: Error } = spawnSync,
 ): { readonly pid: number; readonly command: string } | null {
   if (process.platform === "win32") return null;
   try {
-    const result = spawner("ps", ["-eo", "pid,args"], { encoding: "utf-8", shell: false });
+    const result = spawner("ps", ["-eo", "pid,args"], {
+      encoding: "utf-8",
+      shell: false,
+      timeout: 3000,
+    });
     if (result.error || !result.stdout) return null;
     const stdout =
       typeof result.stdout === "string" ? result.stdout : result.stdout.toString("utf-8");

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -8,7 +8,7 @@ import type { PositionRecord } from "../engine/db-service.js";
 import { computeSummary, toJsonOutput, type PortfolioSummary } from "./portfolio.js";
 import { createLogger } from "../engine/logger.js";
 
-import { readLockfile, isProcessAlive } from "./lockfile.js";
+import { readLockfile, isProcessAlive, findRunningEngineProcess } from "./lockfile.js";
 
 const logger = createLogger("status-cli");
 
@@ -75,8 +75,10 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
           const hasDb = positions.length > 0 || recentAudit.length > 0;
           const lastActivityAt = recentAudit[0]?.timestamp ?? 0;
           const lock = readLockfile();
+          const runningProcess = findRunningEngineProcess();
           const running =
             (lock !== null && isProcessAlive(lock.pid)) ||
+            runningProcess !== null ||
             (hasDb && Date.now() - lastActivityAt < config.scanIntervalMs * 2);
 
           if (opts.json) {

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -8,6 +8,8 @@ import type { PositionRecord } from "../engine/db-service.js";
 import { computeSummary, toJsonOutput, type PortfolioSummary } from "./portfolio.js";
 import { createLogger } from "../engine/logger.js";
 
+import { readLockfile, isProcessAlive } from "./lockfile.js";
+
 const logger = createLogger("status-cli");
 
 export interface StatusJsonOutput {
@@ -72,7 +74,10 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
           const activePositions = positions.filter((p) => p.paperExitedAt === null);
           const hasDb = positions.length > 0 || recentAudit.length > 0;
           const lastActivityAt = recentAudit[0]?.timestamp ?? 0;
-          const running = hasDb && Date.now() - lastActivityAt < config.scanIntervalMs * 2;
+          const lock = readLockfile();
+          const running =
+            (lock !== null && isProcessAlive(lock.pid)) ||
+            (hasDb && Date.now() - lastActivityAt < config.scanIntervalMs * 2);
 
           if (opts.json) {
             const json: StatusJsonOutput = {

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -187,7 +187,7 @@ export const updateCommand = new Command("update")
 
         console.log("Running test suite smoke test...");
         try {
-          execSync("bunx vitest run --reporter=default", { cwd: extractedDir, stdio: "inherit" });
+          execSync("bunx --bun vitest run", { cwd: extractedDir, stdio: "inherit" });
           console.log("✓ Test suite smoke test passed");
         } catch {
           console.error("⚠ Test suite smoke test failed — continuing anyway");

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -203,11 +203,24 @@ export const updateCommand = new Command("update")
       const backupRoot = join(installRoot, "..", `.prism-update-backup`);
       const currentBackup = join(installRoot, "..", `.prism-prev-${installName}`);
 
+      const userFilesToPreserve = [".env", "prism.db", "logs"];
+
       try {
         if (existsSync(stagedRoot)) {
           rmSync(stagedRoot, { recursive: true, force: true });
         }
         execSync(`cp -R "${extractedDir}/." "${stagedRoot}/"`, { stdio: "inherit" });
+
+        for (const file of userFilesToPreserve) {
+          const source = join(installRoot, file);
+          const dest = join(stagedRoot, file);
+          if (existsSync(source)) {
+            if (existsSync(dest)) {
+              rmSync(dest, { recursive: true, force: true });
+            }
+            execSync(`cp -R "${source}" "${dest}"`, { stdio: "inherit" });
+          }
+        }
 
         if (existsSync(backupRoot)) {
           rmSync(backupRoot, { recursive: true, force: true });

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { createWriteStream, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { pipeline } from "stream/promises";
 import { dirname, join, resolve } from "path";
@@ -143,7 +143,7 @@ export const updateCommand = new Command("update")
       console.log("✓ SHA-256 checksum verified");
 
       console.log("Extracting tarball...");
-      execSync(`tar -xzf "${tarballPath}" -C "${workDir}"`, { stdio: "inherit" });
+      execFileSync("tar", ["-xzf", tarballPath, "-C", workDir], { stdio: "inherit" });
 
       // R2 tarballs extract at top level; legacy ones had a subdir.
       const candidateRoots = [workDir, join(workDir, "prism-liquidity-agent")];
@@ -168,7 +168,7 @@ export const updateCommand = new Command("update")
         );
       }
 
-      execSync("bun install", { cwd: extractedDir, stdio: "inherit" });
+      execFileSync("bun", ["install"], { cwd: extractedDir, stdio: "inherit" });
 
       // === Pre-apply smoke tests ===
       const skipSmokeTest = options.skipSmokeTest as boolean;
@@ -178,7 +178,7 @@ export const updateCommand = new Command("update")
       } else {
         console.log("Running TypeScript smoke test...");
         try {
-          execSync("bunx tsc --noEmit", { cwd: extractedDir, stdio: "inherit" });
+          execFileSync("bunx", ["tsc", "--noEmit"], { cwd: extractedDir, stdio: "inherit" });
           console.log("✓ TypeScript smoke test passed");
         } catch {
           console.error("⚠ TypeScript smoke test failed — continuing anyway");
@@ -187,7 +187,7 @@ export const updateCommand = new Command("update")
 
         console.log("Running test suite smoke test...");
         try {
-          execSync("bunx --bun vitest run", { cwd: extractedDir, stdio: "inherit" });
+          execFileSync("bunx", ["--bun", "vitest", "run"], { cwd: extractedDir, stdio: "inherit" });
           console.log("✓ Test suite smoke test passed");
         } catch {
           console.error("⚠ Test suite smoke test failed — continuing anyway");
@@ -209,7 +209,7 @@ export const updateCommand = new Command("update")
         if (existsSync(stagedRoot)) {
           rmSync(stagedRoot, { recursive: true, force: true });
         }
-        execSync(`cp -R "${extractedDir}/." "${stagedRoot}/"`, { stdio: "inherit" });
+        execFileSync("cp", ["-R", `${extractedDir}/.`, `${stagedRoot}/`], { stdio: "inherit" });
 
         for (const file of userFilesToPreserve) {
           const source = join(installRoot, file);
@@ -218,7 +218,7 @@ export const updateCommand = new Command("update")
             if (existsSync(dest)) {
               rmSync(dest, { recursive: true, force: true });
             }
-            execSync(`cp -R "${source}" "${dest}"`, { stdio: "inherit" });
+            execFileSync("cp", ["-R", source, dest], { stdio: "inherit" });
           }
         }
 
@@ -226,29 +226,33 @@ export const updateCommand = new Command("update")
           rmSync(backupRoot, { recursive: true, force: true });
         }
 
-        execSync(`mv "${installRoot}" "${currentBackup}"`, { stdio: "inherit" });
+        execFileSync("mv", [installRoot, currentBackup], { stdio: "inherit" });
         try {
-          execSync(`mv "${stagedRoot}" "${installRoot}"`, { stdio: "inherit" });
+          execFileSync("mv", [stagedRoot, installRoot], { stdio: "inherit" });
         } catch (swapErr) {
           if (existsSync(currentBackup) && !existsSync(installRoot)) {
-            execSync(`mv "${currentBackup}" "${installRoot}"`);
+            execFileSync("mv", [currentBackup, installRoot]);
           }
           throw swapErr;
         }
         if (existsSync(currentBackup)) {
-          execSync(`mv "${currentBackup}" "${backupRoot}"`, { stdio: "inherit" });
+          execFileSync("mv", [currentBackup, backupRoot], { stdio: "inherit" });
         }
 
         // Post-apply health check
         console.log("Running post-apply health check...");
         try {
-          execSync("bunx tsc --noEmit", { cwd: installRoot, stdio: "inherit", timeout: 30_000 });
+          execFileSync("bunx", ["tsc", "--noEmit"], {
+            cwd: installRoot,
+            stdio: "inherit",
+            timeout: 30_000,
+          });
         } catch (healthErr) {
           console.error("Post-apply health check failed — rolling back");
           try {
             rmSync(installRoot, { recursive: true, force: true });
             if (existsSync(backupRoot)) {
-              execSync(`mv "${backupRoot}" "${installRoot}"`, { stdio: "inherit" });
+              execFileSync("mv", [backupRoot, installRoot], { stdio: "inherit" });
             }
           } catch (rollbackErr) {
             throw new UpdateAbort(

--- a/cloudflare/migrations/0010_feedback.sql
+++ b/cloudflare/migrations/0010_feedback.sql
@@ -1,0 +1,25 @@
+-- Migration: Agent feedback storage for GitHub-independent submissions
+-- Created: 2026-07-07
+
+CREATE TABLE IF NOT EXISTS feedback (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    category TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    details TEXT,
+    related_files TEXT,
+    context_json TEXT,
+    prism_version TEXT,
+    platform TEXT,
+    install_method TEXT,
+    runtime TEXT,
+    hash TEXT NOT NULL,
+    github_issue_number INTEGER,
+    github_issue_url TEXT,
+    reported_at INTEGER NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_agent_reported ON feedback(agent_id, reported_at);
+CREATE INDEX IF NOT EXISTS idx_feedback_hash ON feedback(hash);

--- a/cloudflare/workers/api/feedback.test.ts
+++ b/cloudflare/workers/api/feedback.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { env, createExecutionContext } from "cloudflare:test";
+import worker, { type Env } from "./index";
+
+const testEnv = env as unknown as Env;
+
+function buildRequest(method: string, path: string, body?: unknown, token?: string): Request {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+  return new Request(`https://example.com${path}`, init);
+}
+
+describe("Feedback API", () => {
+  beforeAll(async () => {
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS feedback (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        category TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        details TEXT,
+        related_files TEXT,
+        context_json TEXT,
+        prism_version TEXT,
+        platform TEXT,
+        install_method TEXT,
+        runtime TEXT,
+        hash TEXT NOT NULL,
+        github_issue_number INTEGER,
+        github_issue_url TEXT,
+        reported_at INTEGER NOT NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+    ).run();
+    await env.DB.prepare(
+      `CREATE INDEX IF NOT EXISTS idx_feedback_agent_reported ON feedback(agent_id, reported_at)`,
+    ).run();
+    await env.DB.prepare(`CREATE INDEX IF NOT EXISTS idx_feedback_hash ON feedback(hash)`).run();
+  });
+
+  beforeEach(async () => {
+    await env.DB.prepare("DELETE FROM feedback").run();
+  });
+
+  describe("POST /v1/feedback", () => {
+    it("stores valid feedback and returns id", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/feedback", {
+        id: "fb-uuid-1",
+        agentId: "agent-abc",
+        category: "suggestion",
+        severity: "medium",
+        summary: "Add dark mode",
+        details: "It would be easier on the eyes.",
+        relatedFiles: ["cli/index.ts"],
+        context: {
+          prismVersion: "0.0.20",
+          platform: "darwin",
+          installMethod: "curl",
+          runtime: "bun 1.4.0",
+        },
+        hash: "deadbeef",
+        reportedAt: Date.now(),
+      });
+      const response = await worker.fetch(request, testEnv, ctx);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { id: string };
+      expect(body.id).toBe("fb-uuid-1");
+
+      const rows = await env.DB.prepare("SELECT summary FROM feedback WHERE id = ?")
+        .bind("fb-uuid-1")
+        .all();
+      expect(rows.results).toHaveLength(1);
+    });
+
+    it("returns 400 when category is invalid", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/feedback", {
+        id: "fb-uuid-2",
+        agentId: "agent-abc",
+        category: "complaint",
+        severity: "low",
+        summary: "Bad UX",
+      });
+      const response = await worker.fetch(request, testEnv, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when severity is invalid", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/feedback", {
+        id: "fb-uuid-3",
+        agentId: "agent-abc",
+        category: "praise",
+        severity: "critical",
+        summary: "Great work",
+      });
+      const response = await worker.fetch(request, testEnv, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when summary is missing", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/feedback", {
+        id: "fb-uuid-4",
+        agentId: "agent-abc",
+        category: "observation",
+        severity: "low",
+      });
+      const response = await worker.fetch(request, testEnv, ctx);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 200 on duplicate id (idempotency)", async () => {
+      const ctx = createExecutionContext();
+      const payload = {
+        id: "fb-dup",
+        agentId: "agent-abc",
+        category: "friction",
+        severity: "high",
+        summary: "Setup is slow",
+      };
+      const first = await worker.fetch(buildRequest("POST", "/v1/feedback", payload), testEnv, ctx);
+      expect(first.status).toBe(200);
+
+      const second = await worker.fetch(
+        buildRequest("POST", "/v1/feedback", payload),
+        testEnv,
+        ctx,
+      );
+      expect(second.status).toBe(200);
+      const body = (await second.json()) as { id: string };
+      expect(body.id).toBe("fb-dup");
+    });
+  });
+
+  describe("GET /v1/feedback", () => {
+    const adminKey = "test-admin-feedback-key";
+
+    beforeEach(async () => {
+      await env.DB.prepare("DELETE FROM feedback").run();
+      await env.DB.prepare(
+        `INSERT INTO feedback (id, agent_id, category, severity, summary, hash, reported_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind("fb-admin-1", "agent-x", "suggestion", "low", "More docs", "hash1", Date.now())
+        .run();
+    });
+
+    it("returns 401 without admin token", async () => {
+      const ctx = createExecutionContext();
+      const response = await worker.fetch(buildRequest("GET", "/v1/feedback"), testEnv, ctx);
+      expect(response.status).toBe(401);
+    });
+
+    it("returns feedback list with admin token", async () => {
+      const ctx = createExecutionContext();
+      const adminEnv = { ...testEnv, ADMIN_API_KEY: adminKey } as Env;
+      const response = await worker.fetch(
+        buildRequest("GET", "/v1/feedback", undefined, adminKey),
+        adminEnv,
+        ctx,
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { feedback: unknown[] };
+      expect(body.feedback.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/cloudflare/workers/api/feedback.test.ts
+++ b/cloudflare/workers/api/feedback.test.ts
@@ -118,6 +118,35 @@ describe("Feedback API", () => {
       expect(response.status).toBe(400);
     });
 
+    it("returns 400 when hash is missing", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/feedback", {
+        id: "fb-uuid-5",
+        agentId: "agent-abc",
+        category: "observation",
+        severity: "low",
+        summary: "Missing hash field",
+      });
+      const response = await worker.fetch(request, testEnv, ctx);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toContain("hash");
+    });
+
+    it("returns 400 when hash is not a string", async () => {
+      const ctx = createExecutionContext();
+      const request = buildRequest("POST", "/v1/feedback", {
+        id: "fb-uuid-6",
+        agentId: "agent-abc",
+        category: "observation",
+        severity: "low",
+        summary: "Non-string hash",
+        hash: 12345,
+      });
+      const response = await worker.fetch(request, testEnv, ctx);
+      expect(response.status).toBe(400);
+    });
+
     it("returns 200 on duplicate id (idempotency)", async () => {
       const ctx = createExecutionContext();
       const payload = {
@@ -126,6 +155,7 @@ describe("Feedback API", () => {
         category: "friction",
         severity: "high",
         summary: "Setup is slow",
+        hash: "aabbccdd",
       };
       const first = await worker.fetch(buildRequest("POST", "/v1/feedback", payload), testEnv, ctx);
       expect(first.status).toBe(200);

--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -648,6 +648,9 @@ app.post("/v1/feedback", async (c) => {
   if (!body.summary || typeof body.summary !== "string") {
     return c.json({ error: "summary is required" }, 400);
   }
+  if (!body.hash || typeof body.hash !== "string") {
+    return c.json({ error: "hash is required" }, 400);
+  }
 
   // Rate limit: 10 feedback submissions per IP per hour.
   if (CACHE) {
@@ -681,16 +684,20 @@ app.post("/v1/feedback", async (c) => {
         context.platform ?? null,
         context.installMethod ?? null,
         context.runtime ?? null,
-        body.hash ?? null,
+        body.hash,
         body.reportedAt ?? Date.now(),
       )
       .run();
 
-    if (CACHE) {
-      const rateKey = `rate_limit:feedback:${clientIp}`;
-      const rateData = await CACHE.get(rateKey);
-      const count = rateData ? parseInt(rateData, 10) : 0;
-      await CACHE.put(rateKey, String(count + 1), { expirationTtl: 3600 });
+    try {
+      if (CACHE) {
+        const rateKey = `rate_limit:feedback:${clientIp}`;
+        const rateData = await CACHE.get(rateKey);
+        const count = rateData ? parseInt(rateData, 10) : 0;
+        await CACHE.put(rateKey, String(count + 1), { expirationTtl: 3600 });
+      }
+    } catch (kvErr) {
+      console.warn("Failed to update rate-limit counter (non-fatal):", kvErr);
     }
 
     return c.json({ id: body.id });

--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -602,6 +602,144 @@ app.post("/v1/issue", async (c) => {
   }
 });
 
+// ── Agent Feedback ───────────────────────────────────────────────────────────
+// Stores agent/user feedback in D1 when no GitHub token is configured.
+
+const VALID_FEEDBACK_CATEGORIES = new Set(["friction", "suggestion", "observation", "praise"]);
+const VALID_FEEDBACK_SEVERITIES = new Set(["low", "medium", "high"]);
+
+app.post("/v1/feedback", async (c) => {
+  const { DB, CACHE } = c.env;
+  const clientIp = c.req.header("CF-Connecting-IP") || "unknown";
+
+  const body = (await c.req.json().catch(() => ({}))) as {
+    id?: string;
+    agentId?: string;
+    category?: string;
+    severity?: string;
+    summary?: string;
+    details?: string;
+    relatedFiles?: string[];
+    context?: {
+      prismVersion?: string;
+      platform?: string;
+      installMethod?: string;
+      runtime?: string;
+    };
+    hash?: string;
+    reportedAt?: number;
+  };
+
+  if (!body.id || typeof body.id !== "string") {
+    return c.json({ error: "id is required" }, 400);
+  }
+  if (!body.agentId || typeof body.agentId !== "string") {
+    return c.json({ error: "agentId is required" }, 400);
+  }
+  if (!body.category || !VALID_FEEDBACK_CATEGORIES.has(body.category)) {
+    return c.json(
+      { error: "category must be one of: friction, suggestion, observation, praise" },
+      400,
+    );
+  }
+  if (!body.severity || !VALID_FEEDBACK_SEVERITIES.has(body.severity)) {
+    return c.json({ error: "severity must be one of: low, medium, high" }, 400);
+  }
+  if (!body.summary || typeof body.summary !== "string") {
+    return c.json({ error: "summary is required" }, 400);
+  }
+
+  // Rate limit: 10 feedback submissions per IP per hour.
+  if (CACHE) {
+    const rateKey = `rate_limit:feedback:${clientIp}`;
+    const rateData = await CACHE.get(rateKey);
+    const count = rateData ? parseInt(rateData, 10) : 0;
+    if (count >= 10) {
+      return c.json({ error: "Rate limit exceeded. Try again later." }, 429);
+    }
+  }
+
+  try {
+    const context = body.context ?? {};
+    await DB.prepare(
+      `INSERT OR IGNORE INTO feedback (
+        id, agent_id, category, severity, summary, details, related_files,
+        context_json, prism_version, platform, install_method, runtime,
+        hash, reported_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        body.id,
+        body.agentId,
+        body.category,
+        body.severity,
+        body.summary,
+        body.details ?? null,
+        body.relatedFiles ? JSON.stringify(body.relatedFiles) : null,
+        JSON.stringify(context),
+        context.prismVersion ?? null,
+        context.platform ?? null,
+        context.installMethod ?? null,
+        context.runtime ?? null,
+        body.hash ?? null,
+        body.reportedAt ?? Date.now(),
+      )
+      .run();
+
+    if (CACHE) {
+      const rateKey = `rate_limit:feedback:${clientIp}`;
+      const rateData = await CACHE.get(rateKey);
+      const count = rateData ? parseInt(rateData, 10) : 0;
+      await CACHE.put(rateKey, String(count + 1), { expirationTtl: 3600 });
+    }
+
+    return c.json({ id: body.id });
+  } catch (err) {
+    console.error("Failed to store feedback:", err);
+    return c.json({ error: "Failed to store feedback" }, 500);
+  }
+});
+
+app.get("/v1/feedback", async (c) => {
+  const { DB } = c.env;
+
+  const authHeader = c.req.header("Authorization");
+  const match = authHeader?.match(/^Bearer\s+(.+)$/);
+  const token = match?.[1];
+
+  if (!token || !c.env.ADMIN_API_KEY || !constantTimeEqual(token, c.env.ADMIN_API_KEY)) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const category = c.req.query("category");
+  const agentId = c.req.query("agentId");
+  const rawLimit = c.req.query("limit");
+  let limit = rawLimit ? Number.parseInt(rawLimit, 10) : 50;
+  if (!Number.isFinite(limit) || limit < 1) limit = 50;
+  if (limit > 200) limit = 200;
+
+  try {
+    let sql = "SELECT * FROM feedback WHERE 1=1";
+    const params: (string | number)[] = [];
+
+    if (category) {
+      sql += " AND category = ?";
+      params.push(category);
+    }
+    if (agentId) {
+      sql += " AND agent_id = ?";
+      params.push(agentId);
+    }
+    sql += " ORDER BY reported_at DESC LIMIT ?";
+    params.push(limit);
+
+    const result = await DB.prepare(sql).bind(...params).all();
+    return c.json({ feedback: result.results ?? [] });
+  } catch {
+    return c.json({ error: "Failed to fetch feedback" }, 500);
+  }
+});
+
 // ── Error Reporting ──────────────────────────────────────────────────────────
 // Privacy-first error telemetry (opt-in, no auth required for ingestion)
 

--- a/engine/adapter-retry.ts
+++ b/engine/adapter-retry.ts
@@ -20,6 +20,15 @@ export function isRetriableError(err: unknown): boolean {
   return false;
 }
 
+function isRateLimitError(err: unknown): boolean {
+  if (hasCode(err) && err.code === 429) return true;
+  if (hasMessage(err)) {
+    const msg = err.message.toLowerCase();
+    return msg.includes("429") || msg.includes("rate limit") || msg.includes("too many requests");
+  }
+  return false;
+}
+
 // ─── RPC / network error classifier ──────────────────────────────────────────
 // Returns true for errors that indicate transient RPC or network unavailability.
 // These should trip the circuit breaker; business-logic / validation errors should not.
@@ -67,16 +76,23 @@ export interface RetryOptions {
   readonly maxRetries?: number;
   readonly baseDelayMs?: number;
   readonly maxDelayMs?: number;
+  readonly rateLimitBaseDelayMs?: number;
 }
 
-const DEFAULT_RETRY_OPTIONS: Required<RetryOptions> = {
+const DEFAULT_RETRY_OPTIONS: Required<Omit<RetryOptions, "rateLimitBaseDelayMs">> & {
+  readonly rateLimitBaseDelayMs: number;
+} = {
   maxRetries: 5,
   baseDelayMs: 1000,
   maxDelayMs: 30000,
+  rateLimitBaseDelayMs: 5_000,
 };
 
 export async function retryWithBackoff<T>(fn: () => Promise<T>, opts?: RetryOptions): Promise<T> {
-  const { maxRetries, baseDelayMs, maxDelayMs } = { ...DEFAULT_RETRY_OPTIONS, ...opts };
+  const { maxRetries, baseDelayMs, maxDelayMs, rateLimitBaseDelayMs } = {
+    ...DEFAULT_RETRY_OPTIONS,
+    ...opts,
+  };
   let lastError: unknown;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -86,7 +102,8 @@ export async function retryWithBackoff<T>(fn: () => Promise<T>, opts?: RetryOpti
       if (attempt >= maxRetries || !isRetriableError(err)) {
         throw lastError;
       }
-      const exponentialDelay = Math.min(maxDelayMs, baseDelayMs * 2 ** attempt);
+      const effectiveBase = isRateLimitError(err) ? rateLimitBaseDelayMs : baseDelayMs;
+      const exponentialDelay = Math.min(maxDelayMs, effectiveBase * 2 ** attempt);
       const jitter = Math.random() * exponentialDelay * 0.5;
       const delay = Math.floor(exponentialDelay + jitter);
       logger.warn(

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -417,53 +417,65 @@ export const AdapterLive = Layer.effect(
       JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN: 1.0,
     };
 
-    function fetchTokenPrices(
-      mints: ReadonlyArray<string>,
-    ): Effect.Effect<Record<string, number>, unknown> {
+    const PRICE_CACHE_TTL_MS = 60_000;
+    const COINGECKO_BATCH_SIZE = 25;
+    const COINGECKO_DELAY_MS = 1_200;
+
+    interface PriceCacheEntry {
+      readonly price: number;
+      readonly fetchedAt: number;
+    }
+
+    const priceCache = new Map<string, PriceCacheEntry>();
+
+    function getCachedPrice(mint: string): number | undefined {
+      const entry = priceCache.get(mint);
+      if (!entry) return undefined;
+      if (Date.now() - entry.fetchedAt > PRICE_CACHE_TTL_MS) {
+        priceCache.delete(mint);
+        return undefined;
+      }
+      return entry.price;
+    }
+
+    function setCachedPrice(mint: string, price: number): void {
+      priceCache.set(mint, { price, fetchedAt: Date.now() });
+    }
+
+    function fetchJupiterPrices(
+      missing: ReadonlyArray<string>,
+    ): Effect.Effect<Record<string, number>, never> {
+      if (missing.length === 0) return Effect.succeed({});
       return Effect.gen(function* () {
-        const prices: Record<string, number> = {};
-        const missing: string[] = [];
-
-        for (const mint of mints) {
-          if (fallbackPrices[mint]) {
-            prices[mint] = fallbackPrices[mint];
-          } else {
-            missing.push(mint);
+        const ids = missing.join(",");
+        const res = yield* Effect.tryPromise(() =>
+          fetch(`https://price.jup.ag/v6/price?ids=${ids}`),
+        );
+        if (!res.ok) return {};
+        const json = (yield* Effect.tryPromise(() => res.json())) as {
+          data?: Record<string, { price: number }>;
+        };
+        const result: Record<string, number> = {};
+        for (const mint of missing) {
+          const price = json.data?.[mint]?.price;
+          if (price != null) {
+            result[mint] = price;
+            setCachedPrice(mint, price);
           }
         }
+        return result;
+      }).pipe(Effect.catchAll(() => Effect.succeed({})));
+    }
 
-        if (missing.length === 0) return prices;
-
-        // Try Jupiter Price API
-        try {
-          const ids = missing.join(",");
-          const res = yield* Effect.tryPromise(() =>
-            fetch(`https://price.jup.ag/v6/price?ids=${ids}`),
-          );
-          if (res.ok) {
-            const json = (yield* Effect.tryPromise(() => res.json())) as {
-              data?: Record<string, { price: number }>;
-            };
-            const stillMissing: string[] = [];
-            for (const mint of missing) {
-              const price = json.data?.[mint]?.price;
-              if (price != null) {
-                prices[mint] = price;
-              } else {
-                stillMissing.push(mint);
-              }
-            }
-            missing.length = 0;
-            missing.push(...stillMissing);
-            if (missing.length === 0) return prices;
-          }
-        } catch {
-          // fall through
-        }
-
-        // Fallback to CoinGecko
-        try {
-          const ids = missing.join(",");
+    function fetchCoinGeckoPrices(
+      missing: ReadonlyArray<string>,
+    ): Effect.Effect<Record<string, number>, never> {
+      if (missing.length === 0) return Effect.succeed({});
+      return Effect.gen(function* () {
+        const result: Record<string, number> = {};
+        for (let i = 0; i < missing.length; i += COINGECKO_BATCH_SIZE) {
+          const batch = missing.slice(i, i + COINGECKO_BATCH_SIZE);
+          const ids = batch.join(",");
           const res = yield* Effect.tryPromise(() =>
             fetch(
               `https://api.coingecko.com/api/v3/simple/token_price/solana?contract_addresses=${ids}&vs_currencies=usd`,
@@ -474,18 +486,61 @@ export const AdapterLive = Layer.effect(
               string,
               { usd: number }
             >;
-            for (const mint of missing) {
-              prices[mint] = json[mint]?.usd ?? 0;
+            for (const mint of batch) {
+              const price = json[mint]?.usd;
+              if (price != null) {
+                result[mint] = price;
+                setCachedPrice(mint, price);
+              }
             }
-            return prices;
           }
-        } catch {
-          // fall through
+          if (i + COINGECKO_BATCH_SIZE < missing.length) {
+            yield* Effect.sleep(COINGECKO_DELAY_MS);
+          }
+        }
+        return result;
+      }).pipe(Effect.catchAll(() => Effect.succeed({})));
+    }
+
+    function fetchTokenPrices(
+      mints: ReadonlyArray<string>,
+    ): Effect.Effect<Record<string, number>, unknown> {
+      return Effect.gen(function* () {
+        const prices: Record<string, number> = {};
+        const missing: string[] = [];
+
+        for (const mint of mints) {
+          const cached = getCachedPrice(mint);
+          if (cached !== undefined) {
+            prices[mint] = cached;
+          } else if (fallbackPrices[mint]) {
+            prices[mint] = fallbackPrices[mint];
+            setCachedPrice(mint, fallbackPrices[mint]);
+          } else {
+            missing.push(mint);
+          }
         }
 
+        if (missing.length === 0) return prices;
+
+        const jupiterPrices = yield* fetchJupiterPrices(missing);
+        const stillMissing: string[] = [];
         for (const mint of missing) {
-          prices[mint] = 0;
+          const price = jupiterPrices[mint];
+          if (price != null) {
+            prices[mint] = price;
+          } else {
+            stillMissing.push(mint);
+          }
         }
+
+        if (stillMissing.length > 0) {
+          const cgPrices = yield* fetchCoinGeckoPrices(stillMissing);
+          for (const mint of stillMissing) {
+            prices[mint] = cgPrices[mint] ?? 0;
+          }
+        }
+
         return prices;
       });
     }
@@ -522,38 +577,17 @@ export const AdapterLive = Layer.effect(
           (mintYInfo.value?.data as { parsed?: { info?: { decimals?: number } } })?.parsed?.info
             ?.decimals ?? 6;
 
-        const vaultX = yield* Effect.tryPromise(() =>
-          rpcCall(() =>
-            connection.getTokenAccountsByOwner(pubkey, {
-              mint: lbPair.tokenXMint,
-            }),
+        const [balX, balY] = yield* Effect.all([
+          Effect.tryPromise(() =>
+            rpcCall(() => connection.getTokenAccountBalance(lbPair.reserveX)),
           ),
-        );
-        const vaultY = yield* Effect.tryPromise(() =>
-          rpcCall(() =>
-            connection.getTokenAccountsByOwner(pubkey, {
-              mint: lbPair.tokenYMint,
-            }),
+          Effect.tryPromise(() =>
+            rpcCall(() => connection.getTokenAccountBalance(lbPair.reserveY)),
           ),
-        );
+        ]);
 
-        let reserveX = 0;
-        let reserveY = 0;
-
-        if (vaultX.value.length > 0 && vaultX.value[0]) {
-          const firstVault = vaultX.value[0] as { pubkey: PublicKey };
-          const bal = yield* Effect.tryPromise(() =>
-            rpcCall(() => connection.getTokenAccountBalance(firstVault.pubkey)),
-          );
-          reserveX = Number(bal.value.amount) / Math.pow(10, tokenXDecimals);
-        }
-        if (vaultY.value.length > 0 && vaultY.value[0]) {
-          const firstVault = vaultY.value[0] as { pubkey: PublicKey };
-          const bal = yield* Effect.tryPromise(() =>
-            rpcCall(() => connection.getTokenAccountBalance(firstVault.pubkey)),
-          );
-          reserveY = Number(bal.value.amount) / Math.pow(10, tokenYDecimals);
-        }
+        const reserveX = Number(balX.value.amount) / Math.pow(10, tokenXDecimals);
+        const reserveY = Number(balY.value.amount) / Math.pow(10, tokenYDecimals);
 
         const prices = yield* fetchTokenPrices([tokenXMint, tokenYMint]);
         const priceX = prices[tokenXMint] || 0;
@@ -780,121 +814,117 @@ export const AdapterLive = Layer.effect(
             );
           }
 
-          try {
-            const dlmm = yield* Effect.tryPromise(() => getDlmm(poolAddress));
-            const pool = yield* api.getPoolState(poolAddress);
+          const dlmm = yield* Effect.tryPromise(() => getDlmm(poolAddress));
+          const pool = yield* api.getPoolState(poolAddress);
 
-            const prices = yield* fetchTokenPrices([pool.tokenX, pool.tokenY]);
-            const priceX = prices[pool.tokenX] ?? 0;
-            const priceY = prices[pool.tokenY] ?? 0;
+          const prices = yield* fetchTokenPrices([pool.tokenX, pool.tokenY]);
+          const priceX = prices[pool.tokenX] ?? 0;
+          const priceY = prices[pool.tokenY] ?? 0;
 
-            if (!priceX || !priceY) {
-              return yield* Effect.fail(
-                new AdapterError({
-                  message: "Could not fetch token prices",
-                  poolAddress,
-                }),
-              );
-            }
-
-            const halfUsd = positionSizeUsd / 2;
-            const tokenXDecimals = yield* getTokenMeta(pool.tokenX).pipe(
-              Effect.map((m) => m.decimals),
-            );
-            const tokenYDecimals = yield* getTokenMeta(pool.tokenY).pipe(
-              Effect.map((m) => m.decimals),
-            );
-
-            let totalXAmount = new BN(
-              Math.floor((halfUsd / priceX) * Math.pow(10, tokenXDecimals)),
-            );
-            let totalYAmount = new BN(
-              Math.floor((halfUsd / priceY) * Math.pow(10, tokenYDecimals)),
-            );
-
-            // Check balances
-            const balanceX = yield* getTokenBalance(pool.tokenX);
-            const balanceY = yield* getTokenBalance(pool.tokenY);
-            let nativeSolBalance = 0n;
-            if (pool.tokenX === SOL_MINT || pool.tokenY === SOL_MINT) {
-              nativeSolBalance = BigInt(
-                yield* Effect.tryPromise(() =>
-                  rpcCall(() => connection.getBalance(wallet.publicKey)),
-                ),
-              );
-            }
-
-            const maxX = pool.tokenX === SOL_MINT ? nativeSolBalance : balanceX;
-            if (BigInt(totalXAmount.toString()) > maxX) {
-              totalXAmount = new BN(maxX.toString());
-            }
-
-            const maxY = pool.tokenY === SOL_MINT ? nativeSolBalance : balanceY;
-            if (BigInt(totalYAmount.toString()) > maxY) {
-              totalYAmount = new BN(maxY.toString());
-            }
-
-            if (totalXAmount.eq(new BN(0)) || totalYAmount.eq(new BN(0))) {
-              return yield* Effect.fail(
-                new AdapterError({
-                  message: "Insufficient token balance",
-                  poolAddress,
-                }),
-              );
-            }
-
-            const positionKeypair = new Keypair();
-            const strategy = {
-              minBinId: lowerBinId,
-              maxBinId: upperBinId,
-              strategyType: 0,
-            };
-
-            const tx = yield* Effect.tryPromise(() =>
-              dlmm.initializePositionAndAddLiquidityByStrategy({
-                positionPubKey: positionKeypair.publicKey,
-                totalXAmount,
-                totalYAmount,
-                strategy,
-                user: wallet.publicKey,
-                slippage: 50,
+          if (!priceX || !priceY) {
+            return yield* Effect.fail(
+              new AdapterError({
+                message: "Could not fetch token prices",
+                poolAddress,
               }),
             );
+          }
 
-            tx.feePayer = wallet.publicKey;
-            const { blockhash } = yield* Effect.tryPromise(() =>
-              rpcGated(() => connection.getLatestBlockhash()),
-            );
-            tx.recentBlockhash = blockhash;
-            tx.sign(wallet, positionKeypair);
+          const halfUsd = positionSizeUsd / 2;
+          const tokenXDecimals = yield* getTokenMeta(pool.tokenX).pipe(
+            Effect.map((m) => m.decimals),
+          );
+          const tokenYDecimals = yield* getTokenMeta(pool.tokenY).pipe(
+            Effect.map((m) => m.decimals),
+          );
 
-            const signature = yield* Effect.tryPromise(() =>
-              rpcGated(() =>
-                connection.sendRawTransaction(tx.serialize(), {
-                  skipPreflight: false,
-                  preflightCommitment: "confirmed",
-                }),
+          let totalXAmount = new BN(Math.floor((halfUsd / priceX) * Math.pow(10, tokenXDecimals)));
+          let totalYAmount = new BN(Math.floor((halfUsd / priceY) * Math.pow(10, tokenYDecimals)));
+
+          // Check balances
+          const balanceX = yield* getTokenBalance(pool.tokenX);
+          const balanceY = yield* getTokenBalance(pool.tokenY);
+          let nativeSolBalance = 0n;
+          if (pool.tokenX === SOL_MINT || pool.tokenY === SOL_MINT) {
+            nativeSolBalance = BigInt(
+              yield* Effect.tryPromise(() =>
+                rpcCall(() => connection.getBalance(wallet.publicKey)),
               ),
             );
+          }
 
-            yield* Effect.tryPromise(() =>
-              rpcGated(() => connection.confirmTransaction(signature, "confirmed")),
-            );
+          const maxX = pool.tokenX === SOL_MINT ? nativeSolBalance : balanceX;
+          if (BigInt(totalXAmount.toString()) > maxX) {
+            totalXAmount = new BN(maxX.toString());
+          }
 
-            return {
-              positionPubKey: positionKeypair.publicKey.toBase58(),
-              txSignature: signature,
-            };
-          } catch (err) {
+          const maxY = pool.tokenY === SOL_MINT ? nativeSolBalance : balanceY;
+          if (BigInt(totalYAmount.toString()) > maxY) {
+            totalYAmount = new BN(maxY.toString());
+          }
+
+          if (totalXAmount.eq(new BN(0)) || totalYAmount.eq(new BN(0))) {
             return yield* Effect.fail(
+              new AdapterError({
+                message: "Insufficient token balance",
+                poolAddress,
+              }),
+            );
+          }
+
+          const positionKeypair = new Keypair();
+          const strategy = {
+            minBinId: lowerBinId,
+            maxBinId: upperBinId,
+            strategyType: 0,
+          };
+
+          const tx = yield* Effect.tryPromise(() =>
+            dlmm.initializePositionAndAddLiquidityByStrategy({
+              positionPubKey: positionKeypair.publicKey,
+              totalXAmount,
+              totalYAmount,
+              strategy,
+              user: wallet.publicKey,
+              slippage: 50,
+            }),
+          );
+
+          tx.feePayer = wallet.publicKey;
+          const { blockhash } = yield* Effect.tryPromise(() =>
+            rpcGated(() => connection.getLatestBlockhash()),
+          );
+          tx.recentBlockhash = blockhash;
+          tx.sign(wallet, positionKeypair);
+
+          const signature = yield* Effect.tryPromise(() =>
+            rpcGated(() =>
+              connection.sendRawTransaction(tx.serialize(), {
+                skipPreflight: false,
+                preflightCommitment: "confirmed",
+              }),
+            ),
+          );
+
+          yield* Effect.tryPromise(() =>
+            rpcGated(() => connection.confirmTransaction(signature, "confirmed")),
+          );
+
+          return {
+            positionPubKey: positionKeypair.publicKey.toBase58(),
+            txSignature: signature,
+          };
+        }).pipe(
+          Effect.catchAll((err: unknown) =>
+            Effect.fail(
               new AdapterError({
                 message: `Failed to enter position: ${String(err)}`,
                 poolAddress,
                 cause: err,
               }),
-            );
-          }
-        }),
+            ),
+          ),
+        ),
 
       exitPosition: (poolAddress, positionPubKey) =>
         Effect.gen(function* () {
@@ -906,57 +936,57 @@ export const AdapterLive = Layer.effect(
             );
           }
 
-          try {
-            const positionPubkey = new PublicKey(positionPubKey);
-            const dlmm = yield* Effect.tryPromise(() => getDlmm(poolAddress));
+          const positionPubkey = new PublicKey(positionPubKey);
+          const dlmm = yield* Effect.tryPromise(() => getDlmm(poolAddress));
 
-            const position = yield* Effect.tryPromise(() => dlmm.getPosition(positionPubkey));
-            const lowerBinId = position.positionData.lowerBinId;
-            const upperBinId = position.positionData.upperBinId;
+          const position = yield* Effect.tryPromise(() => dlmm.getPosition(positionPubkey));
+          const lowerBinId = position.positionData.lowerBinId;
+          const upperBinId = position.positionData.upperBinId;
 
-            const txs = yield* Effect.tryPromise(() =>
-              dlmm.removeLiquidity({
-                user: wallet.publicKey,
-                position: positionPubkey,
-                fromBinId: lowerBinId,
-                toBinId: upperBinId,
-                bps: new BN(10000),
-                shouldClaimAndClose: true,
-              }),
+          const txs = yield* Effect.tryPromise(() =>
+            dlmm.removeLiquidity({
+              user: wallet.publicKey,
+              position: positionPubkey,
+              fromBinId: lowerBinId,
+              toBinId: upperBinId,
+              bps: new BN(10000),
+              shouldClaimAndClose: true,
+            }),
+          );
+
+          for (const tx of txs) {
+            const { blockhash } = yield* Effect.tryPromise(() =>
+              rpcGated(() => connection.getLatestBlockhash()),
             );
+            tx.feePayer = wallet.publicKey;
+            tx.recentBlockhash = blockhash;
+            tx.sign(wallet);
 
-            for (const tx of txs) {
-              const { blockhash } = yield* Effect.tryPromise(() =>
-                rpcGated(() => connection.getLatestBlockhash()),
-              );
-              tx.feePayer = wallet.publicKey;
-              tx.recentBlockhash = blockhash;
-              tx.sign(wallet);
+            const signature = yield* Effect.tryPromise(() =>
+              rpcGated(() =>
+                connection.sendRawTransaction(tx.serialize(), {
+                  skipPreflight: false,
+                  preflightCommitment: "confirmed",
+                }),
+              ),
+            );
+            yield* Effect.tryPromise(() =>
+              rpcGated(() => connection.confirmTransaction(signature, "confirmed")),
+            );
+          }
 
-              const signature = yield* Effect.tryPromise(() =>
-                rpcGated(() =>
-                  connection.sendRawTransaction(tx.serialize(), {
-                    skipPreflight: false,
-                    preflightCommitment: "confirmed",
-                  }),
-                ),
-              );
-              yield* Effect.tryPromise(() =>
-                rpcGated(() => connection.confirmTransaction(signature, "confirmed")),
-              );
-            }
-
-            return { txSignature: "batch-confirmed" };
-          } catch (err) {
-            return yield* Effect.fail(
+          return { txSignature: "batch-confirmed" };
+        }).pipe(
+          Effect.catchAll((err: unknown) =>
+            Effect.fail(
               new AdapterError({
                 message: `Failed to exit position: ${String(err)}`,
                 poolAddress,
                 cause: err,
               }),
-            );
-          }
-        }),
+            ),
+          ),
+        ),
 
       rebalancePosition: (poolAddress, positionPubKey, newLowerBinId, newUpperBinId) =>
         Effect.gen(function* () {
@@ -995,186 +1025,186 @@ export const AdapterLive = Layer.effect(
             );
           }
 
-          try {
-            const positionPubkey = new PublicKey(positionPubKey);
-            const dlmm = yield* Effect.tryPromise(() => getDlmm(poolAddress));
+          const positionPubkey = new PublicKey(positionPubKey);
+          const dlmm = yield* Effect.tryPromise(() => getDlmm(poolAddress));
 
-            const position = yield* Effect.tryPromise(() => dlmm.getPosition(positionPubkey));
+          const position = yield* Effect.tryPromise(() => dlmm.getPosition(positionPubkey));
 
-            const feeX = Number(position.positionData.feeX.toString());
-            const feeY = Number(position.positionData.feeY.toString());
+          const feeX = Number(position.positionData.feeX.toString());
+          const feeY = Number(position.positionData.feeY.toString());
 
-            if (feeX === 0 && feeY === 0) {
-              return {
-                txSignature: "",
-                feeX: 0,
-                feeY: 0,
-                platformFeeX: 0,
-                platformFeeY: 0,
-                netFeeX: 0,
-                netFeeY: 0,
-              };
-            }
+          if (feeX === 0 && feeY === 0) {
+            return {
+              txSignature: "",
+              feeX: 0,
+              feeY: 0,
+              platformFeeX: 0,
+              platformFeeY: 0,
+              netFeeX: 0,
+              netFeeY: 0,
+            };
+          }
 
-            const txs = yield* Effect.tryPromise(() =>
-              dlmm.claimSwapFee({
-                owner: wallet.publicKey,
-                position: position,
-              }),
-            );
+          const txs = yield* Effect.tryPromise(() =>
+            dlmm.claimSwapFee({
+              owner: wallet.publicKey,
+              position: position,
+            }),
+          );
 
-            const claimInstructions = txs.flatMap((tx) => tx.instructions);
+          const claimInstructions = txs.flatMap((tx) => tx.instructions);
 
-            if (claimInstructions.length === 0) {
-              return {
-                txSignature: "",
-                feeX: 0,
-                feeY: 0,
-                platformFeeX: 0,
-                platformFeeY: 0,
-                netFeeX: 0,
-                netFeeY: 0,
-              };
-            }
+          if (claimInstructions.length === 0) {
+            return {
+              txSignature: "",
+              feeX: 0,
+              feeY: 0,
+              platformFeeX: 0,
+              platformFeeY: 0,
+              netFeeX: 0,
+              netFeeY: 0,
+            };
+          }
 
-            const feeWallet = feeWalletAddress ?? "";
-            const operatorWalletAddress = wallet.publicKey.toBase58();
-            const revenueShare = calculateRevenueShare(
-              feeX,
-              feeY,
-              platformFeeRate,
-              revenueShareEnabled ?? false,
-              revenueShareOperatorPct ?? 0,
-              feeWallet,
-              operatorWalletAddress,
-            );
-            let transferInstructions: TransactionInstruction[] = [];
-            let actualPlatformFeeX = 0;
-            let actualPlatformFeeY = 0;
-            let actualOperatorFeeX = 0;
-            let actualOperatorFeeY = 0;
+          const feeWallet = feeWalletAddress ?? "";
+          const operatorWalletAddress = wallet.publicKey.toBase58();
+          const revenueShare = calculateRevenueShare(
+            feeX,
+            feeY,
+            platformFeeRate,
+            revenueShareEnabled ?? false,
+            revenueShareOperatorPct ?? 0,
+            feeWallet,
+            operatorWalletAddress,
+          );
+          let transferInstructions: TransactionInstruction[] = [];
+          let actualPlatformFeeX = 0;
+          let actualPlatformFeeY = 0;
+          let actualOperatorFeeX = 0;
+          let actualOperatorFeeY = 0;
 
-            if (revenueShare.platformFeeX > 0 || revenueShare.platformFeeY > 0) {
-              if (revenueShare.isCircular) {
-                logger.info("Circular wallet detected — fees retained by operator", {
-                  pool: poolAddress,
-                  platformFeeX: revenueShare.platformFeeX,
-                  platformFeeY: revenueShare.platformFeeY,
-                });
-                actualPlatformFeeX = revenueShare.platformFeeX;
-                actualPlatformFeeY = revenueShare.platformFeeY;
-                actualOperatorFeeX = revenueShare.platformFeeX;
-                actualOperatorFeeY = revenueShare.platformFeeY;
-              } else if (feeWallet) {
-                const feeWalletPubkey = new PublicKey(feeWallet);
-                const tokenXMint = dlmm.lbPair.tokenXMint as PublicKey;
-                const tokenYMint = dlmm.lbPair.tokenYMint as PublicKey;
+          if (revenueShare.platformFeeX > 0 || revenueShare.platformFeeY > 0) {
+            if (revenueShare.isCircular) {
+              logger.info("Circular wallet detected — fees retained by operator", {
+                pool: poolAddress,
+                platformFeeX: revenueShare.platformFeeX,
+                platformFeeY: revenueShare.platformFeeY,
+              });
+              actualPlatformFeeX = revenueShare.platformFeeX;
+              actualPlatformFeeY = revenueShare.platformFeeY;
+              actualOperatorFeeX = revenueShare.platformFeeX;
+              actualOperatorFeeY = revenueShare.platformFeeY;
+            } else if (feeWallet) {
+              const feeWalletPubkey = new PublicKey(feeWallet);
+              const tokenXMint = dlmm.lbPair.tokenXMint as PublicKey;
+              const tokenYMint = dlmm.lbPair.tokenYMint as PublicKey;
 
-                const mints: Array<[PublicKey, number]> = [
-                  [tokenXMint, revenueShare.amountToTransferX],
-                  [tokenYMint, revenueShare.amountToTransferY],
-                ];
+              const mints: Array<[PublicKey, number]> = [
+                [tokenXMint, revenueShare.amountToTransferX],
+                [tokenYMint, revenueShare.amountToTransferY],
+              ];
 
-                for (const [mint, amount] of mints) {
-                  if (amount < 1) continue;
-                  const fromAta = yield* Effect.tryPromise(() =>
-                    getAssociatedTokenAddress(mint, wallet!.publicKey),
-                  );
-                  const toAta = yield* Effect.tryPromise(() =>
-                    getAssociatedTokenAddress(mint, feeWalletPubkey),
-                  );
-                  // Check if destination ATA exists
-                  const toAtaInfo = yield* Effect.tryPromise(() =>
-                    rpcCall(() => connection.getAccountInfo(toAta)),
-                  );
-                  if (!toAtaInfo) {
-                    transferInstructions.push(
-                      createAssociatedTokenAccountInstruction(
-                        wallet!.publicKey,
-                        toAta,
-                        feeWalletPubkey,
-                        mint,
-                      ),
-                    );
-                  }
+              for (const [mint, amount] of mints) {
+                if (amount < 1) continue;
+                const fromAta = yield* Effect.tryPromise(() =>
+                  getAssociatedTokenAddress(mint, wallet!.publicKey),
+                );
+                const toAta = yield* Effect.tryPromise(() =>
+                  getAssociatedTokenAddress(mint, feeWalletPubkey),
+                );
+                // Check if destination ATA exists
+                const toAtaInfo = yield* Effect.tryPromise(() =>
+                  rpcCall(() => connection.getAccountInfo(toAta)),
+                );
+                if (!toAtaInfo) {
                   transferInstructions.push(
-                    createTransferInstruction(
-                      fromAta,
-                      toAta,
+                    createAssociatedTokenAccountInstruction(
                       wallet!.publicKey,
-                      BigInt(Math.floor(amount)),
+                      toAta,
+                      feeWalletPubkey,
+                      mint,
                     ),
                   );
                 }
+                transferInstructions.push(
+                  createTransferInstruction(
+                    fromAta,
+                    toAta,
+                    wallet!.publicKey,
+                    BigInt(Math.floor(amount)),
+                  ),
+                );
+              }
 
-                if (transferInstructions.length > 0) {
-                  actualPlatformFeeX = revenueShare.platformFeeX;
-                  actualPlatformFeeY = revenueShare.platformFeeY;
-                  actualOperatorFeeX = revenueShare.operatorFeeX;
-                  actualOperatorFeeY = revenueShare.operatorFeeY;
-                } else {
-                  logger.info("No platform fee to transfer — operator keeps full share", {
-                    pool: poolAddress,
-                  });
-                }
+              if (transferInstructions.length > 0) {
+                actualPlatformFeeX = revenueShare.platformFeeX;
+                actualPlatformFeeY = revenueShare.platformFeeY;
+                actualOperatorFeeX = revenueShare.operatorFeeX;
+                actualOperatorFeeY = revenueShare.operatorFeeY;
               } else {
-                logger.warn("No fee wallet configured — skipping platform fee transfer", {
+                logger.info("No platform fee to transfer — operator keeps full share", {
                   pool: poolAddress,
                 });
               }
+            } else {
+              logger.warn("No fee wallet configured — skipping platform fee transfer", {
+                pool: poolAddress,
+              });
             }
+          }
 
-            const allInstructions = [...claimInstructions, ...transferInstructions];
+          const allInstructions = [...claimInstructions, ...transferInstructions];
 
-            const { blockhash } = yield* Effect.tryPromise(() =>
-              rpcGated(() => connection.getLatestBlockhash()),
-            );
+          const { blockhash } = yield* Effect.tryPromise(() =>
+            rpcGated(() => connection.getLatestBlockhash()),
+          );
 
-            const messageV0 = new TransactionMessage({
-              payerKey: wallet.publicKey,
-              recentBlockhash: blockhash,
-              instructions: allInstructions,
-            }).compileToV0Message();
+          const messageV0 = new TransactionMessage({
+            payerKey: wallet.publicKey,
+            recentBlockhash: blockhash,
+            instructions: allInstructions,
+          }).compileToV0Message();
 
-            const versionedTx = new VersionedTransaction(messageV0);
-            versionedTx.sign([wallet]);
+          const versionedTx = new VersionedTransaction(messageV0);
+          versionedTx.sign([wallet]);
 
-            const signature = yield* Effect.tryPromise(() =>
-              rpcGated(() =>
-                connection.sendRawTransaction(versionedTx.serialize(), {
-                  skipPreflight: false,
-                  preflightCommitment: "confirmed",
-                }),
-              ),
-            );
+          const signature = yield* Effect.tryPromise(() =>
+            rpcGated(() =>
+              connection.sendRawTransaction(versionedTx.serialize(), {
+                skipPreflight: false,
+                preflightCommitment: "confirmed",
+              }),
+            ),
+          );
 
-            yield* Effect.tryPromise(() =>
-              rpcGated(() => connection.confirmTransaction(signature, "confirmed")),
-            );
+          yield* Effect.tryPromise(() =>
+            rpcGated(() => connection.confirmTransaction(signature, "confirmed")),
+          );
 
-            return {
-              txSignature: signature,
-              feeX,
-              feeY,
-              platformFeeX: actualPlatformFeeX,
-              platformFeeY: actualPlatformFeeY,
-              netFeeX: feeX - actualPlatformFeeX,
-              netFeeY: feeY - actualPlatformFeeY,
-              ...(transferInstructions.length > 0 ? { feeTransferTxSignature: signature } : {}),
-              ...(actualOperatorFeeX > 0 || actualOperatorFeeY > 0
-                ? { operatorFeeX: actualOperatorFeeX, operatorFeeY: actualOperatorFeeY }
-                : {}),
-            };
-          } catch (err) {
-            return yield* Effect.fail(
+          return {
+            txSignature: signature,
+            feeX,
+            feeY,
+            platformFeeX: actualPlatformFeeX,
+            platformFeeY: actualPlatformFeeY,
+            netFeeX: feeX - actualPlatformFeeX,
+            netFeeY: feeY - actualPlatformFeeY,
+            ...(transferInstructions.length > 0 ? { feeTransferTxSignature: signature } : {}),
+            ...(actualOperatorFeeX > 0 || actualOperatorFeeY > 0
+              ? { operatorFeeX: actualOperatorFeeX, operatorFeeY: actualOperatorFeeY }
+              : {}),
+          };
+        }).pipe(
+          Effect.catchAll((err: unknown) =>
+            Effect.fail(
               new AdapterError({
                 message: `Failed to claim fees: ${String(err)}`,
                 poolAddress,
                 cause: err,
               }),
-            );
-          }
-        }),
+            ),
+          ),
+        ),
 
       reportFeeCollection(event) {
         void (async () => {

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -509,13 +509,11 @@ export const AdapterLive = Layer.effect(
         const prices: Record<string, number> = {};
         const missing: string[] = [];
 
+        // 1. Cache only — never use hardcoded fallback here
         for (const mint of mints) {
           const cached = getCachedPrice(mint);
           if (cached !== undefined) {
             prices[mint] = cached;
-          } else if (fallbackPrices[mint]) {
-            prices[mint] = fallbackPrices[mint];
-            setCachedPrice(mint, fallbackPrices[mint]);
           } else {
             missing.push(mint);
           }
@@ -523,6 +521,7 @@ export const AdapterLive = Layer.effect(
 
         if (missing.length === 0) return prices;
 
+        // 2. Jupiter (live prices are cached inside fetchJupiterPrices)
         const jupiterPrices = yield* fetchJupiterPrices(missing);
         const stillMissing: string[] = [];
         for (const mint of missing) {
@@ -534,11 +533,24 @@ export const AdapterLive = Layer.effect(
           }
         }
 
-        if (stillMissing.length > 0) {
-          const cgPrices = yield* fetchCoinGeckoPrices(stillMissing);
-          for (const mint of stillMissing) {
-            prices[mint] = cgPrices[mint] ?? 0;
+        if (stillMissing.length === 0) return prices;
+
+        // 3. CoinGecko (live prices are cached inside fetchCoinGeckoPrices)
+        const cgPrices = yield* fetchCoinGeckoPrices(stillMissing);
+        const unresolved: string[] = [];
+        for (const mint of stillMissing) {
+          const cgPrice = cgPrices[mint];
+          if (cgPrice != null) {
+            prices[mint] = cgPrice;
+          } else {
+            unresolved.push(mint);
           }
+        }
+
+        // 4. Hardcoded fallback — NOT cached (stale values must not pollute
+        //    the live price cache; next cycle will re-attempt live sources)
+        for (const mint of unresolved) {
+          prices[mint] = fallbackPrices[mint] ?? 0;
         }
 
         return prices;

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -169,11 +169,17 @@ const loadConfig = Effect.gen(function* () {
   const heliusApiKey = yield* Config.string("HELIUS_API_KEY").pipe(
     Effect.orElseSucceed(() => (isTest ? "test-helius-key" : "")),
   );
-  const solanaRpcUrl = yield* Config.string("SOLANA_RPC_URL").pipe(
+  let solanaRpcUrl = yield* Config.string("SOLANA_RPC_URL").pipe(
     Effect.orElseSucceed(() =>
       isTest ? "https://example.com" : "https://api.mainnet-beta.solana.com",
     ),
   );
+
+  // If no SOLANA_RPC_URL is configured but a Helius key is present, prefer
+  // Helius over the public Solana RPC for reliability.
+  if (!isTest && !process.env.SOLANA_RPC_URL && heliusApiKey.length > 0) {
+    solanaRpcUrl = `https://mainnet.helius-rpc.com/?api-key=${heliusApiKey}`;
+  }
   const paperTrading = yield* Config.boolean("PAPER_TRADING").pipe(
     Effect.orElseSucceed(() => true),
   );

--- a/engine/db-service.ts
+++ b/engine/db-service.ts
@@ -339,7 +339,9 @@ export const DbLive = (dbPath?: string) =>
                     .map((row) => {
                       const rawDistance = row.distance;
                       const distance =
-                        rawDistance === undefined || rawDistance === null || Number.isNaN(rawDistance)
+                        rawDistance === undefined ||
+                        rawDistance === null ||
+                        Number.isNaN(rawDistance)
                           ? 1
                           : Number(rawDistance);
                       const simScore = 1 - distance;
@@ -637,10 +639,7 @@ export const DbLive = (dbPath?: string) =>
         saveSignalSnapshot: (snapshot) =>
           Effect.sync(() => {
             const result = (
-              db.run as (
-                sql: string,
-                ...params: unknown[]
-              ) => { lastInsertRowid: number | bigint }
+              db.run as (sql: string, ...params: unknown[]) => { lastInsertRowid: number | bigint }
             )(
               `INSERT INTO signal_snapshots (pool_address, timestamp, fee_il_ratio, volume_authenticity, bin_utilization, tvl_usd, tvl_velocity, volatility_stddev, bin_step, action, confidence) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
               snapshot.poolAddress,

--- a/engine/feedback-service.ts
+++ b/engine/feedback-service.ts
@@ -51,11 +51,13 @@ function submitCloudFeedback(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(10_000),
       }),
     );
     if (!res.ok) return null;
-    const json = (yield* Effect.tryPromise(() => res.json())) as { id?: string };
-    return json.id ? { id: json.id } : null;
+    const json = (yield* Effect.tryPromise(() => res.json())) as Record<string, unknown>;
+    if (typeof json.id !== "string") return null;
+    return { id: json.id };
   }).pipe(Effect.catchAll(() => Effect.succeed(null)));
 }
 const STOP_WORDS = new Set([

--- a/engine/feedback-service.ts
+++ b/engine/feedback-service.ts
@@ -1,5 +1,5 @@
 import { Effect, Layer } from "effect";
-import { createHash } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
@@ -26,6 +26,38 @@ const FEEDBACK_LIMITS = {
 
 const SIMILARITY_THRESHOLD = 0.7;
 const MAX_KEYWORDS = 5;
+const DEFAULT_CLOUD_FEEDBACK_URL = "https://prism-api.irfndi.workers.dev/v1/feedback";
+
+interface CloudFeedbackPayload {
+  id: string;
+  agentId: string;
+  category: string;
+  severity: string;
+  summary: string;
+  details?: string | undefined;
+  relatedFiles?: string[] | undefined;
+  context: FeedbackContext;
+  hash: string;
+  reportedAt: number;
+}
+
+function submitCloudFeedback(
+  apiUrl: string,
+  payload: CloudFeedbackPayload,
+): Effect.Effect<{ readonly id: string } | null, never> {
+  return Effect.gen(function* () {
+    const res = yield* Effect.tryPromise(() =>
+      fetch(apiUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      }),
+    );
+    if (!res.ok) return null;
+    const json = (yield* Effect.tryPromise(() => res.json())) as { id?: string };
+    return json.id ? { id: json.id } : null;
+  }).pipe(Effect.catchAll(() => Effect.succeed(null)));
+}
 const STOP_WORDS = new Set([
   "the",
   "a",
@@ -411,6 +443,44 @@ export const FeedbackLive = Layer.effect(
         }
 
         if (!config.githubToken) {
+          const cloudUrl = process.env.PRISM_API_URL
+            ? `${process.env.PRISM_API_URL}/v1/feedback`
+            : DEFAULT_CLOUD_FEEDBACK_URL;
+          const reportedAt = Date.now();
+          const cloudId = randomUUID();
+          const cloudResult = yield* submitCloudFeedback(cloudUrl, {
+            id: cloudId,
+            agentId,
+            category: feedback.category,
+            severity: feedback.severity,
+            summary: feedback.summary,
+            details: feedback.details,
+            relatedFiles: feedback.relatedFiles ? [...feedback.relatedFiles] : undefined,
+            context,
+            hash,
+            reportedAt,
+          });
+
+          if (cloudResult) {
+            const entry: FeedbackEntry = {
+              id: cloudResult.id,
+              agentId,
+              category: feedback.category,
+              severity: feedback.severity,
+              summary: feedback.summary,
+              details: feedback.details ?? null,
+              relatedFiles: feedback.relatedFiles ?? [],
+              contextJson: JSON.stringify(context),
+              githubIssueNumber: null,
+              githubIssueUrl: null,
+              reportedAt,
+              hash,
+            };
+            yield* db.saveFeedback(entry);
+            logger.info(`Submitted feedback to Prism cloud: ${feedback.summary}`);
+            return { kind: "cloud" as const, id: cloudResult.id };
+          }
+
           const localId = `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
           const entry: FeedbackEntry = {
             id: localId,
@@ -420,7 +490,7 @@ export const FeedbackLive = Layer.effect(
             summary: feedback.summary,
             details: feedback.details ?? null,
             relatedFiles: feedback.relatedFiles ?? [],
-            contextJson: JSON.stringify(feedback.context),
+            contextJson: JSON.stringify(context),
             githubIssueNumber: null,
             githubIssueUrl: null,
             reportedAt: Date.now(),
@@ -428,7 +498,7 @@ export const FeedbackLive = Layer.effect(
           };
           yield* db.saveFeedback(entry);
           logger.warn(
-            "GITHUB_TOKEN unset — feedback stored locally only. " +
+            "GITHUB_TOKEN unset and cloud feedback unavailable — feedback stored locally only. " +
               "Set GITHUB_TOKEN to enable GitHub Issues filing.",
           );
           return { kind: "local_only" as const, localId };

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -1514,9 +1514,19 @@ export const program = Effect.gen(function* () {
           action: decision.action,
           pool: poolAddress,
         });
-        executed = yield* executePaper(decision, pool, signalTimestamp, signalSnapshotId ?? undefined);
+        executed = yield* executePaper(
+          decision,
+          pool,
+          signalTimestamp,
+          signalSnapshotId ?? undefined,
+        );
       } else {
-        executed = yield* executeLive(decision, pool, signalTimestamp, signalSnapshotId ?? undefined);
+        executed = yield* executeLive(
+          decision,
+          pool,
+          signalTimestamp,
+          signalSnapshotId ?? undefined,
+        );
       }
 
       // Audit after execution
@@ -1708,11 +1718,11 @@ export const program = Effect.gen(function* () {
             lastFeeClaimAt: Date.now(),
             trailingStopThreshold: null,
             highestValueUsd: null,
-          lastRebalanceAt: 0,
-          paperExitedAt: null,
-          entrySignalTimestamp: signalTimestamp ?? null,
-          entrySignalSnapshotId: signalSnapshotId ?? null,
-        };
+            lastRebalanceAt: 0,
+            paperExitedAt: null,
+            entrySignalTimestamp: signalTimestamp ?? null,
+            entrySignalSnapshotId: signalSnapshotId ?? null,
+          };
           trackedPositions.set(decision.poolAddress, pos);
           yield* db.savePosition(pos).pipe(Effect.catchAll(() => Effect.void));
           return true;

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -339,7 +339,7 @@ export interface DbApi {
       lastRebalanceAt: number;
       paperExitedAt: number | null;
       entrySignalTimestamp: number | null;
-    entrySignalSnapshotId: number | null;
+      entrySignalSnapshotId: number | null;
     } | null,
     unknown
   >;
@@ -363,7 +363,7 @@ export interface DbApi {
       lastRebalanceAt: number;
       paperExitedAt: number | null;
       entrySignalTimestamp: number | null;
-    entrySignalSnapshotId: number | null;
+      entrySignalSnapshotId: number | null;
     }>,
     unknown
   >;
@@ -387,7 +387,7 @@ export interface DbApi {
       lastRebalanceAt: number;
       paperExitedAt: number | null;
       entrySignalTimestamp: number | null;
-    entrySignalSnapshotId: number | null;
+      entrySignalSnapshotId: number | null;
     }>,
     unknown
   >;
@@ -670,6 +670,7 @@ export type FeedbackResult =
   | { kind: "rate_limited"; reason: string }
   | { kind: "opt_out" }
   | { kind: "local_only"; localId: string }
+  | { kind: "cloud"; id: string }
   | { kind: "error"; error: string };
 
 export interface FeedbackEntry {


### PR DESCRIPTION
## Summary

This PR bundles reliability and UX improvements across the CLI, engine, and Cloudflare API.

### CLI / update flow
- Runs the update smoke test with the Bun runtime (`bun run test`) so it matches the project's canonical test command.
- Preserves `.env`, the SQLite database, and `logs/` across atomic upgrades by copying them into the staged install before the swap.
- Adds `prism update` alias `prism upgrade`.

### `prism status` running detection
- Detects a live engine by reading the lockfile PID and verifying the process is alive.
- Falls back to scanning `ps` for `engine/index.ts` / `run dev` / `cli/dev.ts` processes.
- Keeps the previous DB-activity heuristic only when no lockfile exists.

### `prism dev` local-only mode
- Allows paper trading without a Prism account.
- Warns and continues instead of error-exiting when no credentials are found.

### Feedback pipeline
- `prism feedback` now submits to the Prism cloud `/v1/feedback` endpoint first, then falls back to local storage if the cloud is unreachable.
- Cloudflare API adds `POST /v1/feedback` and `GET /v1/feedback` backed by D1 and KV rate-limiting.
- Adds `cloudflare/migrations/0010_feedback.sql` and `cloudflare/workers/api/feedback.test.ts`.

### Engine resilience
- `retryWithBackoff` uses a dedicated, longer base delay for 429 / rate-limit errors.
- `AdapterLive.fetchTokenPrices` caches prices for 60 s and batches CoinGecko calls (25 IDs per request with 1.2 s delays).
- `config-service` prefers Helius RPC when `SOLANA_RPC_URL` is unset and a `HELIUS_API_KEY` is configured.
- Applied `oxfmt` formatting across the engine.

### Review-comment fixes
- `cli/update.ts`: replaced `execSync` with `execFileSync` argument arrays to remove shell-injection risk.
- `cli/lockfile.ts`: added a 3s timeout to the synchronous `ps` call so a hanging process list cannot block `prism status`.
- `engine/adapter-service.ts`: fixed critical fallback-price ordering so SOL/USDC/USDT/etc. are priced from Jupiter/CoinGecko first, hardcoded map last.
- `engine/feedback-service.ts`: added an `AbortSignal` timeout and runtime `id` type check to the cloud feedback POST.
- `cloudflare/workers/api/index.ts`: added 400 validation for the required `hash` field and isolated the KV rate-limit write so it cannot turn a committed D1 insert into a 500.

## Validation

- `bun run lint` — 0 warnings, 0 errors.
- `bun run format:check` — all matched files use correct format.
- `bun run test` — **47/47 test files, 486/486 tests passed**.
- `cd cloudflare && bunx vitest run` — **9/9 test files, 82/82 tests passed**.

## Notes

The existing three CLI fix commits remain in the branch history. This final commit adds the engine/cloud feedback work and formatting cleanup on top of them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cloud-based feedback submission with a fallback to local storage when cloud access isn’t available.
  * Introduced a new feedback listing endpoint for admins with filtering and pagination limits.
  * Added a new alias for the update command and improved dev-mode behavior so the CLI can continue in local-only mode without credentials.

* **Bug Fixes**
  * Improved retry behavior for rate-limit errors.
  * Enhanced lockfile and running-process detection for better status reporting and safer updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->