### PR TITLE
chore(review): address PR #78 bot-review follow-ups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set VERSION and CHANNEL
         run: |

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Common agent commands:
 | `prism update`                                                   | Self-update from R2/GitHub releases (with smoke tests + rollback) |
 | `prism wallet {generate,import,show}`                            | Non-custodial local keypair (required for live trading)           |
 
-Do NOT manually edit `.env` or run `bun run dev` directly — always go through the `prism` wrapper so the working directory and config are resolved consistently. See [docs/agent-harness.md](docs/agent-harness.md) for the full agent guide and common anti-patterns.
+For the bundle-install paths (one-liner and pinned release), do NOT manually edit `.env` or bypass the `prism` wrapper — always invoke `prism` so the install root and config directories are resolved consistently. If you are developing on Prism from source, use `bun run dev` directly instead; the source workflow does not create `~/.local/bin/prism` or run `install.sh`. See [docs/agent-harness.md](docs/agent-harness.md) for the full agent guide and common anti-patterns.
 
 To run the historical simulation:
 

--- a/bench/update-check.test.ts
+++ b/bench/update-check.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Effect, Layer } from "effect";
 import { rmSync, mkdtempSync } from "fs";
-import { homedir, tmpdir } from "os";
+import { tmpdir } from "os";
 import { join } from "path";
 import { ConfigService } from "../engine/config-service.js";
 import { DbLive } from "../engine/db-service.js";
@@ -118,18 +118,15 @@ describe("checkForAutoUpdate", () => {
     vi.stubEnv("HOME", tempHome);
     vi.stubEnv("USERPROFILE", tempHome);
     exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-    try {
-      rmSync(join(homedir(), ".config", "prism", "version-installed-at"));
-    } catch {
-      // ignore if file does not exist
-    }
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
-    rmSync(tempHome, { recursive: true, force: true });
+    if (tempHome) {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
   });
 
   it("respects check interval (skips if recent)", async () => {

--- a/bench/update-check.test.ts
+++ b/bench/update-check.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Effect, Layer } from "effect";
-import { rmSync } from "fs";
-import { homedir } from "os";
+import { rmSync, mkdtempSync } from "fs";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { ConfigService } from "../engine/config-service.js";
 import { DbLive } from "../engine/db-service.js";
@@ -111,8 +111,12 @@ function buildLayer(
 describe("checkForAutoUpdate", () => {
   const originalFetch = globalThis.fetch;
   let exitSpy: ReturnType<typeof vi.spyOn>;
+  let tempHome: string;
 
   beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "prism-update-check-"));
+    vi.stubEnv("HOME", tempHome);
+    vi.stubEnv("USERPROFILE", tempHome);
     exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
     try {
       rmSync(join(homedir(), ".config", "prism", "version-installed-at"));
@@ -124,6 +128,8 @@ describe("checkForAutoUpdate", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    rmSync(tempHome, { recursive: true, force: true });
   });
 
   it("respects check interval (skips if recent)", async () => {

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -80,7 +80,10 @@ function runCommand(
     ...(options?.timeout ? { timeout: options.timeout } : {}),
   });
   if (!result.success) {
-    throw new UpdateAbort(`Command failed: ${name} ${args.join(" ")} (exit ${result.exitCode})`);
+    const cwdMsg = options?.cwd ? ` in ${options.cwd}` : "";
+    throw new UpdateAbort(
+      `Command failed: ${name} ${args.join(" ")}${cwdMsg} (exit ${result.exitCode})`,
+    );
   }
 }
 
@@ -98,7 +101,10 @@ function runCommandOutput(
     ...(options?.timeout ? { timeout: options.timeout } : {}),
   });
   if (!result.success) {
-    throw new UpdateAbort(`Command failed: ${name} ${args.join(" ")} (exit ${result.exitCode})`);
+    const cwdMsg = options?.cwd ? ` in ${options.cwd}` : "";
+    throw new UpdateAbort(
+      `Command failed: ${name} ${args.join(" ")}${cwdMsg} (exit ${result.exitCode})`,
+    );
   }
   return result.stdout.toString().trim();
 }

--- a/engine/update-utils.ts
+++ b/engine/update-utils.ts
@@ -5,7 +5,10 @@ function tryNetwork<T>(promise: () => Promise<T>, description: string): Effect.E
   return Effect.tryPromise({
     try: promise,
     catch: (error) =>
-      new Error(`${description}: ${error instanceof Error ? error.message : String(error)}`),
+      new Error(
+        `${description}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      ),
   });
 }
 


### PR DESCRIPTION
This is a follow-up to #78 that addresses the actionable bot review comments without reverting the compiled bundle distribution approach.

Changes:
- engine/update-utils.ts: preserve original error in tryNetwork via cause.
- cli/update.ts: include cwd in runCommand/runCommandOutput failure messages.
- bench/update-check.test.ts: isolate tests with a temporary HOME via vi.stubEnv instead of touching the real ~/.config/prism.
- .github/workflows/release.yml: add persist-credentials: false to the release job checkout.
- README.md: clarify that the prism wrapper guidance applies only to bundle installs and document the source workflow separately.

Verification:
- bun run lint: 0 warnings, 0 errors
- bun run test: 488 tests passed

## Summary by Sourcery

Improve update error reporting, test isolation, release workflow safety, and clarify installation documentation.

Bug Fixes:
- Preserve original network error details in update utilities via error causes.
- Include working directory information in CLI update command failure messages.
- Isolate auto-update bench tests by using a temporary HOME directory instead of the real user config.

Enhancements:
- Clarify README guidance for bundle-based installs versus source-based development workflows.

CI:
- Disable credential persistence in the release workflow checkout step to reduce token exposure.