### PR TITLE
fix: v0.0.23 update/test failures

### DIFF
--- a/bench/error-reporter.test.ts
+++ b/bench/error-reporter.test.ts
@@ -183,6 +183,16 @@ describe("classification", () => {
     expect(r.getPending()[0]?.category).toBe("Unknown");
     r.dispose();
   });
+
+  it("classifies unknown patterns as Unknown even when stack contains 'update'", () => {
+    const r = makeReporter();
+    const err = new Error("Something completely unexpected happened");
+    err.stack =
+      "Error: Something completely unexpected happened\n    at updateSnapshot (file.ts:1:1)";
+    r.report(err);
+    expect(r.getPending()[0]?.category).toBe("Unknown");
+    r.dispose();
+  });
 });
 
 // ─── Buffering ───────────────────────────────────────────────────────────────

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -17,6 +17,11 @@ import semver from "semver";
 import { Effect } from "effect";
 import { createLogger } from "../engine/logger.js";
 
+if (typeof Bun === "undefined") {
+  console.error("The prism update command requires the Bun runtime.");
+  process.exit(1);
+}
+
 const logger = createLogger("update");
 
 class UpdateAbort extends Error {

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -29,6 +29,20 @@ class UpdateAbort extends Error {
   }
 }
 
+/**
+ * Resolve a command to an absolute path using Bun.which. Passing absolute
+ * paths to execFileSync avoids ENOENT surprises when the target environment
+ * has a restricted PATH or when Bun's internal fallback tries to spawn a
+ * shell that does not exist (e.g. `/bin/sh` in minimal containers).
+ */
+function resolveBin(name: string): string {
+  const resolved = Bun.which(name);
+  if (!resolved) {
+    throw new UpdateAbort(`${name} not found in PATH. Ensure Bun is installed and on your PATH.`);
+  }
+  return resolved;
+}
+
 // Walk up from this CLI's location to the Prism install root. Required so
 // that `prism update` is safe to run from any directory — using process.cwd()
 // would let the swap clobber an unrelated working dir.
@@ -143,7 +157,7 @@ export const updateCommand = new Command("update")
       console.log("✓ SHA-256 checksum verified");
 
       console.log("Extracting tarball...");
-      execFileSync("tar", ["-xzf", tarballPath, "-C", workDir], { stdio: "inherit" });
+      execFileSync(resolveBin("tar"), ["-xzf", tarballPath, "-C", workDir], { stdio: "inherit" });
 
       // R2 tarballs extract at top level; legacy ones had a subdir.
       const candidateRoots = [workDir, join(workDir, "prism-liquidity-agent")];
@@ -168,7 +182,7 @@ export const updateCommand = new Command("update")
         );
       }
 
-      execFileSync("bun", ["install"], { cwd: extractedDir, stdio: "inherit" });
+      execFileSync(resolveBin("bun"), ["install"], { cwd: extractedDir, stdio: "inherit" });
 
       // === Pre-apply smoke tests ===
       const skipSmokeTest = options.skipSmokeTest as boolean;
