### PR TITLE
fix: reduce repeated live entry failures and RPC pressure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,7 +311,7 @@ In test mode (`NODE_ENV=test` or `VITEST=true`), missing `HELIUS_API_KEY` defaul
 - **Live discovery is opt-in.** Keep `ENABLE_POOL_DISCOVERY=false` and configure `WATCHLIST_POOLS` with approved pools. Automatic discovery also excludes Meteora launchpad pools.
 - **Deployer blacklist is half-wired.** `blacklist.checkPool()` accepts deployer addresses, but deployers are not currently fetched from on-chain metadata.
 - **One ENTER per live cycle.** In live mode, `ENTER` is silently skipped if any position is already open.
-- **Live entry balance policy.** Live entries fail closed when either requested token amount exceeds the wallet balance; they are not silently downsized.
+- **Live entry balance policy.** Live entries fail closed when requested token amount exceeds the wallet balance; they are not silently downsized.
 - **Live entry retry policy.** Deterministic insufficient-token failures are exponentially backed off per pool (30 minutes to 6 hours) to avoid repeating doomed entries and amplifying RPC load.
 - **Scan metrics.** Cycle logs report `decided`, `executed`, and `failed` pools separately; `decided` is not a success count.
 - **Scan failure semantics.** `failed` counts processing or execution failures; risk and backoff gates are rejected decisions recorded in the audit trail, not execution failures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,8 @@ In test mode (`NODE_ENV=test` or `VITEST=true`), missing `HELIUS_API_KEY` defaul
 - **Deployer blacklist is half-wired.** `blacklist.checkPool()` accepts deployer addresses, but deployers are not currently fetched from on-chain metadata.
 - **One ENTER per live cycle.** In live mode, `ENTER` is silently skipped if any position is already open.
 - **Live entry balance policy.** Live entries fail closed when either requested token amount exceeds the wallet balance; they are not silently downsized.
