### PR TITLE
fix(runtime): fail-open install paths, agent overlay, and sqlite-vec for v0.0.28

### DIFF
--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -176,7 +176,7 @@ function selectTransport(
     });
   }
 
-  if (runtime === "openclaw" && (detection.openclaw.gatewayRunning || detection.openclaw.available)) {
+  if (runtime === "openclaw" && detection.openclaw.gatewayRunning) {
     return new GatewayTransport({
       url: config.agentGatewayUrl,
       token: config.agentGatewayToken,

--- a/engine/db.ts
+++ b/engine/db.ts
@@ -60,12 +60,13 @@ export function createDatabase(dbPath = "./prism.db"): Database {
   fs.mkdirSync(path.dirname(path.resolve(dbPath)), { recursive: true });
   const db = new Database(dbPath);
   db.exec("PRAGMA journal_mode = WAL;");
-  runMigrations(db);
 
-  // If a previous attempt in this process showed sqlite-vec cannot work,
-  // skip it entirely to avoid repeated warnings on every DB open.
+  // Load sqlite-vec before migrations so migration v1 can create the vec_memory
+  // virtual table without warning. Extension availability is determined by the
+  // runtime environment and won't change within a process, so a process-wide
+  // flag is used to skip repeated failing attempts.
+  let vecLoaded = false;
   if (!sqliteVecEverFailed) {
-    let vecLoaded = false;
     try {
       loadVec(db);
       vecLoaded = true;
@@ -101,15 +102,17 @@ export function createDatabase(dbPath = "./prism.db"): Database {
         sqliteVecEverFailed = true;
       }
     }
+  }
 
-    if (vecLoaded && !hasVecMemoryTable(db)) {
-      tryCreateVecMemoryTable(db);
-      if (hasVecMemoryTable(db)) {
-        logger.info("sqlite-vec vec_memory table self-healed");
-      } else {
-        logger.warn("sqlite-vec vec_memory table not queryable; memory disabled");
-        sqliteVecEverFailed = true;
-      }
+  runMigrations(db);
+
+  if (vecLoaded && !hasVecMemoryTable(db)) {
+    tryCreateVecMemoryTable(db);
+    if (hasVecMemoryTable(db)) {
+      logger.info("sqlite-vec vec_memory table self-healed");
+    } else {
+      logger.warn("sqlite-vec vec_memory table not queryable; memory disabled");
+      sqliteVecEverFailed = true;
     }
   }
 

--- a/engine/db.ts
+++ b/engine/db.ts
@@ -6,6 +6,7 @@ import { createLogger } from "./logger.js";
 import { getEmbeddedVec0Path } from "./sqlite-vec-embedded.js";
 
 const logger = createLogger("db");
+let sqliteVecEverFailed = false;
 
 function setupCustomSQLite() {
   if (process.platform === "darwin") {
@@ -59,50 +60,59 @@ export function createDatabase(dbPath = "./prism.db"): Database {
   fs.mkdirSync(path.dirname(path.resolve(dbPath)), { recursive: true });
   const db = new Database(dbPath);
   db.exec("PRAGMA journal_mode = WAL;");
-  let vecLoaded = false;
-  try {
-    loadVec(db);
-    vecLoaded = true;
-  } catch (e) {
-    const envPath = process.env.PRISM_VEC0_PATH;
-    if (envPath) {
-      try {
-        db.loadExtension(envPath);
-        vecLoaded = true;
-      } catch (envErr) {
-        logger.warn("PRISM_VEC0_PATH sqlite-vec extension could not be loaded", {
-          error: envErr instanceof Error ? envErr.message : String(envErr),
-        });
-      }
-    }
-    if (!vecLoaded) {
-      const embeddedPath = getEmbeddedVec0Path();
-      if (embeddedPath) {
+  runMigrations(db);
+
+  // If a previous attempt in this process showed sqlite-vec cannot work,
+  // skip it entirely to avoid repeated warnings on every DB open.
+  if (!sqliteVecEverFailed) {
+    let vecLoaded = false;
+    try {
+      loadVec(db);
+      vecLoaded = true;
+    } catch (e) {
+      const envPath = process.env.PRISM_VEC0_PATH;
+      if (envPath) {
         try {
-          db.loadExtension(embeddedPath);
+          db.loadExtension(envPath);
           vecLoaded = true;
-        } catch (embeddedErr) {
-          logger.warn("Embedded sqlite-vec extension could not be loaded", {
-            error: embeddedErr instanceof Error ? embeddedErr.message : String(embeddedErr),
+        } catch (envErr) {
+          logger.warn("PRISM_VEC0_PATH sqlite-vec extension could not be loaded", {
+            error: envErr instanceof Error ? envErr.message : String(envErr),
           });
         }
       }
+      if (!vecLoaded) {
+        const embeddedPath = getEmbeddedVec0Path();
+        if (embeddedPath) {
+          try {
+            db.loadExtension(embeddedPath);
+            vecLoaded = true;
+          } catch (embeddedErr) {
+            logger.warn("Embedded sqlite-vec extension could not be loaded", {
+              error: embeddedErr instanceof Error ? embeddedErr.message : String(embeddedErr),
+            });
+          }
+        }
+      }
+      if (!vecLoaded) {
+        logger.warn("sqlite-vec extension could not be loaded; memory will be disabled", {
+          error: e instanceof Error ? e.message : String(e),
+        });
+        sqliteVecEverFailed = true;
+      }
     }
-    if (!vecLoaded) {
-      logger.warn("sqlite-vec extension could not be loaded", {
-        error: e instanceof Error ? e.message : String(e),
-      });
+
+    if (vecLoaded && !hasVecMemoryTable(db)) {
+      tryCreateVecMemoryTable(db);
+      if (hasVecMemoryTable(db)) {
+        logger.info("sqlite-vec vec_memory table self-healed");
+      } else {
+        logger.warn("sqlite-vec vec_memory table not queryable; memory disabled");
+        sqliteVecEverFailed = true;
+      }
     }
   }
-  runMigrations(db);
-  if (vecLoaded && !hasVecMemoryTable(db)) {
-    tryCreateVecMemoryTable(db);
-    if (hasVecMemoryTable(db)) {
-      logger.info("sqlite-vec vec_memory table self-healed");
-    } else {
-      logger.warn("sqlite-vec vec_memory table not queryable after self-heal attempt");
-    }
-  }
+
   return db;
 }
 

--- a/engine/paths.ts
+++ b/engine/paths.ts
@@ -30,6 +30,12 @@ function resolveEntryScript(): string {
 }
 
 function resolveProjectRoot(): string {
+  // The wrapper sets this so bundled/source installs resolve consistently
+  // regardless of how the binary was invoked or where the caller's CWD is.
+  if (process.env.PRISM_INSTALL_DIR) {
+    return path.resolve(process.env.PRISM_INSTALL_DIR);
+  }
+
   const entry = resolveEntryScript();
   if (!entry) return process.cwd();
 

--- a/engine/run-engine.ts
+++ b/engine/run-engine.ts
@@ -6,13 +6,18 @@ import { program, buildLayer } from "./program.js";
 import { ConfigService, ConfigLive } from "./config-service.js";
 import { errorReporter } from "./error-reporter.js";
 import { getCurrentVersion } from "./version.js";
-import { getPrismLogsDir } from "./paths.js";
+import { getPrismConfigDir, getPrismDataDir, getPrismDbPath, getPrismEnvPath, getPrismLogsDir } from "./paths.js";
 
 function redirectStdoutStderrToFile(): void {
   const logsDir = getPrismLogsDir();
   fs.mkdirSync(logsDir, { recursive: true, mode: 0o700 });
   const logPath = path.join(logsDir, "engine.log");
   const stream = fs.createWriteStream(logPath, { flags: "a" });
+
+  stream.on("error", (err) => {
+    // Use original stderr to avoid recursive failure if the audit stream is broken.
+    process.stderr.write(`[run-engine] log stream error: ${err.message}\n`);
+  });
 
   const originalStdoutWrite = process.stdout.write.bind(process.stdout) as (
     chunk: unknown,
@@ -61,6 +66,9 @@ function ensureError(cause: unknown): Error {
 
 export function runEngine(): Promise<void> {
   errorReporter.setAppVersion(getCurrentVersion());
+
+  console.info(`Prism engine starting — version ${getCurrentVersion()}`);
+  console.info(`Resolved paths: installDir=${process.env.PRISM_INSTALL_DIR ?? "(not set)"} configDir=${getPrismConfigDir()} dataDir=${getPrismDataDir()} envPath=${getPrismEnvPath()} dbPath=${getPrismDbPath()} logsDir=${getPrismLogsDir()}`);
 
   process.on("uncaughtException", (err) => {
     errorReporter.report(ensureError(err), { severity: "critical" });

--- a/engine/run-engine.ts
+++ b/engine/run-engine.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { Effect } from "effect";
 import { program, buildLayer } from "./program.js";
 import { ConfigService, ConfigLive } from "./config-service.js";
+import { createLogger } from "./logger.js";
 import { errorReporter } from "./error-reporter.js";
 import { getCurrentVersion } from "./version.js";
 import { getPrismConfigDir, getPrismDataDir, getPrismDbPath, getPrismEnvPath, getPrismLogsDir } from "./paths.js";
@@ -74,8 +75,9 @@ function ensureError(cause: unknown): Error {
 export function runEngine(): Promise<void> {
   errorReporter.setAppVersion(getCurrentVersion());
 
-  console.info(`Prism engine starting — version ${getCurrentVersion()}`);
-  console.info(`Resolved paths: installDir=${process.env.PRISM_INSTALL_DIR ?? "(not set)"} configDir=${getPrismConfigDir()} dataDir=${getPrismDataDir()} envPath=${getPrismEnvPath()} dbPath=${getPrismDbPath()} logsDir=${getPrismLogsDir()}`);
+  const logger = createLogger("run-engine");
+  logger.info(`Prism engine starting — version ${getCurrentVersion()}`);
+  logger.info(`Resolved paths: installDir=${process.env.PRISM_INSTALL_DIR ?? "(not set)"} configDir=${getPrismConfigDir()} dataDir=${getPrismDataDir()} envPath=${getPrismEnvPath()} dbPath=${getPrismDbPath()} logsDir=${getPrismLogsDir()}`);
 
   process.on("uncaughtException", (err) => {
     errorReporter.report(ensureError(err), { severity: "critical" });

--- a/engine/run-engine.ts
+++ b/engine/run-engine.ts
@@ -14,11 +14,6 @@ function redirectStdoutStderrToFile(): void {
   const logPath = path.join(logsDir, "engine.log");
   const stream = fs.createWriteStream(logPath, { flags: "a" });
 
-  stream.on("error", (err) => {
-    // Use original stderr to avoid recursive failure if the audit stream is broken.
-    process.stderr.write(`[run-engine] log stream error: ${err.message}\n`);
-  });
-
   const originalStdoutWrite = process.stdout.write.bind(process.stdout) as (
     chunk: unknown,
     encoding?: unknown,
@@ -35,7 +30,19 @@ function redirectStdoutStderrToFile(): void {
     cb?: unknown,
   ) => boolean;
 
+  let streamBroken = false;
+
+  stream.on("error", (err) => {
+    if (streamBroken) return;
+    streamBroken = true;
+    // Restore original writers so a broken stream doesn't keep swallowing output.
+    process.stdout.write = originalStdoutWrite as typeof process.stdout.write;
+    process.stderr.write = originalStderrWrite as typeof process.stderr.write;
+    process.stderr.write(`[run-engine] log stream error: ${err.message}\n`);
+  });
+
   function safeStreamWrite(chunk: unknown, encoding?: unknown, cb?: unknown): void {
+    if (streamBroken) return;
     try {
       streamWrite(chunk, encoding, cb);
     } catch {

--- a/scripts/prism.sh
+++ b/scripts/prism.sh
@@ -15,5 +15,6 @@ done
 PACKAGE_ROOT=$(cd -- "$(dirname -- "$SOURCE")/.." && pwd)
 
 cd "$PACKAGE_ROOT"
+export PRISM_INSTALL_DIR="$PACKAGE_ROOT"
 exec bun "$PACKAGE_ROOT/cli/index.ts" "$@"
 


### PR DESCRIPTION
Fixes the runtime health issues seen after updating to v0.0.28.

- **Install path anchoring**: `scripts/prism.sh` now exports `PRISM_INSTALL_DIR` and `engine/paths.ts` uses it as the authoritative project root. This prevents mismatches between the engine and CLI when the binary is invoked via symlink or from a different CWD.
- **Startup observability**: `engine/run-engine.ts` logs resolved `installDir`, `configDir`, `dataDir`, `envPath`, `dbPath`, and `logsDir` at startup, and surfaces log-stream errors so an empty `audit-trail.jsonl` is easier to diagnose.
- **Agent overlay fail-open**: `engine/agent-service.ts` only selects `openclaw` when the OpenClaw gateway is actually running; avoids a 5s connect timeout per decision when the binary exists but the gateway is down.
- **sqlite-vec quiet fallback**: `engine/db.ts` remembers extension failure within a process, skips retries, and logs `memory disabled` once instead of repeating self-heal warnings.

**Post-review fixes:**
- `engine/db.ts`: load sqlite-vec **before** running migrations so migration v1 can create the `vec_memory` virtual table cleanly on fresh DBs (no noisy fallback warnings).
- `engine/run-engine.ts`: if the log stream errors, restore original `stdout`/`stderr` writers so a broken stream doesn't keep swallowing output.
- `engine/run-engine.ts`: use `createLogger("run-engine")` for startup diagnostics for consistent formatting with the rest of `runEngine()`.

**Verification:**
- `bun run lint` → 0 warnings, 0 errors.
- `bun run test` → 494 tests passed (50 test files).