@@ -178,7 +192,10 @@ export const updateCommand = new Command("update")
       } else {
         console.log("Running TypeScript smoke test...");
         try {
-          execFileSync("bunx", ["tsc", "--noEmit"], { cwd: extractedDir, stdio: "inherit" });
+          execFileSync(resolveBin("bunx"), ["tsc", "--noEmit"], {
+            cwd: extractedDir,
+            stdio: "inherit",
+          });
           console.log("✓ TypeScript smoke test passed");
         } catch {
           console.error("⚠ TypeScript smoke test failed — continuing anyway");
@@ -187,7 +204,10 @@ export const updateCommand = new Command("update")
 
         console.log("Running test suite smoke test...");
         try {
-          execFileSync("bunx", ["--bun", "vitest", "run"], { cwd: extractedDir, stdio: "inherit" });
+          execFileSync(resolveBin("bunx"), ["--bun", "vitest", "run"], {
+            cwd: extractedDir,
+            stdio: "inherit",
+          });
           console.log("✓ Test suite smoke test passed");
         } catch {
           console.error("⚠ Test suite smoke test failed — continuing anyway");
@@ -209,7 +229,9 @@ export const updateCommand = new Command("update")
         if (existsSync(stagedRoot)) {
           rmSync(stagedRoot, { recursive: true, force: true });
         }
-        execFileSync("cp", ["-R", `${extractedDir}/.`, `${stagedRoot}/`], { stdio: "inherit" });
+        execFileSync(resolveBin("cp"), ["-R", `${extractedDir}/.`, `${stagedRoot}/`], {
+          stdio: "inherit",
+        });
 
         for (const file of userFilesToPreserve) {
           const source = join(installRoot, file);
@@ -218,7 +240,7 @@ export const updateCommand = new Command("update")
             if (existsSync(dest)) {
               rmSync(dest, { recursive: true, force: true });
             }
-            execFileSync("cp", ["-R", source, dest], { stdio: "inherit" });
+            execFileSync(resolveBin("cp"), ["-R", source, dest], { stdio: "inherit" });
           }
         }
 
@@ -226,23 +248,23 @@ export const updateCommand = new Command("update")
           rmSync(backupRoot, { recursive: true, force: true });
         }
 
-        execFileSync("mv", [installRoot, currentBackup], { stdio: "inherit" });
+        execFileSync(resolveBin("mv"), [installRoot, currentBackup], { stdio: "inherit" });
         try {
-          execFileSync("mv", [stagedRoot, installRoot], { stdio: "inherit" });
+          execFileSync(resolveBin("mv"), [stagedRoot, installRoot], { stdio: "inherit" });
         } catch (swapErr) {
           if (existsSync(currentBackup) && !existsSync(installRoot)) {
-            execFileSync("mv", [currentBackup, installRoot]);
+            execFileSync(resolveBin("mv"), [currentBackup, installRoot]);
           }
           throw swapErr;
         }
         if (existsSync(currentBackup)) {
-          execFileSync("mv", [currentBackup, backupRoot], { stdio: "inherit" });
+          execFileSync(resolveBin("mv"), [currentBackup, backupRoot], { stdio: "inherit" });
         }
 
         // Post-apply health check
         console.log("Running post-apply health check...");
         try {
-          execFileSync("bunx", ["tsc", "--noEmit"], {
+          execFileSync(resolveBin("bunx"), ["tsc", "--noEmit"], {
             cwd: installRoot,
             stdio: "inherit",
             timeout: 30_000,
@@ -252,7 +274,7 @@ export const updateCommand = new Command("update")
           try {
             rmSync(installRoot, { recursive: true, force: true });
             if (existsSync(backupRoot)) {
-              execFileSync("mv", [backupRoot, installRoot], { stdio: "inherit" });
+              execFileSync(resolveBin("mv"), [backupRoot, installRoot], { stdio: "inherit" });
             }
           } catch (rollbackErr) {
             throw new UpdateAbort(

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -38,7 +38,11 @@ class UpdateAbort extends Error {
 function resolveBin(name: string): string {
   const resolved = Bun.which(name);
   if (!resolved) {
-    throw new UpdateAbort(`${name} not found in PATH. Ensure Bun is installed and on your PATH.`);
+    const hint =
+      name === "bun" || name === "bunx"
+        ? "Ensure Bun is installed and on your PATH."
+        : "Ensure it is installed and on your PATH.";
+    throw new UpdateAbort(`${name} not found in PATH. ${hint}`);
   }
   return resolved;
 }
@@ -253,7 +257,7 @@ export const updateCommand = new Command("update")
           execFileSync(resolveBin("mv"), [stagedRoot, installRoot], { stdio: "inherit" });
         } catch (swapErr) {
           if (existsSync(currentBackup) && !existsSync(installRoot)) {
-            execFileSync(resolveBin("mv"), [currentBackup, installRoot]);
+            execFileSync(resolveBin("mv"), [currentBackup, installRoot], { stdio: "inherit" });
           }
           throw swapErr;
         }

--- a/engine/error-reporter.ts
+++ b/engine/error-reporter.ts
@@ -101,7 +101,7 @@ function sanitizeStack(stack: string): string {
 // ─── Error classification ────────────────────────────────────────────────────
 
 function classifyError(error: Error): ErrorCategory {
-  const msg = error.message;
+  const msg = error.message ?? "";
   const stack = error.stack ?? "";
   const combined = `${msg} ${stack}`.toLowerCase();
 

--- a/engine/error-reporter.ts
+++ b/engine/error-reporter.ts
@@ -123,10 +123,14 @@ function classifyError(error: Error): ErrorCategory {
   if (combined.includes("config")) {
     return "Config_Error";
   }
+  // Only inspect the error message for update-related keywords; stack traces
+  // from test frameworks or Vitest internals (e.g. "updateSnapshot") must not
+  // cause unrelated errors to be classified as UpdateFailure.
+  const lowerMsg = msg.toLowerCase();
   if (
-    combined.includes("update") ||
-    combined.includes("tarball") ||
-    combined.includes("download")
+    lowerMsg.includes("update") ||
+    lowerMsg.includes("tarball") ||
+    lowerMsg.includes("download")
   ) {
     return "UpdateFailure";
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,7 @@ import { defineConfig } from "vitest/config";
 // Prism's tests depend on Bun-only APIs (bun:sqlite, Bun.serve). Running under
 // Node produces dozens of cryptic import errors; fail fast with a clear message.
 if (typeof Bun === "undefined") {
-  console.error("Prism tests require the Bun runtime. Run: bun run test");
-  process.exit(1);
+  throw new Error("Prism tests require the Bun runtime. Run: bun run test");
 }
 
 export default defineConfig({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,12 @@
 import { defineConfig } from "vitest/config";
+
+// Prism's tests depend on Bun-only APIs (bun:sqlite, Bun.serve). Running under
+// Node produces dozens of cryptic import errors; fail fast with a clear message.
+if (typeof Bun === "undefined") {
+  console.error("Prism tests require the Bun runtime. Run: bun run test");
+  process.exit(1);
+}
+
 export default defineConfig({
   test: {
     globals: true,


### PR DESCRIPTION
This PR addresses the five failures seen during the v0.0.23 update/smoke-test run, plus all review feedback on the initial changes.

## Changes

1. **fix(update): resolve executables to absolute paths with Bun.which** (`cli/update.ts`)
   - Replaces bare command names (`bun`, `bunx`, `tar`, `cp`, `mv`) with absolute paths returned by `Bun.which`.
   - Prevents the `ENOENT posix_spawn '/bin/sh'` failure when the target environment has a restricted PATH or when Bun's fallback tries to spawn a shell that does not exist.

2. **fix(error-reporter): classify update errors by message only** (`engine/error-reporter.ts`, `bench/error-reporter.test.ts`)
   - `classifyError` now checks only the error message for `update`/`tarball`/`download` keywords.
   - Stack traces from test frameworks (e.g. `updateSnapshot`) no longer cause unrelated errors to be misclassified as `UpdateFailure`.
   - Added a regression test with a stack containing `updateSnapshot`.

3. **chore(vitest): fail fast with clear message when run outside Bun** (`vitest.config.ts`)
   - The test suite depends on Bun-only APIs (`bun:sqlite`, `Bun.serve`).
   - Running under Node now fails immediately with `Prism tests require the Bun runtime. Run: bun run test` instead of producing dozens of cryptic import errors.

4. **fix(update): address review feedback on resolveBin and rollback output** (`cli/update.ts`)
   - `resolveBin()` now gives a generic PATH hint for non-Bun binaries (`tar`, `cp`, `mv`) and a Bun-specific hint only for `bun`/`bunx`.
   - The emergency rollback `mv` now uses `{ stdio: "inherit" }` so rescue failures are visible.

5. **fix(cli/engine): address Gemini review edge cases** (`cli/update.ts`, `engine/error-reporter.ts`)
   - Added a Bun runtime guard at the top of `cli/update.ts` so it fails gracefully if invoked under Node.
   - Guarded against an undefined `error.message` in `classifyError`.

6. **chore(vitest): replace process.exit with thrown error per review** (`vitest.config.ts`)
   - Replaced `process.exit(1)` with `throw new Error(...)` in the Bun runtime guard so Vitest reports the failure normally.

## Verification

- `bun run lint` — 0 warnings, 0 errors
- `bun run build` — succeeds
- `bun run test` — 48 files, 487 tests passed
- `node node_modules/.bin/vitest run` — fails fast with `Prism tests require the Bun runtime. Run: bun run test`

## Commits

- 9f46a08 fix(update): resolve executables to absolute paths with Bun.which
- 8517a1e fix(error-reporter): classify update errors by message only
- 66696ac chore(vitest): fail fast with clear message when run outside Bun
- 4bc5142 fix(update): address review feedback on resolveBin and rollback output
- ff89180 fix(cli/engine): address Gemini review edge cases
- 81f927a chore(vitest): replace process.exit with thrown error per review
