### PR TITLE
fix(update): avoid execFileSync shell fallback and stale backup dirs

### DIFF
--- a/cli/update.ts
+++ b/cli/update.ts
@@ -1,5 +1,4 @@
 import { Command } from "commander";
-import { execFileSync } from "child_process";
 import { createWriteStream, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { pipeline } from "stream/promises";
 import { dirname, join, resolve } from "path";
@@ -36,7 +35,7 @@ class UpdateAbort extends Error {
 
 /**
  * Resolve a command to an absolute path using Bun.which. Passing absolute
- * paths to execFileSync avoids ENOENT surprises when the target environment
+ * paths to the runner avoids ENOENT surprises when the target environment
  * has a restricted PATH or when Bun's internal fallback tries to spawn a
  * shell that does not exist (e.g. `/bin/sh` in minimal containers).
  */
@@ -50,6 +49,31 @@ function resolveBin(name: string): string {
     throw new UpdateAbort(`${name} not found in PATH. ${hint}`);
   }
   return resolved;
+}
+
+/**
+ * Run an external command with Bun.spawnSync. Avoids child_process.execFileSync,
+ * which can fall back to a shell spawn and fail with
+ * `ENOENT posix_spawn '/bin/sh'` in some environments.
+ *
+ * @see https://github.com/oven-sh/bun/issues/33729
+ */
+function runCommand(
+  name: string,
+  args: string[],
+  options?: { cwd?: string; timeout?: number },
+): void {
+  const bin = resolveBin(name);
+  const result = Bun.spawnSync([bin, ...args], {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+    ...(options?.cwd ? { cwd: options.cwd } : {}),
+    ...(options?.timeout ? { timeout: options.timeout } : {}),
+  });
+  if (!result.success) {
+    throw new UpdateAbort(`Command failed: ${name} ${args.join(" ")} (exit ${result.exitCode})`);
+  }
 }
 
 // Walk up from this CLI's location to the Prism install root. Required so
@@ -166,7 +190,7 @@ export const updateCommand = new Command("update")
       console.log("✓ SHA-256 checksum verified");
 
       console.log("Extracting tarball...");
-      execFileSync(resolveBin("tar"), ["-xzf", tarballPath, "-C", workDir], { stdio: "inherit" });
+      runCommand("tar", ["-xzf", tarballPath, "-C", workDir]);
 
       // R2 tarballs extract at top level; legacy ones had a subdir.
       const candidateRoots = [workDir, join(workDir, "prism-liquidity-agent")];
@@ -191,7 +215,7 @@ export const updateCommand = new Command("update")
         );
       }
 
-      execFileSync(resolveBin("bun"), ["install"], { cwd: extractedDir, stdio: "inherit" });
+      runCommand("bun", ["install"], { cwd: extractedDir });
 
       // === Pre-apply smoke tests ===
       const skipSmokeTest = options.skipSmokeTest as boolean;