+- **Live entry retry policy.** Deterministic insufficient-token failures are exponentially backed off per pool (30 minutes to 6 hours) to avoid repeating doomed entries and amplifying RPC load.
+- **Scan metrics.** Cycle logs report `decided`, `executed`, and `failed` pools separately; `decided` is not a success count.
 - **sqlite-vec extension.** Source installs rely on `scripts/generate-vec-embed.ts` to create `engine/sqlite-vec-embedded.ts`; bundled installs provide the native extension via `PRISM_VEC0_PATH`.
 - **Backtest is a simplified simulation.** It does not replicate the full decision loop (no risk gates, memory, dynamic ENTER/EXIT sizing, trailing stop). Use it as a regression baseline, not a performance forecast.
 - **`.env.example` is stale in places.** For example, its `UPDATE_R2_PUBLIC_URL` default does not match the code fallback. Always verify against `engine/config-service.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,7 @@ In test mode (`NODE_ENV=test` or `VITEST=true`), missing `HELIUS_API_KEY` defaul
 - **Live entry balance policy.** Live entries fail closed when either requested token amount exceeds the wallet balance; they are not silently downsized.
 - **Live entry retry policy.** Deterministic insufficient-token failures are exponentially backed off per pool (30 minutes to 6 hours) to avoid repeating doomed entries and amplifying RPC load.
 - **Scan metrics.** Cycle logs report `decided`, `executed`, and `failed` pools separately; `decided` is not a success count.
+- **Scan failure semantics.** `failed` counts processing or execution failures; risk and backoff gates are rejected decisions recorded in the audit trail, not execution failures.
 - **sqlite-vec extension.** Source installs rely on `scripts/generate-vec-embed.ts` to create `engine/sqlite-vec-embedded.ts`; bundled installs provide the native extension via `PRISM_VEC0_PATH`.
 - **Backtest is a simplified simulation.** It does not replicate the full decision loop (no risk gates, memory, dynamic ENTER/EXIT sizing, trailing stop). Use it as a regression baseline, not a performance forecast.
 - **`.env.example` is stale in places.** For example, its `UPDATE_R2_PUBLIC_URL` default does not match the code fallback. Always verify against `engine/config-service.ts`.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Live entries that fail because the wallet lacks a pool token are backed off
 exponentially for that pool, starting at 30 minutes and capped at 6 hours.
 RPC requests are paced, wallet balances are cached briefly within the adapter,
 and scan logs report decided, executed, and failed pools separately.
+`failed` counts processing or execution failures; risk and backoff gates are
+rejected decisions recorded in the audit trail, not execution failures.
 
 ## Agent runtime overlay
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Key `.env` variables:
 | `SQLITE_DB_PATH`          | `./prism.db` | SQLite database file path                |
 | `ENABLE_SNAPSHOT_CAPTURE` | `false`      | Dump pool snapshots to DB (paper only)   |
 
+Live entries that fail because the wallet lacks a pool token are backed off
+exponentially for that pool, starting at 30 minutes and capped at 6 hours.
+RPC requests are paced, wallet balances are cached briefly within the adapter,
+and scan logs report decided, executed, and failed pools separately.
+
 ## Agent runtime overlay
 
 When Prism runs under a local agent harness (Hermes or OpenClaw), enable `AGENTIC_MODE=true` to let the harness review decisions and receive proactive check-ins. No remote LLM API keys are used; communication happens over local ACP (Hermes) or Gateway WebSocket (OpenClaw). The overlay can only reduce confidence or change an action to `HOLD`.

--- a/bench/adapter-retry.test.ts
+++ b/bench/adapter-retry.test.ts
@@ -94,6 +94,29 @@ describe("retryWithBackoff", () => {
     );
     expect(fn).toHaveBeenCalledTimes(1);
   });
+
+  it("honors Retry-After headers when rate limited", async () => {
+    let call = 0;
+    const startedAt = Date.now();
+    const fn = vi.fn(async () => {
+      call++;
+      if (call === 1) {
+        throw {
+          code: 429,
+          headers: { get: () => "0.02" },
+          message: "too many requests",
+        };
+      }
+      return "ok";
+    });
+
+    await Effect.runPromise(
+      retryWithBackoff(fn, { baseDelayMs: 1, rateLimitBaseDelayMs: 1, maxRetries: 1 }),
+    );
+
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(15);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
 });
 
 // ── CircuitBreaker ────────────────────────────────────────────────

--- a/bench/adapter-retry.test.ts
+++ b/bench/adapter-retry.test.ts
@@ -42,6 +42,12 @@ describe("isRetriableError", () => {
   });
 });
 
+describe("isRpcNetworkError", () => {
+  it("classifies adapter RPC timeouts as network failures", () => {
+    expect(isRpcNetworkError(new Error("RPC request timeout after 15s"))).toBe(true);
+  });
+});
+
 // ── retryWithBackoff ──────────────────────────────────────────────
 
 describe("retryWithBackoff", () => {

--- a/bench/adapter-retry.test.ts
+++ b/bench/adapter-retry.test.ts
@@ -4,6 +4,7 @@ import {
   isRetriableError,
   isRpcNetworkError,
   retryWithBackoff,
+  retryAfterMs,
   CircuitBreaker,
   CircuitBreakerOpenError,
 } from "../engine/adapter-retry.js";
@@ -45,6 +46,51 @@ describe("isRetriableError", () => {
 describe("isRpcNetworkError", () => {
   it("classifies adapter RPC timeouts as network failures", () => {
     expect(isRpcNetworkError(new Error("RPC request timeout after 15s"))).toBe(true);
+  });
+});
+
+// ── retryAfterMs ──────────────────────────────────────────────────
+
+describe("retryAfterMs", () => {
+  it("parses Retry-After seconds from Headers-like object", () => {
+    expect(retryAfterMs({ headers: { get: () => "2" } })).toBe(2000);
+  });
+
+  it("parses Retry-After seconds from plain object header", () => {
+    expect(retryAfterMs({ headers: { "retry-after": "3" } })).toBe(3000);
+    expect(retryAfterMs({ headers: { "Retry-After": "4" } })).toBe(4000);
+  });
+
+  it("parses Retry-After seconds from nested response.headers", () => {
+    expect(retryAfterMs({ response: { headers: { get: () => "5" } } })).toBe(5000);
+    expect(retryAfterMs({ response: { headers: { "retry-after": "6" } } })).toBe(6000);
+  });
+
+  it("parses HTTP-date Retry-After header", () => {
+    const retryAt = Date.now() + 5000;
+    const date = new Date(retryAt).toUTCString();
+    const result = retryAfterMs({ headers: { get: () => date } });
+    expect(result).toBeGreaterThanOrEqual(4000);
+    expect(result).toBeLessThanOrEqual(5500);
+  });
+
+  it("caps Retry-After at 5 minutes", () => {
+    expect(retryAfterMs({ headers: { get: () => "600" } })).toBe(300_000);
+  });
+
+  it("caps HTTP-date Retry-After at 5 minutes", () => {
+    const farFuture = new Date(Date.now() + 600_000).toUTCString();
+    expect(retryAfterMs({ headers: { get: () => farFuture } })).toBe(300_000);
+  });
+
+  it("returns undefined when no Retry-After header is present", () => {
+    expect(retryAfterMs({ headers: { get: () => null } })).toBeUndefined();
+    expect(retryAfterMs({})).toBeUndefined();
+    expect(retryAfterMs("not an object")).toBeUndefined();
+  });
+
+  it("ignores invalid Retry-After values", () => {
+    expect(retryAfterMs({ headers: { get: () => "not-a-number" } })).toBeUndefined();
   });
 });
 
@@ -110,6 +156,29 @@ describe("retryWithBackoff", () => {
         throw {
           code: 429,
           headers: { get: () => "0.02" },
+          message: "too many requests",
+        };
+      }
+      return "ok";
+    });
+
+    await Effect.runPromise(
+      retryWithBackoff(fn, { baseDelayMs: 1, rateLimitBaseDelayMs: 1, maxRetries: 1 }),
+    );
+
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(15);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors Retry-After from plain object headers", async () => {
+    let call = 0;
+    const startedAt = Date.now();
+    const fn = vi.fn(async () => {
+      call++;
+      if (call === 1) {
+        throw {
+          code: 429,
+          headers: { "retry-after": "0.02" },
           message: "too many requests",
         };
       }

--- a/bench/entry-backoff.test.ts
+++ b/bench/entry-backoff.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  isInsufficientTokenBalanceError,
+  nextEntryFailureBackoff,
+} from "../engine/entry-backoff.js";
+
+describe("entry failure backoff", () => {
+  it("classifies only deterministic token-balance failures", () => {
+    expect(isInsufficientTokenBalanceError("Insufficient token balance: SOL required 1")).toBe(
+      true,
+    );
+    expect(isInsufficientTokenBalanceError("RPC 429 Too Many Requests")).toBe(false);
+    expect(isInsufficientTokenBalanceError(undefined)).toBe(false);
+  });
+
+  it("increases the retry delay and caps it", () => {
+    const first = nextEntryFailureBackoff(undefined, 1_000);
+    const second = nextEntryFailureBackoff(first, 1_000);
+    let capped = second;
+    for (let i = 0; i < 10; i++) {
+      capped = nextEntryFailureBackoff(capped, 1_000);
+    }
+
+    expect(first.nextAttemptAt).toBe(1_801_000);
+    expect(second.nextAttemptAt).toBe(3_601_000);
+    expect(capped.nextAttemptAt).toBe(21_601_000);
+  });
+});

--- a/bench/entry-backoff.test.ts
+++ b/bench/entry-backoff.test.ts
@@ -15,7 +15,7 @@ describe("entry failure backoff", () => {
 
   it("increases the retry delay and caps it", () => {
     const first = nextEntryFailureBackoff(undefined, 1_000);
-    const second = nextEntryFailureBackoff(first, 1_000);
+    const second = nextEntryFailureBackoff({ ...first, nextAttemptAt: 0 }, 1_000);
     let capped = second;
     for (let i = 0; i < 10; i++) {
       capped = nextEntryFailureBackoff(capped, 1_000);

--- a/engine/adapter-retry.ts
+++ b/engine/adapter-retry.ts
@@ -15,6 +15,44 @@ function hasMessage(err: unknown): err is { readonly message: string } {
   return isObject(err) && "message" in err && typeof err.message === "string";
 }
 
+function retryAfterMs(err: unknown): number | undefined {
+  if (!isObject(err)) return undefined;
+  const headers = err["headers"];
+  const response = err["response"];
+  const responseHeaders = isObject(response) ? response["headers"] : undefined;
+  const getHeader = (value: unknown): string | null => {
+    if (isObject(value) && typeof value["get"] === "function") {
+      const result = (value["get"] as (name: string) => unknown)("retry-after");
+      return typeof result === "string" ? result : null;
+    }
+    return null;
+  };
+  const header = getHeader(headers) ?? getHeader(responseHeaders);
+  if (!header) return undefined;
+  const seconds = Number(header);
+  if (!Number.isFinite(seconds) || seconds < 0) return undefined;
+  return Math.min(seconds * 1000, 120_000);
+}
+
+const retryLogState = new Map<string, { lastLoggedAt: number; suppressed: number }>();
+const RETRY_LOG_INTERVAL_MS = 10_000;
+
+function logRetry(err: unknown, message: string): void {
+  const now = Date.now();
+  const key = String(err);
+  const previous = retryLogState.get(key);
+  if (previous && now - previous.lastLoggedAt < RETRY_LOG_INTERVAL_MS) {
+    previous.suppressed++;
+    return;
+  }
+  const suppressed = previous?.suppressed ?? 0;
+  retryLogState.set(key, { lastLoggedAt: now, suppressed: 0 });
+  logger.warn(message, {
+    error: String(err),
+    ...(suppressed > 0 ? { suppressedRetries: suppressed } : {}),
+  });
+}
+
 export function isRetriableError(err: unknown): boolean {
   if (hasCode(err) && (err.code === 429 || err.code === -32005)) return true;
   if (hasMessage(err)) {
@@ -140,11 +178,11 @@ export function retryEffectWithBackoff<T>(
         const effectiveBase = isRateLimitError(err) ? rateLimitBaseDelayMs : baseDelayMs;
         const exponentialDelay = Math.min(maxDelayMs, effectiveBase * 2 ** attemptNumber);
         const jitter = Math.random() * exponentialDelay * 0.5;
-        const delay = Math.floor(exponentialDelay + jitter);
+        const delay = Math.max(Math.floor(exponentialDelay + jitter), retryAfterMs(err) ?? 0);
         return Effect.sync(() =>
-          logger.warn(
+          logRetry(
+            err,
             `Retriable RPC error (attempt ${attemptNumber + 1}/${maxRetries}), retrying in ${delay}ms`,
-            { error: String(err) },
           ),
         ).pipe(
           Effect.zipRight(Effect.sleep(delay)),

--- a/engine/adapter-retry.ts
+++ b/engine/adapter-retry.ts
@@ -30,25 +30,37 @@ function retryAfterMs(err: unknown): number | undefined {
   const header = getHeader(headers) ?? getHeader(responseHeaders);
   if (!header) return undefined;
   const seconds = Number(header);
-  if (!Number.isFinite(seconds) || seconds < 0) return undefined;
-  return Math.min(seconds * 1000, 120_000);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const retryAt = Date.parse(header);
+  return Number.isFinite(retryAt) ? Math.max(0, retryAt - Date.now()) : undefined;
 }
 
 const retryLogState = new Map<string, { lastLoggedAt: number; suppressed: number }>();
 const RETRY_LOG_INTERVAL_MS = 10_000;
+const RETRY_LOG_MAX_ENTRIES = 512;
+
+function safeErrorMessage(err: unknown): string {
+  return String(err)
+    .replace(/([?&](?:api[-_]?key|token|authorization)=)[^&\s]+/gi, "$1***")
+    .replace(/(Bearer\s+)[^\s]+/gi, "$1***");
+}
 
 function logRetry(err: unknown, message: string): void {
   const now = Date.now();
-  const key = String(err);
+  const key = safeErrorMessage(err);
   const previous = retryLogState.get(key);
   if (previous && now - previous.lastLoggedAt < RETRY_LOG_INTERVAL_MS) {
     previous.suppressed++;
     return;
   }
   const suppressed = previous?.suppressed ?? 0;
+  if (!previous && retryLogState.size >= RETRY_LOG_MAX_ENTRIES) {
+    const oldest = retryLogState.keys().next().value;
+    if (oldest !== undefined) retryLogState.delete(oldest);
+  }
   retryLogState.set(key, { lastLoggedAt: now, suppressed: 0 });
   logger.warn(message, {
-    error: String(err),
+    error: key,
     ...(suppressed > 0 ? { suppressedRetries: suppressed } : {}),
   });
 }
@@ -60,6 +72,7 @@ export function isRetriableError(err: unknown): boolean {
     if (msg.includes("429") || msg.includes("rate limit") || msg.includes("too many requests")) {
       return true;
     }
+    if (msg.includes("rpc request timeout")) return true;
   }
   return false;
 }
@@ -112,6 +125,7 @@ export function isRpcNetworkError(err: unknown): boolean {
     if (msg.includes("429") || msg.includes("rate limit") || msg.includes("too many requests")) {
       return true;
     }
+    if (msg.includes("rpc request timeout")) return true;
     if (/HTTP\s+5\d{2}/.test(err.message)) return true;
   }
 

--- a/engine/adapter-retry.ts
+++ b/engine/adapter-retry.ts
@@ -15,24 +15,35 @@ function hasMessage(err: unknown): err is { readonly message: string } {
   return isObject(err) && "message" in err && typeof err.message === "string";
 }
 
-function retryAfterMs(err: unknown): number | undefined {
+const RETRY_AFTER_MAX_MS = 300_000;
+
+export function retryAfterMs(err: unknown): number | undefined {
   if (!isObject(err)) return undefined;
   const headers = err["headers"];
   const response = err["response"];
   const responseHeaders = isObject(response) ? response["headers"] : undefined;
   const getHeader = (value: unknown): string | null => {
-    if (isObject(value) && typeof value["get"] === "function") {
+    if (!isObject(value)) return null;
+    if (typeof value["get"] === "function") {
       const result = (value["get"] as (name: string) => unknown)("retry-after");
-      return typeof result === "string" ? result : null;
+      if (typeof result === "string") return result;
     }
+    const direct = value["retry-after"] ?? value["Retry-After"];
+    if (typeof direct === "string") return direct;
+    if (typeof direct === "number") return String(direct);
     return null;
   };
   const header = getHeader(headers) ?? getHeader(responseHeaders);
   if (!header) return undefined;
   const seconds = Number(header);
-  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, RETRY_AFTER_MAX_MS);
+  }
   const retryAt = Date.parse(header);
-  return Number.isFinite(retryAt) ? Math.max(0, retryAt - Date.now()) : undefined;
+  if (Number.isFinite(retryAt)) {
+    return Math.min(Math.max(0, retryAt - Date.now()), RETRY_AFTER_MAX_MS);
+  }
+  return undefined;
 }
 
 const retryLogState = new Map<string, { lastLoggedAt: number; suppressed: number }>();

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -356,7 +356,12 @@ export const AdapterLive = Layer.effect(
           Effect.zipRight(
             breaker.execute(
               retryEffectWithBackoff(
-                withRpcTimeout(Effect.tryPromise(() => fn(conn))),
+                withRpcTimeout(
+                  Effect.tryPromise({
+                    try: () => fn(conn),
+                    catch: (cause) => cause,
+                  }),
+                ),
                 RPC_RETRY_OPTIONS,
               ),
               isRpcNetworkError,
@@ -448,19 +453,21 @@ export const AdapterLive = Layer.effect(
     const fetchHeliusAssetCached = yield* Effect.cachedFunction((mint: string) => {
       const url = `https://mainnet.helius-rpc.com/?api-key=${config.heliusApiKey}`;
       const assetRequest = Effect.gen(function* () {
-        const res = yield* Effect.tryPromise(() =>
-          fetch(url, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              jsonrpc: "2.0",
-              id: "get-asset",
-              method: "getAsset",
-              params: { id: mint },
+        const res = yield* Effect.tryPromise({
+          try: () =>
+            fetch(url, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                jsonrpc: "2.0",
+                id: "get-asset",
+                method: "getAsset",
+                params: { id: mint },
+              }),
+              signal: AbortSignal.timeout(10_000),
             }),
-            signal: AbortSignal.timeout(10_000),
-          }),
-        );
+          catch: (cause) => cause,
+        });
         if (!res.ok) {
           return yield* Effect.fail(
             Object.assign(new Error(`Helius getAsset returned HTTP ${res.status}`), {

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -39,12 +39,13 @@ const SOL_MINT = "So11111111111111111111111111111111111111112";
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const GAS_RESERVE_LAMPORTS = 20_000_000n; // 0.02 SOL reserved for fees and non-System-program costs
 const RPC_RETRY_OPTIONS = {
-  maxRetries: 2,
+  maxRetries: 1,
   baseDelayMs: 1_000,
   maxDelayMs: 30_000,
   rateLimitBaseDelayMs: 5_000,
 } as const;
 const RPC_MIN_INTERVAL_MS = 50;
+const RPC_REQUEST_TIMEOUT_MS = 15_000;
 
 function formatTokenAmount(amount: bigint, decimals: number): string {
   return (Number(amount) / 10 ** decimals).toFixed(Math.min(decimals, 6));
@@ -319,18 +320,31 @@ export const AdapterLive = Layer.effect(
     let nextHeliusRequestAt = 0;
 
     function paceRpc(conn: Connection): Effect.Effect<void> {
-      const now = Date.now();
-      const nextStartAt = nextRpcStartAt.get(conn) ?? now;
-      const waitMs = Math.max(0, nextStartAt - now);
-      nextRpcStartAt.set(conn, Math.max(now, nextStartAt) + RPC_MIN_INTERVAL_MS);
-      return Effect.sleep(waitMs);
+      return Effect.sync(() => {
+        const now = Date.now();
+        const nextStartAt = nextRpcStartAt.get(conn) ?? now;
+        const waitMs = Math.max(0, nextStartAt - now);
+        nextRpcStartAt.set(conn, Math.max(now, nextStartAt) + RPC_MIN_INTERVAL_MS);
+        return waitMs;
+      }).pipe(Effect.flatMap(Effect.sleep));
     }
 
     function paceHeliusRequest(): Effect.Effect<void> {
-      const now = Date.now();
-      const waitMs = Math.max(0, nextHeliusRequestAt - now);
-      nextHeliusRequestAt = Math.max(now, nextHeliusRequestAt) + RPC_MIN_INTERVAL_MS;
-      return Effect.sleep(waitMs);
+      return Effect.sync(() => {
+        const now = Date.now();
+        const waitMs = Math.max(0, nextHeliusRequestAt - now);
+        nextHeliusRequestAt = Math.max(now, nextHeliusRequestAt) + RPC_MIN_INTERVAL_MS;
+        return waitMs;
+      }).pipe(Effect.flatMap(Effect.sleep));
+    }
+
+    function withRpcTimeout<T>(effect: Effect.Effect<T, unknown>): Effect.Effect<T, unknown> {
+      return effect.pipe(
+        Effect.timeoutFail({
+          duration: RPC_REQUEST_TIMEOUT_MS,
+          onTimeout: () => new Error("RPC request timeout after 15s"),
+        }),
+      );
     }
 
     function rpcCall<T>(
@@ -341,7 +355,7 @@ export const AdapterLive = Layer.effect(
         paceRpc(conn).pipe(
           Effect.zipRight(
             breaker.execute(
-              retryWithBackoff(() => fn(conn), RPC_RETRY_OPTIONS),
+              withRpcTimeout(retryWithBackoff(() => fn(conn), RPC_RETRY_OPTIONS)),
               isRpcNetworkError,
             ),
           ),
@@ -1187,8 +1201,8 @@ export const AdapterLive = Layer.effect(
             }),
           );
 
-          yield* rpcCall((conn) => conn.confirmTransaction(signature, "confirmed"));
           yield* invalidateBalanceCaches;
+          yield* rpcCall((conn) => conn.confirmTransaction(signature, "confirmed"));
 
           return {
             positionPubKey: positionKeypair.publicKey.toBase58(),

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -44,6 +44,7 @@ const RPC_RETRY_OPTIONS = {
   maxDelayMs: 30_000,
   rateLimitBaseDelayMs: 5_000,
 } as const;
+const RPC_MIN_INTERVAL_MS = 50;
 
 function formatTokenAmount(amount: bigint, decimals: number): string {
   return (Number(amount) / 10 ** decimals).toFixed(Math.min(decimals, 6));
@@ -314,15 +315,36 @@ export const AdapterLive = Layer.effect(
     const fallbackRpcCircuitBreaker = fallbackConnection
       ? new CircuitBreaker({ failureThreshold: 3, resetTimeoutMs: 30_000 })
       : null;
+    const nextRpcStartAt = new Map<Connection, number>();
+    let nextHeliusRequestAt = 0;
+
+    function paceRpc(conn: Connection): Effect.Effect<void> {
+      const now = Date.now();
+      const nextStartAt = nextRpcStartAt.get(conn) ?? now;
+      const waitMs = Math.max(0, nextStartAt - now);
+      nextRpcStartAt.set(conn, Math.max(now, nextStartAt) + RPC_MIN_INTERVAL_MS);
+      return Effect.sleep(waitMs);
+    }
+
+    function paceHeliusRequest(): Effect.Effect<void> {
+      const now = Date.now();
+      const waitMs = Math.max(0, nextHeliusRequestAt - now);
+      nextHeliusRequestAt = Math.max(now, nextHeliusRequestAt) + RPC_MIN_INTERVAL_MS;
+      return Effect.sleep(waitMs);
+    }
 
     function rpcCall<T>(
       fn: (conn: Connection) => Promise<T>,
       primaryConn: Connection = connection,
     ): Effect.Effect<T, unknown> {
       const run = (conn: Connection, breaker: CircuitBreaker): Effect.Effect<T, unknown> =>
-        breaker.execute(
-          retryWithBackoff(() => fn(conn), RPC_RETRY_OPTIONS),
-          isRpcNetworkError,
+        paceRpc(conn).pipe(
+          Effect.zipRight(
+            breaker.execute(
+              retryWithBackoff(() => fn(conn), RPC_RETRY_OPTIONS),
+              isRpcNetworkError,
+            ),
+          ),
         );
 
       return run(primaryConn, primaryRpcCircuitBreaker).pipe(
@@ -426,6 +448,7 @@ export const AdapterLive = Layer.effect(
           return yield* Effect.fail(
             Object.assign(new Error(`Helius getAsset returned HTTP ${res.status}`), {
               code: res.status,
+              headers: res.headers,
             }),
           );
         }
@@ -440,7 +463,9 @@ export const AdapterLive = Layer.effect(
         return json;
       });
       return Effect.cachedInvalidateWithTTL(
-        retryEffectWithBackoff(assetRequest, RPC_RETRY_OPTIONS),
+        paceHeliusRequest().pipe(
+          Effect.zipRight(retryEffectWithBackoff(assetRequest, RPC_RETRY_OPTIONS)),
+        ),
         HELIUS_ASSET_CACHE_TTL_MS,
       );
     });
@@ -740,11 +765,15 @@ export const AdapterLive = Layer.effect(
     }
 
     const WALLET_BALANCE_CACHE_TTL_MS = 30_000;
+    const tokenBalanceCache = new Map<string, { value: bigint; expiresAt: number }>();
+    let nativeSolBalanceCache: { value: bigint; expiresAt: number } | undefined;
 
     function readTokenBalance(mintAddress: string): Effect.Effect<bigint, unknown> {
       return Effect.gen(function* () {
         const activeWallet = wallet;
         if (!activeWallet) return 0n;
+        const cached = tokenBalanceCache.get(mintAddress);
+        if (cached && cached.expiresAt > Date.now()) return cached.value;
         const mint = new PublicKey(mintAddress);
         const accounts = yield* rpcCall((conn) =>
           conn.getParsedTokenAccountsByOwner(activeWallet.publicKey, { mint }),
@@ -762,7 +791,26 @@ export const AdapterLive = Layer.effect(
           const amount = tokenAmount["amount"];
           if (typeof amount === "string") total += BigInt(amount);
         }
+        tokenBalanceCache.set(mintAddress, {
+          value: total,
+          expiresAt: Date.now() + WALLET_BALANCE_CACHE_TTL_MS,
+        });
         return total;
+      });
+    }
+
+    function readNativeSolBalance(): Effect.Effect<bigint, unknown> {
+      return Effect.gen(function* () {
+        if (!wallet) return 0n;
+        if (nativeSolBalanceCache && nativeSolBalanceCache.expiresAt > Date.now()) {
+          return nativeSolBalanceCache.value;
+        }
+        const value = BigInt(yield* rpcCall((conn) => conn.getBalance(wallet.publicKey)));
+        nativeSolBalanceCache = {
+          value,
+          expiresAt: Date.now() + WALLET_BALANCE_CACHE_TTL_MS,
+        };
+        return value;
       });
     }
 
@@ -782,6 +830,11 @@ export const AdapterLive = Layer.effect(
       readWalletBalanceUsd(),
       WALLET_BALANCE_CACHE_TTL_MS,
     );
+
+    const invalidateBalanceCaches = Effect.sync(() => {
+      tokenBalanceCache.clear();
+      nativeSolBalanceCache = undefined;
+    }).pipe(Effect.zipRight(invalidateWalletBalance));
 
     // ─── Pool stats ────────────────────────────────────────────────────────
 
@@ -846,8 +899,7 @@ export const AdapterLive = Layer.effect(
       getNativeSolBalance: () =>
         Effect.gen(function* () {
           if (!wallet) return 0;
-          const lamports = yield* rpcCall((conn) => conn.getBalance(wallet.publicKey));
-          return lamports;
+          return Number(yield* readNativeSolBalance());
         }),
 
       getPoolState: (poolAddress) =>
@@ -1054,7 +1106,7 @@ export const AdapterLive = Layer.effect(
           const balanceY = yield* getTokenBalance(pool.tokenY);
           const nativeSolBalance =
             pool.tokenX === SOL_MINT || pool.tokenY === SOL_MINT
-              ? BigInt(yield* rpcCall((conn) => conn.getBalance(wallet.publicKey)))
+              ? yield* readNativeSolBalance()
               : undefined;
 
           const maxX =
@@ -1113,8 +1165,7 @@ export const AdapterLive = Layer.effect(
             wallet.publicKey,
           );
           const requiredLamports = transactionLamports + GAS_RESERVE_LAMPORTS;
-          const actualSolBalance =
-            nativeSolBalance ?? BigInt(yield* rpcCall((conn) => conn.getBalance(wallet.publicKey)));
+          const actualSolBalance = nativeSolBalance ?? (yield* readNativeSolBalance());
           if (actualSolBalance < requiredLamports) {
             return yield* Effect.fail(
               new AdapterError({
@@ -1137,7 +1188,7 @@ export const AdapterLive = Layer.effect(
           );
 
           yield* rpcCall((conn) => conn.confirmTransaction(signature, "confirmed"));
-          yield* invalidateWalletBalance;
+          yield* invalidateBalanceCaches;
 
           return {
             positionPubKey: positionKeypair.publicKey.toBase58(),
@@ -1197,7 +1248,7 @@ export const AdapterLive = Layer.effect(
             );
             yield* rpcCall((conn) => conn.confirmTransaction(signature, "confirmed"));
           }
-          yield* invalidateWalletBalance;
+          yield* invalidateBalanceCaches;
 
           return { txSignature: "batch-confirmed" };
         }).pipe(
@@ -1396,7 +1447,7 @@ export const AdapterLive = Layer.effect(
           );
 
           yield* rpcCall((conn) => conn.confirmTransaction(signature, "confirmed"));
-          yield* invalidateWalletBalance;
+          yield* invalidateBalanceCaches;
 
           return {
             txSignature: signature,
@@ -1547,8 +1598,8 @@ export const AdapterLive = Layer.effect(
           const activeWallet = wallet;
           if (!activeWallet) return;
 
-          const lamports = yield* rpcCall((conn) => conn.getBalance(activeWallet.publicKey));
-          const solBalance = lamports / 1e9;
+          const lamports = yield* readNativeSolBalance();
+          const solBalance = Number(lamports) / 1e9;
 
           if (solBalance >= minSolThreshold) return;
 
@@ -1622,7 +1673,7 @@ export const AdapterLive = Layer.effect(
             );
 
             yield* rpcCall((conn) => conn.confirmTransaction(sig, "confirmed"));
-            yield* invalidateWalletBalance;
+            yield* invalidateBalanceCaches;
             logger.info("Swapped USDC → SOL for gas", { tx: sig, amountUSDC: swapAmountUSDC });
           });
 

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -355,7 +355,10 @@ export const AdapterLive = Layer.effect(
         paceRpc(conn).pipe(
           Effect.zipRight(
             breaker.execute(
-              withRpcTimeout(retryWithBackoff(() => fn(conn), RPC_RETRY_OPTIONS)),
+              retryEffectWithBackoff(
+                withRpcTimeout(Effect.tryPromise(() => fn(conn))),
+                RPC_RETRY_OPTIONS,
+              ),
               isRpcNetworkError,
             ),
           ),
@@ -478,7 +481,7 @@ export const AdapterLive = Layer.effect(
       });
       return Effect.cachedInvalidateWithTTL(
         paceHeliusRequest().pipe(
-          Effect.zipRight(retryEffectWithBackoff(assetRequest, RPC_RETRY_OPTIONS)),
+          Effect.zipRight(retryEffectWithBackoff(withRpcTimeout(assetRequest), RPC_RETRY_OPTIONS)),
         ),
         HELIUS_ASSET_CACHE_TTL_MS,
       );
@@ -813,10 +816,12 @@ export const AdapterLive = Layer.effect(
       });
     }
 
-    function readNativeSolBalance(): Effect.Effect<bigint, unknown> {
+    function readNativeSolBalance(opts?: {
+      readonly force?: boolean;
+    }): Effect.Effect<bigint, unknown> {
       return Effect.gen(function* () {
         if (!wallet) return 0n;
-        if (nativeSolBalanceCache && nativeSolBalanceCache.expiresAt > Date.now()) {
+        if (!opts?.force && nativeSolBalanceCache && nativeSolBalanceCache.expiresAt > Date.now()) {
           return nativeSolBalanceCache.value;
         }
         const value = BigInt(yield* rpcCall((conn) => conn.getBalance(wallet.publicKey)));
@@ -830,9 +835,8 @@ export const AdapterLive = Layer.effect(
 
     function readWalletBalanceUsd(): Effect.Effect<number, unknown> {
       return Effect.gen(function* () {
-        const activeWallet = wallet;
-        if (!activeWallet) return 0;
-        const lamports = yield* rpcCall((conn) => conn.getBalance(activeWallet.publicKey));
+        if (!wallet) return 0;
+        const lamports = Number(yield* readNativeSolBalance());
         const prices = yield* fetchTokenPrices([SOL_MINT]);
         const solPrice = prices[SOL_MINT] ?? fallbackPrices[SOL_MINT] ?? 0;
         const usdcRaw = yield* readTokenBalance(USDC_MINT);
@@ -1179,7 +1183,7 @@ export const AdapterLive = Layer.effect(
             wallet.publicKey,
           );
           const requiredLamports = transactionLamports + GAS_RESERVE_LAMPORTS;
-          const actualSolBalance = nativeSolBalance ?? (yield* readNativeSolBalance());
+          const actualSolBalance = yield* readNativeSolBalance({ force: true });
           if (actualSolBalance < requiredLamports) {
             return yield* Effect.fail(
               new AdapterError({

--- a/engine/entry-backoff.ts
+++ b/engine/entry-backoff.ts
@@ -1,0 +1,23 @@
+const ENTRY_FAILURE_COOLDOWN_BASE_MS = 30 * 60 * 1000;
+const ENTRY_FAILURE_COOLDOWN_MAX_MS = 6 * 60 * 60 * 1000;
+
+export interface EntryFailureBackoff {
+  readonly failures: number;
+  readonly nextAttemptAt: number;
+}
+
+export function isInsufficientTokenBalanceError(error: string | undefined): boolean {
+  return error?.toLowerCase().includes("insufficient token balance") ?? false;
+}
+
+export function nextEntryFailureBackoff(
+  previous: EntryFailureBackoff | undefined,
+  now = Date.now(),
+): EntryFailureBackoff {
+  const failures = (previous?.failures ?? 0) + 1;
+  const cooldownMs = Math.min(
+    ENTRY_FAILURE_COOLDOWN_MAX_MS,
+    ENTRY_FAILURE_COOLDOWN_BASE_MS * 2 ** (failures - 1),
+  );
+  return { failures, nextAttemptAt: now + cooldownMs };
+}

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -654,6 +654,7 @@ export const program = Effect.gen(function* () {
         poolsDecided: 0,
         poolsExecuted: 0,
         poolsFailed: 0,
+        poolsActioned: 0,
         decisions: [],
         totalGasCostSol: 0,
         paperTrading: config.paperTrading,
@@ -684,6 +685,7 @@ export const program = Effect.gen(function* () {
         if (decision) {
           cycle.decisions.push(decision);
           cycle.poolsDecided++;
+          cycle.poolsActioned++;
         }
         cycle.poolsScanned++;
       }
@@ -1335,9 +1337,35 @@ export const program = Effect.gen(function* () {
             const entryBackoff = entryFailureBackoff.get(poolAddress);
             if (entryBackoff) {
               if (entryBackoff.nextAttemptAt > Date.now()) {
+                const retryAfterMs = entryBackoff.nextAttemptAt - Date.now();
+                cycle.poolsDecided++;
+                cycle.poolsActioned++;
+                yield* audit
+                  .recordDecision({
+                    timestamp: Date.now(),
+                    cycleId,
+                    poolAddress,
+                    action: "ENTER",
+                    confidence: 0,
+                    reasoning: `[entry-backoff] insufficient token balance; retry in ${Math.ceil(retryAfterMs / 60_000)} minutes`,
+                    metrics,
+                    riskResult: {
+                      approved: false,
+                      reason: "Entry suppressed after insufficient token balance",
+                    },
+                    executed: false,
+                    paperTrading: config.paperTrading,
+                  })
+                  .pipe(Effect.catchAll(() => Effect.void));
+                yield* memory
+                  .upsert({
+                    category: "warning",
+                    content: `Entry suppressed for ${poolAddress} after insufficient token balance; retry in ${Math.ceil(retryAfterMs / 60_000)} minutes.`,
+                    poolAddress,
+                  })
+                  .pipe(Effect.catchAll(() => Effect.void));
                 return null;
               }
-              entryFailureBackoff.delete(poolAddress);
             }
 
             // F7: pool cooldown check — skip ENTER if this pool is on cooldown

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -654,7 +654,6 @@ export const program = Effect.gen(function* () {
         poolsDecided: 0,
         poolsExecuted: 0,
         poolsFailed: 0,
-        poolsActioned: 0,
         decisions: [],
         totalGasCostSol: 0,
         paperTrading: config.paperTrading,
@@ -685,7 +684,6 @@ export const program = Effect.gen(function* () {
         if (decision) {
           cycle.decisions.push(decision);
           cycle.poolsDecided++;
-          cycle.poolsActioned++;
         }
         cycle.poolsScanned++;
       }
@@ -1339,7 +1337,6 @@ export const program = Effect.gen(function* () {
               if (entryBackoff.nextAttemptAt > Date.now()) {
                 const retryAfterMs = entryBackoff.nextAttemptAt - Date.now();
                 cycle.poolsDecided++;
-                cycle.poolsActioned++;
                 yield* audit
                   .recordDecision({
                     timestamp: Date.now(),

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -70,6 +70,11 @@ import type { AgentRuntimeAlert, AgentRuntimeCheckin } from "./agent-transport.j
 import { randomUUID } from "crypto";
 import { AgentLive, AgentNoOp } from "./agent-service.js";
 import { createLogger } from "./logger.js";
+import {
+  isInsufficientTokenBalanceError,
+  nextEntryFailureBackoff,
+  type EntryFailureBackoff,
+} from "./entry-backoff.js";
 
 const logger = createLogger("program");
 
@@ -328,6 +333,7 @@ export const program = Effect.gen(function* () {
   for (const pos of allPositions) {
     trackedPositions.set(pos.poolAddress, pos);
   }
+  const entryFailureBackoff = new Map<string, EntryFailureBackoff>();
 
   // Agent check-in state
   const programStartTime = Date.now();
@@ -645,7 +651,9 @@ export const program = Effect.gen(function* () {
         cycleId: randomUUID(),
         startedAt: Date.now(),
         poolsScanned: 0,
-        poolsActioned: 0,
+        poolsDecided: 0,
+        poolsExecuted: 0,
+        poolsFailed: 0,
         decisions: [],
         totalGasCostSol: 0,
         paperTrading: config.paperTrading,
@@ -665,8 +673,9 @@ export const program = Effect.gen(function* () {
       }
 
       for (const poolAddress of poolsToScan) {
-        const decision = yield* evaluatePool(poolAddress, cycle.cycleId).pipe(
+        const decision = yield* evaluatePool(poolAddress, cycle).pipe(
           Effect.catchAll((err) => {
+            cycle.poolsFailed++;
             console.error("Error processing pool", { poolAddress, err: String(err) });
             return Effect.succeed(null);
           }),
@@ -674,7 +683,7 @@ export const program = Effect.gen(function* () {
 
         if (decision) {
           cycle.decisions.push(decision);
-          cycle.poolsActioned++;
+          cycle.poolsDecided++;
         }
         cycle.poolsScanned++;
       }
@@ -684,7 +693,9 @@ export const program = Effect.gen(function* () {
       console.info("Scan cycle complete", {
         cycleId: cycle.cycleId,
         scanned: cycle.poolsScanned,
-        actioned: cycle.poolsActioned,
+        decided: cycle.poolsDecided,
+        executed: cycle.poolsExecuted,
+        failed: cycle.poolsFailed,
         durationSec: (durationMs / 1000).toFixed(1),
       });
 
@@ -823,9 +834,10 @@ export const program = Effect.gen(function* () {
 
   const evaluatePool = (
     poolAddress: string,
-    cycleId: string,
+    cycle: AgentCycle,
   ): Effect.Effect<AgentDecision | null, unknown> =>
     Effect.gen(function* () {
+      const cycleId = cycle.cycleId;
       const pool = yield* adapter.getPoolState(poolAddress);
       const binArray = yield* adapter.getBinArray(poolAddress);
       pushBinHistory(poolAddress, pool.activeBinId);
@@ -1320,6 +1332,13 @@ export const program = Effect.gen(function* () {
               logger.info("Skipping ENTER for unmanaged pool", { pool: poolAddress });
               return null;
             }
+            const entryBackoff = entryFailureBackoff.get(poolAddress);
+            if (entryBackoff) {
+              if (entryBackoff.nextAttemptAt > Date.now()) {
+                return null;
+              }
+              entryFailureBackoff.delete(poolAddress);
+            }
 
             // F7: pool cooldown check — skip ENTER if this pool is on cooldown
             const cooldown = yield* db
@@ -1605,6 +1624,25 @@ export const program = Effect.gen(function* () {
         );
         executed = liveResult.executed;
         executionError = liveResult.error;
+      }
+
+      if (decision.action !== "HOLD") {
+        if (executed) {
+          cycle.poolsExecuted++;
+        } else {
+          cycle.poolsFailed++;
+        }
+      }
+      if (decision.action === "ENTER" && isInsufficientTokenBalanceError(executionError)) {
+        const backoff = nextEntryFailureBackoff(entryFailureBackoff.get(poolAddress));
+        entryFailureBackoff.set(poolAddress, backoff);
+        logger.warn("Entry suppressed after insufficient token balance", {
+          pool: poolAddress,
+          retryAfterMs: backoff.nextAttemptAt - Date.now(),
+          failures: backoff.failures,
+        });
+      } else if (decision.action === "ENTER" && executed) {
+        entryFailureBackoff.delete(poolAddress);
       }
 
       // Audit after execution

--- a/engine/types.ts
+++ b/engine/types.ts
@@ -141,6 +141,7 @@ export interface AgentCycle {
   poolsDecided: number;
   poolsExecuted: number;
   poolsFailed: number;
+  poolsActioned: number;
   decisions: AgentDecision[];
   totalGasCostSol: number;
   paperTrading: boolean;

--- a/engine/types.ts
+++ b/engine/types.ts
@@ -138,7 +138,9 @@ export interface AgentCycle {
   startedAt: number;
   completedAt?: number;
   poolsScanned: number;
-  poolsActioned: number;
+  poolsDecided: number;
+  poolsExecuted: number;
+  poolsFailed: number;
   decisions: AgentDecision[];
   totalGasCostSol: number;
   paperTrading: boolean;

--- a/engine/types.ts
+++ b/engine/types.ts
@@ -141,7 +141,6 @@ export interface AgentCycle {
   poolsDecided: number;
   poolsExecuted: number;
   poolsFailed: number;
-  poolsActioned: number;
   decisions: AgentDecision[];
   totalGasCostSol: number;
   paperTrading: boolean;


### PR DESCRIPTION
## Summary

- Add per-pool exponential backoff for deterministic insufficient-token live ENTER failures (30 minutes to 6 hours).
- Cache native SOL and SPL token balances for 30 seconds, invalidate after transactions, and pace Solana/Helius requests.
- Honor `Retry-After` headers and deduplicate repeated retry warnings.
- Report scan decisions, successful executions, and failures separately.

## Why

v0.0.31 correctly fails closed when a wallet cannot fund both pool token legs, but it retries the same impossible ENTER every scan and can amplify provider rate limits. This keeps live safety while reducing repeated RPC work and making cycle status accurate.

## Verification

- `bun run test` (510 passed)
- `bun run lint`
- `bun run build`
- `bun run format:check`
- `bun cli/index.ts --help`

Provider plan capacity still needs to be configured operationally; this PR reduces avoidable request pressure but cannot raise Helius account limits.

## Summary by Sourcery

Introduce per-pool exponential backoff for deterministic insufficient-token live entry failures, pace and cache RPC-related wallet balance reads, and expand cycle metrics and documentation to distinguish decided, executed, and failed pools while honoring rate-limit headers.

New Features:
- Add per-pool exponential backoff for live ENTER failures caused by deterministic insufficient token balance.
- Cache native SOL and SPL token balances briefly in the adapter to reduce repeated RPC reads.
- Track and report separate counts of scanned, decided, executed, and failed pools in scan cycles.

Enhancements:
- Pace Solana and Helius RPC requests and incorporate Retry-After headers into backoff calculations to reduce provider load.
- Deduplicate repeated retry warning logs for retriable RPC errors.
- Invalidate all wallet balance-related caches after successful transactions to keep cached data fresh.

Documentation:
- Update README and agent documentation to describe live entry backoff behavior, RPC pacing and caching, and the new scan metrics semantics.

Tests:
- Add tests covering entry failure backoff behavior and classification of insufficient token balance errors.
- Extend adapter retry tests to verify behavior when Retry-After headers are present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-pool backoff for live entry attempts when required tokens are unavailable, using deterministic exponential delays (30m–6h) and fail-closed behavior.
  - Improved retry behavior by honoring `Retry-After` and treating RPC timeouts as retriable/network-fault errors.
  - Added RPC pacing plus TTL-cached wallet balance checks, with automatic cache invalidation after key actions.
  - Scan logs now separately report pools as **decided**, **executed**, and **failed** (with clearer failure/rejection meaning).
- **Bug Fixes**
  - Rate-suppressed retry warnings to reduce noisy repeated logs.
- **Documentation**
  - Updated configuration notes for live-entry handling, backoff/retry behavior, and scan reporting.
- **Tests**
  - Added coverage for `Retry-After` parsing, retry pacing, and entry backoff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->