### PR TITLE
chore(skills): sync skill frontmatter versions to 0.0.31

### DIFF
--- a/skills/prism-hermes/SKILL.md
+++ b/skills/prism-hermes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prism-hermes
-version: "0.0.22"
+version: "0.0.31"
 description: >
   Operate Prism, an autonomous Solana DLMM liquidity agent for Meteora pools,
   through Hermes ACP. Use when the user asks about "prism", "DLMM", "liquidity

--- a/skills/prism-openclaw/SKILL.md
+++ b/skills/prism-openclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prism-openclaw
-version: "0.0.22"
+version: "0.0.31"
 description: >
   Operate Prism, an autonomous Solana DLMM liquidity agent for Meteora pools,
   through the OpenClaw Gateway. Use when the user asks about "prism", "DLMM",

--- a/skills/prism/SKILL.md
+++ b/skills/prism/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prism
-version: "0.0.22"
+version: "0.0.31"
 description: >
   Operate Prism, an autonomous Solana DLMM liquidity agent for Meteora pools.
   Use when the user asks about "prism", "DLMM", "liquidity agent",


### PR DESCRIPTION
Syncs the stale skill frontmatter versions from 0.0.22 to match the current package.json release version 0.0.31.\n\nChanged files:\n- skills/prism/SKILL.md\n- skills/prism-openclaw/SKILL.md\n- skills/prism-hermes/SKILL.md\n\nLint and format checks pass locally.

## Summary by Sourcery

Chores:
- Update version metadata in Prism, Prism Hermes, and Prism OpenClaw SKILL frontmatter to 0.0.31.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated skill metadata versions to `0.0.31` across the Prism skill definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->