@@ -201,9 +225,8 @@ export const updateCommand = new Command("update")
       } else {
         console.log("Running TypeScript smoke test...");
         try {
-          execFileSync(resolveBin("bunx"), ["tsc", "--noEmit"], {
+          runCommand("bun", [join(extractedDir, "node_modules/typescript/bin/tsc"), "--noEmit"], {
             cwd: extractedDir,
-            stdio: "inherit",
           });
           console.log("✓ TypeScript smoke test passed");
         } catch {
@@ -213,9 +236,8 @@ export const updateCommand = new Command("update")
 
         console.log("Running test suite smoke test...");
         try {
-          execFileSync(resolveBin("bunx"), ["--bun", "vitest", "run"], {
+          runCommand("bun", [join(extractedDir, "node_modules/vitest/vitest.mjs"), "run"], {
             cwd: extractedDir,
-            stdio: "inherit",
           });
           console.log("✓ Test suite smoke test passed");
         } catch {
@@ -238,9 +260,7 @@ export const updateCommand = new Command("update")
         if (existsSync(stagedRoot)) {
           rmSync(stagedRoot, { recursive: true, force: true });
         }
-        execFileSync(resolveBin("cp"), ["-R", `${extractedDir}/.`, `${stagedRoot}/`], {
-          stdio: "inherit",
-        });
+        runCommand("cp", ["-R", `${extractedDir}/.`, `${stagedRoot}/`]);
 
         for (const file of userFilesToPreserve) {
           const source = join(installRoot, file);
@@ -249,7 +269,7 @@ export const updateCommand = new Command("update")
             if (existsSync(dest)) {
               rmSync(dest, { recursive: true, force: true });
             }
-            execFileSync(resolveBin("cp"), ["-R", source, dest], { stdio: "inherit" });
+            runCommand("cp", ["-R", source, dest]);
           }
         }
 
@@ -257,25 +277,31 @@ export const updateCommand = new Command("update")
           rmSync(backupRoot, { recursive: true, force: true });
         }
 
-        execFileSync(resolveBin("mv"), [installRoot, currentBackup], { stdio: "inherit" });
+        // A previous failed update may have left the current backup behind.
+        // Remove it so `mv installRoot currentBackup` does not fail with
+        // "Directory not empty".
+        if (existsSync(currentBackup)) {
+          rmSync(currentBackup, { recursive: true, force: true });
+        }
+
+        runCommand("mv", [installRoot, currentBackup]);
         try {
-          execFileSync(resolveBin("mv"), [stagedRoot, installRoot], { stdio: "inherit" });
+          runCommand("mv", [stagedRoot, installRoot]);
         } catch (swapErr) {
           if (existsSync(currentBackup) && !existsSync(installRoot)) {
-            execFileSync(resolveBin("mv"), [currentBackup, installRoot], { stdio: "inherit" });
+            runCommand("mv", [currentBackup, installRoot]);
           }
           throw swapErr;
         }
         if (existsSync(currentBackup)) {
-          execFileSync(resolveBin("mv"), [currentBackup, backupRoot], { stdio: "inherit" });
+          runCommand("mv", [currentBackup, backupRoot]);
         }
 
         // Post-apply health check
         console.log("Running post-apply health check...");
         try {
-          execFileSync(resolveBin("bunx"), ["tsc", "--noEmit"], {
+          runCommand("bun", [join(installRoot, "node_modules/typescript/bin/tsc"), "--noEmit"], {
             cwd: installRoot,
-            stdio: "inherit",
             timeout: 30_000,
           });
         } catch (healthErr) {
@@ -283,7 +309,7 @@ export const updateCommand = new Command("update")
           try {
             rmSync(installRoot, { recursive: true, force: true });
             if (existsSync(backupRoot)) {
-              execFileSync(resolveBin("mv"), [backupRoot, installRoot], { stdio: "inherit" });
+              runCommand("mv", [backupRoot, installRoot]);
             }
           } catch (rollbackErr) {
             throw new UpdateAbort(

--- a/engine/update-utils.ts
+++ b/engine/update-utils.ts
@@ -1,6 +1,14 @@
 import { Effect } from "effect";
 import semver from "semver";
 
+function tryNetwork<T>(promise: () => Promise<T>, description: string): Effect.Effect<T, Error> {
+  return Effect.tryPromise({
+    try: promise,
+    catch: (error) =>
+      new Error(`${description}: ${error instanceof Error ? error.message : String(error)}`),
+  });
+}
+
 export function compareVersions(a: string, b: string): number {
   const cleanA = semver.clean(a) || a;
   const cleanB = semver.clean(b) || b;
@@ -61,13 +69,15 @@ export function fetchR2Manifest(
     const path = R2_MANIFEST_PATHS[channel];
     const url = `${r2PublicUrl}/${path}`;
 
-    const response = yield* Effect.tryPromise(() =>
-      fetch(url, {
-        headers: {
-          "User-Agent": "prism-liquidity-agent",
-          Accept: "application/json",
-        },
-      }),
+    const response = yield* tryNetwork(
+      () =>
+        fetch(url, {
+          headers: {
+            "User-Agent": "prism-liquidity-agent",
+            Accept: "application/json",
+          },
+        }),
+      `Failed to fetch R2 manifest from ${url}`,
     );
 
     if (!response.ok) {
@@ -79,7 +89,10 @@ export function fetchR2Manifest(
       );
     }
 
-    const manifest = (yield* Effect.tryPromise(() => response.json())) as R2Manifest;
+    const manifest = (yield* tryNetwork(
+      () => response.json(),
+      "Failed to parse R2 manifest JSON",
+    )) as R2Manifest;
     return manifest;
   });
 }
@@ -103,7 +116,10 @@ export function fetchGitHubRelease(
       headers.Authorization = `Bearer ${token}`;
     }
 
-    const response = yield* Effect.tryPromise(() => fetch(url, { headers }));
+    const response = yield* tryNetwork(
+      () => fetch(url, { headers }),
+      `Failed to fetch GitHub release from ${url}`,
+    );
 
     if (response.status === 403 || response.status === 429) {
       const rateLimitRemaining = response.headers.get("x-ratelimit-remaining");
@@ -123,13 +139,17 @@ export function fetchGitHubRelease(
     }
 
     if (channel === "stable") {
-      const release = (yield* Effect.tryPromise(() => response.json())) as
-        | GitHubRelease
-        | undefined;
+      const release = (yield* tryNetwork(
+        () => response.json(),
+        "Failed to parse GitHub release JSON",
+      )) as GitHubRelease | undefined;
       return release ?? null;
     }
 
-    const firstPageReleases = (yield* Effect.tryPromise(() => response.json())) as GitHubRelease[];
+    const firstPageReleases = (yield* tryNetwork(
+      () => response.json(),
+      "Failed to parse GitHub releases JSON",
+    )) as GitHubRelease[];
 
     const allReleases: GitHubRelease[] = Array.isArray(firstPageReleases)
       ? [...firstPageReleases]
@@ -150,8 +170,9 @@ export function fetchGitHubRelease(
       if (token) {
         pageHeaders.Authorization = `Bearer ${token}`;
       }
-      const pageResponse = yield* Effect.tryPromise(() =>
-        fetch(pageUrl!, { headers: pageHeaders }),
+      const pageResponse = yield* tryNetwork(
+        () => fetch(pageUrl!, { headers: pageHeaders }),
+        "Failed to fetch GitHub releases page",
       );
 
       if (!pageResponse.ok) {
@@ -160,7 +181,10 @@ export function fetchGitHubRelease(
         );
       }
 
-      const releases = (yield* Effect.tryPromise(() => pageResponse.json())) as GitHubRelease[];
+      const releases = (yield* tryNetwork(
+        () => pageResponse.json(),
+        "Failed to parse GitHub releases page JSON",
+      )) as GitHubRelease[];
 
       if (!Array.isArray(releases) || releases.length === 0) {
         break;
@@ -237,11 +261,22 @@ export function fetchLatestRelease(
         return r2ManifestToInfo(manifest);
       }
     }
+    const r2Error = r2Result._tag === "Left" ? r2Result.left : null;
 
-    const ghRelease = yield* fetchGitHubRelease(repo, channel, token);
-    if (!ghRelease) {
+    const ghResult = yield* Effect.either(fetchGitHubRelease(repo, channel, token));
+    if (ghResult._tag === "Right") {
+      if (ghResult.right) {
+        return githubReleaseToInfo(ghResult.right, channel);
+      }
       return null;
     }
-    return githubReleaseToInfo(ghRelease, channel);
+
+    const ghError = ghResult.left;
+    if (r2Error) {
+      return yield* Effect.fail(
+        new Error(`Update check failed. R2: ${r2Error.message}; GitHub: ${ghError.message}`),
+      );
+    }
+    return yield* Effect.fail(new Error(`Update check failed: ${ghError.message}`));
   });
 }


### PR DESCRIPTION
## What changed

- Replaced every `execFileSync` call in `cli/update.ts` with `Bun.spawnSync`, avoiding the Bun shell-fallback bug that produced `ENOENT posix_spawn '/bin/sh'` during the v0.0.24 update swap.
- Pre-removes stale `.prism-prev-*` backup directories before the atomic `mv`, so a previous failed update cannot cause `Directory not empty` errors.
- Runs smoke tests directly under Bun via `node_modules/typescript/bin/tsc` and `node_modules/vitest/vitest.mjs`, bypassing `bunx`'s Node fallback that tripped the Bun guard in some environments.
- Improved network error messages in `engine/update-utils.ts` so R2/GitHub failures surface the real cause instead of `An unknown error occurred in Effect.tryPromise`.

## Upstream bug

- oven-sh/bun#33729

## Verification

- `bun run lint` — pass
- `bun run format:check` — pass
- `bun run build` — pass
- `bun run test` — 487/487 pass
- `bun cli/index.ts update --check-only` — works, reports `0.0.20 → v0.0.24`
