### PR TITLE
fix: telegram/API security chain + update hardening (Wave 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,10 @@ The `Dockerfile` builds the engine bundle with `oven/bun:canary-slim`, then copi
 - **Feedback.** `prism feedback` submits authenticated records to Prism Cloud D1 and keeps a local SQLite record for deduplication/outage recovery. Opt out with `PRISM_FEEDBACK_OPT_OUT=true`.
 - **Auto-update integrity.** The updater verifies SHA-256 checksums before applying a release. GPG signatures are generated but **not yet verified client-side**.
 - **Secret sanitization.** `engine/error-reporter.ts` strips sensitive values from telemetry.
+- **Telegram bot ↔ API shared secret.** `BOT_API_SECRET` (wrangler secret, set on BOTH workers with the same value) authenticates the bot to the API via the `X-Bot-Api-Secret` header. `/v1/register-telegram`, `/v1/whoami-telegram`, `/v1/agent-status` and the telegram-binding path of `/v1/register` fail closed (401) when it is missing or unset. Plain CLI `/v1/register` (no `telegram_id`) does not need it.
+- **Telegram webhook fails closed.** The bot worker rejects every webhook POST unless `TELEGRAM_WEBHOOK_SECRET` is set AND the `X-Telegram-Bot-Api-Secret-Token` header matches it (constant-time comparison). Set the same value in Telegram's `setWebhook?secret_token=...`.
+- **Telegram link codes.** Codes are `LINK-` + 16 hex chars (64-bit CSPRNG), expire after 10 minutes (`expires_at` is unixepoch INTEGER in D1), allow 5 confirm attempts before burning, are limited to 10 confirm attempts/hour/IP, and requesting a new code invalidates the user's outstanding codes.
+- **Group-chat refusals.** The bot only answers `/register`, `/whoami`, `/status`, `/link` and link-code confirmations in private chats, and HTML-escapes user-controlled text in `parse_mode: HTML` replies.
 
 ## Important environment variables
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Common agent commands:
 | `prism feedback "..."`                                          | Store structured feedback in Prism Cloud D1                      |
 | `prism issue "..."`                                             | Store an issue in Prism Cloud D1                                  |
 | `prism whoami`                                                   | Show current user / API key info (requires `register`)            |
-| `prism link-telegram`                                            | Issue a 6-char code to link `@prism_agent_bot` (optional)         |
+| `prism link-telegram`                                            | Issue a `LINK-<16 hex>` code to link `@prism_agent_bot` (optional)  |
 | `prism update`                                                   | Self-update from R2/GitHub releases (with smoke tests + rollback) |
 | `prism wallet {generate,import,show}`                            | Non-custodial local keypair (required for live trading)           |
 

--- a/bench/adapter-revenue-report.test.ts
+++ b/bench/adapter-revenue-report.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Effect, Layer } from "effect";
+import { AdapterService } from "../engine/services.js";
+import { AdapterLive } from "../engine/adapter-service.js";
+import { ConfigService } from "../engine/config-service.js";
+import { AuditLive } from "../engine/audit-service.js";
+import { DbLive } from "../engine/db-service.js";
+import { defaultAppConfig } from "./helpers.js";
+
+function buildAdapterLayer(
+  overrides: Parameters<typeof defaultAppConfig>[0] = {},
+): Layer.Layer<AdapterService, never, never> {
+  const configLayer = Layer.succeed(
+    ConfigService,
+    defaultAppConfig({
+      solanaRpcUrl: "https://api.mainnet.helius-rpc.com",
+      solanaRpcFallbackUrl: "",
+      sqliteDbPath: ":memory:",
+      autoUpdate: false,
+      ...overrides,
+    }),
+  );
+  const auditLayer = Layer.provide(AuditLive, DbLive(":memory:"));
+  const withDeps = Layer.provide(AdapterLive, Layer.merge(configLayer, auditLayer));
+  return withDeps as Layer.Layer<AdapterService, never, never>;
+}
+
+const FEE_EVENT = {
+  poolAddress: "5JvD1TW5nqSz6gJtHfVnZKq3fZmBnL5xY7u9dR2wT4k",
+  feeX: 10,
+  feeY: 20,
+  platformFeeX: 1,
+  platformFeeY: 2,
+  tier: "pro",
+  txSignature: "sig-123",
+};
+
+describe("AdapterService.reportFeeCollection opt-out", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("does not POST revenue telemetry when feedbackOptOut is set", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const layer = buildAdapterLayer({ feedbackOptOut: true });
+
+    await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          yield* adapter.reportFeeCollection(FEE_EVENT);
+        }),
+        layer,
+      ),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("POSTs revenue telemetry when feedbackOptOut is not set", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const layer = buildAdapterLayer({ feedbackOptOut: false });
+
+    await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          yield* adapter.reportFeeCollection(FEE_EVENT);
+        }),
+        layer,
+      ),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/v1/revenue/log");
+  });
+});

--- a/bench/adapter-revenue-report.test.ts
+++ b/bench/adapter-revenue-report.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Effect, Layer } from "effect";
+import fs from "fs";
 import { AdapterService } from "../engine/services.js";
 import { AdapterLive } from "../engine/adapter-service.js";
 import { ConfigService } from "../engine/config-service.js";
@@ -35,17 +36,40 @@ const FEE_EVENT = {
   txSignature: "sig-123",
 };
 
-describe("AdapterService.reportFeeCollection opt-out", () => {
-  const originalFetch = globalThis.fetch;
+// reportFeeCollection reads ~/.config/prism/{install-id,credentials.json} from
+// the real home directory — stub those reads so tests never touch the
+// environment. Paths that don't match fall through to the real fs.
+function stubPrismConfigDir(): void {
+  const realReadFileSync = fs.readFileSync;
+  const realExistsSync = fs.existsSync;
+  vi.spyOn(fs, "readFileSync").mockImplementation(((
+    path: fs.PathOrFileDescriptor,
+    options?: unknown,
+  ) => {
+    if (typeof path === "string" && path.includes("install-id")) {
+      return "ci-test-install-id-1234";
+    }
+    if (typeof path === "string" && path.includes("credentials.json")) {
+      return JSON.stringify({ apiKey: "ci-test-api-key", userId: "ci-test-user" });
+    }
+    return realReadFileSync(path, options as never);
+  }) as typeof fs.readFileSync);
+  vi.spyOn(fs, "existsSync").mockImplementation((path: fs.PathLike) => {
+    if (typeof path === "string" && path.includes("install-id")) return true;
+    return realExistsSync(path);
+  });
+}
 
+describe("AdapterService.reportFeeCollection opt-out", () => {
   afterEach(() => {
-    globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 
   it("does not POST revenue telemetry when feedbackOptOut is set", async () => {
-    const fetchMock = vi.fn();
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    stubPrismConfigDir();
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => Promise.resolve(new Response("{}", { status: 200 })));
     const layer = buildAdapterLayer({ feedbackOptOut: true });
 
     await Effect.runPromise(
@@ -58,12 +82,14 @@ describe("AdapterService.reportFeeCollection opt-out", () => {
       ),
     );
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("POSTs revenue telemetry when feedbackOptOut is not set", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    stubPrismConfigDir();
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => Promise.resolve(new Response("{}", { status: 200 })));
     const layer = buildAdapterLayer({ feedbackOptOut: false });
 
     await Effect.runPromise(
@@ -76,7 +102,7 @@ describe("AdapterService.reportFeeCollection opt-out", () => {
       ),
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/v1/revenue/log");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/v1/revenue/log");
   });
 });

--- a/bench/cli-dev-telemetry.test.ts
+++ b/bench/cli-dev-telemetry.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../cli/api.js", () => ({
+  pingInstall: vi.fn(),
+  requireRegistered: vi.fn(),
+}));
+
+// Keep the engine out of this unit test — dev.ts imports runEngine at module
+// scope, and loading the real module wires up the entire engine.
+vi.mock("../engine/run-engine.js", () => ({
+  runEngine: vi.fn(),
+}));
+
+import { pingInstall } from "../cli/api.js";
+import { reportDevStartTelemetry } from "../cli/dev.js";
+
+const mockedPingInstall = vi.mocked(pingInstall);
+
+describe("cli/dev telemetry degrade", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("warns and continues when the telemetry ping fails", async () => {
+    mockedPingInstall.mockResolvedValue(false);
+
+    await expect(reportDevStartTelemetry("user-1")).resolves.toBeUndefined();
+
+    expect(mockedPingInstall).toHaveBeenCalledWith("dev_start", { userId: "user-1" });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("telemetry is unavailable"));
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when the telemetry ping succeeds", async () => {
+    mockedPingInstall.mockResolvedValue(true);
+
+    await expect(reportDevStartTelemetry("user-1")).resolves.toBeUndefined();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/bench/revenue-config-service.test.ts
+++ b/bench/revenue-config-service.test.ts
@@ -203,6 +203,41 @@ describe("RevenueConfigService — refreshConfig", () => {
   });
 });
 
+// ─── fetch timeout ───────────────────────────────────────────────────────────
+
+describe("RevenueConfigService — fetch timeout", () => {
+  it("passes an AbortSignal timeout to the config API fetch", async () => {
+    const config = {
+      tier: "pro",
+      platformFeeRate: 0.05,
+      revenueShareEnabled: true,
+      revenueShareOperatorPct: 0.2,
+      feeWalletAddress: "TimeoutWallet11111111111111111111111111111",
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(config),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    mockCredentialsFile();
+    const layer = buildLayer();
+
+    await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const svc = yield* RevenueConfigService;
+          return yield* svc.getConfig();
+        }),
+        layer,
+      ),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as { signal?: AbortSignal } | undefined;
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
 // ─── In-memory cache within TTL ─────────────────────────────────────────────
 
 describe("RevenueConfigService — in-memory cache within TTL", () => {

--- a/cli/dev.ts
+++ b/cli/dev.ts
@@ -7,6 +7,15 @@ interface DevCommandOptions {
   exitLive: boolean;
 }
 
+// Telemetry must never block agent startup — degrade to a warning when the
+// API is unreachable so offline work keeps running.
+export async function reportDevStartTelemetry(userId: string): Promise<void> {
+  if (!(await pingInstall("dev_start", { userId }))) {
+    console.warn("⚠️  Prism telemetry is unavailable; continuing without telemetry.");
+    console.warn("Run 'prism doctor' to diagnose the account and API connection.");
+  }
+}
+
 export const devCommand = new Command("dev")
   .description("Start the trading agent")
   .option(
@@ -23,11 +32,7 @@ export const devCommand = new Command("dev")
       process.exit(1);
     }
 
-    if (!(await pingInstall("dev_start", { userId: creds.userId }))) {
-      console.error("Error: Prism telemetry is unavailable; refusing to start the agent.");
-      console.error("Run 'prism doctor' to diagnose the account and API connection.");
-      process.exit(1);
-    }
+    await reportDevStartTelemetry(creds.userId);
 
     const lock = acquireLock();
     if (!lock.acquired) {

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -6,6 +6,7 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   realpathSync,
   renameSync,
@@ -634,8 +635,7 @@ export const updateCommand = new Command("update")
         return;
       }
 
-      workDir = join(tmpdir(), `prism-update-${Date.now()}`);
-      mkdirSync(workDir, { recursive: true });
+      workDir = mkdtempSync(join(tmpdir(), "prism-update-"));
 
       const installRoot = resolveInstallRoot();
       const fromSource = isSourceInstall(installRoot);

--- a/cloudflare/.dev.vars.example
+++ b/cloudflare/.dev.vars.example
@@ -1,0 +1,17 @@
+# Local development secrets for `wrangler dev`. Copy to `.dev.vars` and fill in.
+# NEVER commit real values — production secrets go through `wrangler secret put`.
+
+# Telegram bot token from @BotFather (both workers)
+TELEGRAM_BOT_TOKEN=
+
+# REQUIRED for the telegram-bot worker: Telegram setWebhook secret_token.
+# Webhook POSTs are rejected when this is unset (fail closed).
+TELEGRAM_WEBHOOK_SECRET=
+
+# Shared secret between telegram-bot and API workers (X-Bot-Api-Secret header).
+# Must be identical in both workers' .dev.vars / production secrets.
+BOT_API_SECRET=
+
+# API worker only
+FEE_WALLET_ADDRESS=
+ADMIN_API_KEY=

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -14,9 +14,9 @@ cloudflare/
 │   │   └── api.test.ts              # API tests (vitest-pool-workers)
 │   └── telegram-bot/                # Telegram webhook handler
 │       ├── index.ts                 # Bot commands: /start, /register, /link, /whoami, /status
-│       └── telegram-bot.test.ts     # Bot tests (16 tests, all passing)
+│       └── telegram-bot.test.ts     # Bot tests (vitest-pool-workers)
 ├── migrations/
-│   └── 0001_initial.sql             # D1 schema: users, api_keys, telegram_link_codes, wallets, subscriptions, audit_log
+│   └── NNNN_*.sql                   # D1 schema migrations (users, api_keys, telegram_link_codes, …)
 ├── wrangler.toml                    # API worker config
 ├── wrangler.telegram.toml           # Telegram bot worker config
 ├── wrangler.telegram.test.toml      # Telegram bot test config (no service bindings)
@@ -110,8 +110,14 @@ wrangler d1 migrations apply prism-db --local
 # Telegram bot token (get from @BotFather)
 echo "YOUR_TELEGRAM_BOT_TOKEN" | wrangler secret put TELEGRAM_BOT_TOKEN
 
-# Optional: webhook secret for additional security
+# REQUIRED: webhook secret — the bot worker rejects all webhook POSTs without it
 echo "RANDOM_SECRET" | wrangler secret put TELEGRAM_WEBHOOK_SECRET
+
+# REQUIRED: shared secret between the telegram bot and API workers.
+# The bot sends it as the X-Bot-Api-Secret header; the API rejects
+# telegram_id-keyed endpoints without it. Use the SAME value in both workers:
+echo "RANDOM_SHARED_SECRET" | wrangler secret put BOT_API_SECRET
+echo "RANDOM_SHARED_SECRET" | wrangler secret put BOT_API_SECRET --config wrangler.telegram.toml
 
 # Optional: fee collection wallet (Solana address)
 echo "YOUR_SOLANA_ADDRESS" | wrangler secret put FEE_WALLET_ADDRESS
@@ -130,8 +136,9 @@ wrangler deploy --config wrangler.telegram.toml
 ### 7. Setup Telegram webhook
 
 ```bash
-# Replace YOUR_BOT_TOKEN with the token from step 5
-curl "https://api.telegram.org/botYOUR_BOT_TOKEN/setWebhook?url=https://prism-telegram-bot.YOUR_SUBDOMAIN.workers.dev/webhook"
+# Replace YOUR_BOT_TOKEN with the token from step 5.
+# secret_token MUST match TELEGRAM_WEBHOOK_SECRET — the worker fails closed without it.
+curl "https://api.telegram.org/botYOUR_BOT_TOKEN/setWebhook?url=https://prism-telegram-bot.YOUR_SUBDOMAIN.workers.dev/webhook&secret_token=YOUR_WEBHOOK_SECRET"
 
 # Verify
 curl "https://api.telegram.org/botYOUR_BOT_TOKEN/getWebhookInfo"
@@ -139,23 +146,29 @@ curl "https://api.telegram.org/botYOUR_BOT_TOKEN/getWebhookInfo"
 
 ## API Endpoints
 
-| Endpoint                    | Method | Auth   | Description                           |
-| --------------------------- | ------ | ------ | ------------------------------------- |
-| `/health`                   | GET    | None   | Health check                          |
-| `/v1/register`              | POST   | None   | Register new user, returns API key    |
-| `/v1/login`                 | POST   | Bearer | Validate API key, returns user info   |
-| `/v1/whoami`                | GET    | Bearer | Get current user info                 |
-| `/v1/whoami-telegram`       | POST   | None   | Look up user by telegram_id (for bot) |
-| `/v1/link-telegram/start`   | POST   | Bearer | Generate `LINK-XXXXXX` code           |
-| `/v1/link-telegram/confirm` | POST   | None   | Confirm Telegram link with code       |
-| `/v1/register-telegram`     | POST   | None   | Register via Telegram (for bot)       |
-| `/v1/agent-status`          | POST   | None   | Get agent status (for Telegram bot)   |
-| `/v1/issue`                 | POST   | Bearer | Store an issue in D1                  |
-| `/v1/feedback`              | POST   | Bearer | Store deduplicated agent feedback     |
-| `/v1/errors/report`         | POST   | Bearer | Store one authenticated error report  |
-| `/v1/errors/batch`          | POST   | Bearer | Store authenticated error reports     |
-| `/v1/installs/ping`         | POST   | Mixed  | Anonymous install; auth for lifecycle|
-| `/v1/audit`                 | GET    | Admin  | Query deduplicated audit summaries   |
+| Endpoint                    | Method | Auth        | Description                           |
+| --------------------------- | ------ | ----------- | ------------------------------------- |
+| `/health`                   | GET    | None        | Health check                          |
+| `/v1/register`              | POST   | None¹       | Register new user, returns API key    |
+| `/v1/login`                 | POST   | Bearer      | Validate API key, returns user info   |
+| `/v1/whoami`                | GET    | Bearer      | Get current user info                 |
+| `/v1/whoami-telegram`       | POST   | Bot secret  | Look up user by telegram_id (for bot) |
+| `/v1/link-telegram/start`   | POST   | Bearer      | Generate `LINK-<16 hex>` code         |
+| `/v1/link-telegram/confirm` | POST   | Rate-limited² | Confirm Telegram link with code     |
+| `/v1/register-telegram`     | POST   | Bot secret  | Register via Telegram (for bot)       |
+| `/v1/agent-status`          | POST   | Bot secret  | Get agent status (for Telegram bot)   |
+| `/v1/issue`                 | POST   | Bearer      | Store an issue in D1                  |
+| `/v1/feedback`              | POST   | Bearer      | Store deduplicated agent feedback     |
+| `/v1/errors/report`         | POST   | Bearer      | Store one authenticated error report  |
+| `/v1/errors/batch`          | POST   | Bearer      | Store authenticated error reports     |
+| `/v1/installs/ping`         | POST   | Mixed       | Anonymous install; auth for lifecycle|
+| `/v1/audit`                 | GET    | Admin       | Query deduplicated audit summaries   |
+
+¹ `/v1/register` is open for normal CLI registration, but binding a `telegram_id`
+in the same call requires the `X-Bot-Api-Secret` header.
+² `/v1/link-telegram/confirm` is limited to 10 attempts/hour/IP, and each code is
+burned after 5 attempts. Link codes expire 10 minutes after issue (unixepoch
+comparison) and requesting a new code invalidates the user's outstanding ones.
 
 ## Telegram Bot Commands
 
@@ -168,7 +181,12 @@ curl "https://api.telegram.org/botYOUR_BOT_TOKEN/getWebhookInfo"
 | `/status`   | Show agent status (positions, P&L)         |
 | `/help`     | List all commands                          |
 
-Send a 6-character code to link your Telegram to an existing account.
+Send the `LINK-<16 hex>` code to link your Telegram to an existing account.
+
+**Private chats only:** `/register`, `/whoami`, `/status`, `/link` and link-code
+confirmation are refused in group chats — credentials must never be posted where
+other members can see them. User-controlled text (e.g. first names) is
+HTML-escaped before being interpolated into `parse_mode: HTML` replies.
 
 ## Bindings
 
@@ -205,16 +223,17 @@ bunx vitest run
 bunx vitest run workers/telegram-bot/telegram-bot.test.ts
 ```
 
-### Test coverage: 16 tests for Telegram bot
+### Test coverage: 30 tests for Telegram bot
 
 - Health check (1)
-- Webhook security (2)
-- Command handlers (4)
-- Link code handling (2)
+- Webhook security (4, incl. fail-closed when the secret is unset)
+- Command handlers (6, incl. HTML-escaping of user-controlled names)
+- Group chat restrictions (5)
+- Link code handling (6, incl. bot-secret header and 16-hex codes)
 - Registration flow (2)
 - Whoami command (2)
 - Status command (1)
-- Edge cases (2)
+- Edge cases (3)
 
 ## Development
 

--- a/cloudflare/migrations/0012_link_code_security.sql
+++ b/cloudflare/migrations/0012_link_code_security.sql
@@ -1,0 +1,24 @@
+-- Migration: telegram_link_codes — unixepoch expiry + per-code attempt counter
+-- Created: 2026-07-17
+--
+-- Security context (Wave 3 remediation):
+--   * expires_at was ISO-8601 text compared against CURRENT_TIMESTAMP, which
+--     compares lexicographically ('T' > ' ') and kept 10-minute codes valid
+--     for ~24h. It is now INTEGER unixepoch seconds compared with unixepoch().
+--   * attempts backs the 5-strike burn that thwarts code brute-forcing.
+-- Link codes are ephemeral (10-minute TTL), so existing rows are discarded
+-- rather than migrated.
+
+DROP TABLE IF EXISTS telegram_link_codes;
+
+CREATE TABLE telegram_link_codes (
+    code TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    expires_at INTEGER NOT NULL,
+    used_at DATETIME,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_telegram_link_codes_user ON telegram_link_codes(user_id);

--- a/cloudflare/worker-configuration.d.ts
+++ b/cloudflare/worker-configuration.d.ts
@@ -14,5 +14,6 @@ declare namespace Cloudflare {
     TELEGRAM_BOT_TOKEN?: string;
     TELEGRAM_WEBHOOK_SECRET?: string;
     ADMIN_API_KEY?: string;
+    BOT_API_SECRET?: string;
   }
 }

--- a/cloudflare/workers/api/audit.test.ts
+++ b/cloudflare/workers/api/audit.test.ts
@@ -46,8 +46,10 @@ describe("Audit Logging API", () => {
       `CREATE TABLE IF NOT EXISTS telegram_link_codes (
         code TEXT PRIMARY KEY,
         user_id TEXT NOT NULL,
-        expires_at DATETIME NOT NULL,
-        used_at DATETIME
+        expires_at INTEGER NOT NULL,
+        used_at DATETIME,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )`,
     ).run();
     await env.DB.prepare(
@@ -102,6 +104,7 @@ describe("Audit Logging API", () => {
     await env.DB.prepare("DELETE FROM api_keys").run();
     await env.DB.prepare("DELETE FROM users").run();
     await env.CACHE.delete("rate_limit:register:unknown");
+    await env.CACHE.delete("rate_limit:link_confirm:unknown");
 
     // Register a user to get an API key
     const ctx = createExecutionContext();
@@ -192,7 +195,7 @@ describe("Audit Logging API", () => {
     await env.DB.prepare(
       "INSERT INTO telegram_link_codes (code, user_id, expires_at) VALUES (?, ?, ?)",
     )
-      .bind("LINK-TEST", userId, new Date(Date.now() + 600000).toISOString())
+      .bind("LINK-TEST", userId, Math.floor(Date.now() / 1000) + 600)
       .run();
 
     const ctx = createExecutionContext();

--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -10,6 +10,9 @@ export interface Env {
   FEE_WALLET_ADDRESS: string;
   TELEGRAM_BOT_TOKEN: string;
   ADMIN_API_KEY?: string;
+  // Shared secret the Telegram bot worker presents as X-Bot-Api-Secret for
+  // telegram_id-keyed endpoints. Unset means those endpoints fail closed.
+  BOT_API_SECRET?: string;
 }
 
 function constantTimeEqual(a: string, b: string): boolean {
@@ -19,6 +22,13 @@ function constantTimeEqual(a: string, b: string): boolean {
     mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
   }
   return mismatch === 0;
+}
+
+// Telegram-bot shared-secret check. Fails closed: an unset server secret
+// rejects everything, and comparison is constant-time.
+function isBotAuthorized(env: Env, headerSecret: string | undefined): boolean {
+  if (!env.BOT_API_SECRET || !headerSecret) return false;
+  return constantTimeEqual(headerSecret, env.BOT_API_SECRET);
 }
 
 const MAX_ERROR_MESSAGE_LENGTH = 4096;
@@ -53,6 +63,16 @@ const generateId = () => {
   const randomBytes = new Uint8Array(8);
   crypto.getRandomValues(randomBytes);
   return `${Date.now()}-${Array.from(randomBytes)
+    .map((b) => b.toString(36).padStart(2, "0"))
+    .join("")}`;
+};
+
+// API keys are bearer credentials: 20 CSPRNG bytes (~160 bits), no timestamp
+// component, so they cannot be predicted from registration time.
+const generateApiKey = () => {
+  const randomBytes = new Uint8Array(20);
+  crypto.getRandomValues(randomBytes);
+  return `sk-prism-${Array.from(randomBytes)
     .map((b) => b.toString(36).padStart(2, "0"))
     .join("")}`;
 };
@@ -181,7 +201,7 @@ const TIERS: Record<string, { platformFeeRate: number }> = {
 const registerHandler = (db: D1Database) =>
   Effect.gen(function* () {
     const userId = generateId();
-    const apiKey = `sk-prism-${generateId()}`;
+    const apiKey = generateApiKey();
     const keyHash = yield* hashKey(apiKey);
 
     yield* Effect.tryPromise(() =>
@@ -270,26 +290,39 @@ const whoamiHandler = (db: D1Database, userId: string) =>
     return result;
   });
 
-// Link Telegram start handler
+// Link Telegram start handler. Codes carry 64 bits of CSPRNG entropy and a
+// unixepoch expiry; requesting a new code burns the user's outstanding ones.
 const linkTelegramStartHandler = (db: D1Database, userId: string) =>
   Effect.gen(function* () {
-    const randomBytes = new Uint8Array(4);
+    const randomBytes = new Uint8Array(8);
     crypto.getRandomValues(randomBytes);
     const code = `LINK-${Array.from(randomBytes)
-      .map((b) => b.toString(36).padStart(2, "0"))
+      .map((b) => b.toString(16).padStart(2, "0"))
       .join("")
-      .toUpperCase()
-      .slice(0, 6)}`;
-    const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString(); // 10 minutes
+      .toUpperCase()}`;
+    const expiresAtEpoch = Math.floor(Date.now() / 1000) + 10 * 60; // 10 minutes
+
+    yield* Effect.tryPromise(() =>
+      db
+        .prepare(
+          `UPDATE telegram_link_codes
+           SET used_at = CURRENT_TIMESTAMP
+           WHERE user_id = ? AND used_at IS NULL`,
+        )
+        .bind(userId)
+        .run(),
+    );
 
     yield* Effect.tryPromise(() =>
       db
         .prepare("INSERT INTO telegram_link_codes (code, user_id, expires_at) VALUES (?, ?, ?)")
-        .bind(code, userId, expiresAt)
+        .bind(code, userId, expiresAtEpoch)
         .run(),
     );
 
-    return { code, expiresAt };
+    // expiresAt stays an ISO string in the API response — the CLI parses it
+    // with new Date() to display the remaining time.
+    return { code, expiresAt: new Date(expiresAtEpoch * 1000).toISOString() };
   });
 
 // Health check
@@ -314,7 +347,7 @@ const registerTelegramHandler = (db: D1Database, telegramId: string, firstName: 
     }
 
     const userId = generateId();
-    const apiKey = `sk-prism-${generateId()}`;
+    const apiKey = generateApiKey();
     const keyHash = yield* hashKey(apiKey);
 
     yield* Effect.tryPromise(() =>
@@ -392,6 +425,11 @@ app.post("/v1/register", async (c) => {
     yield* Effect.tryPromise(() => CACHE.put(rateKey, String(count + 1), { expirationTtl: 3600 }));
 
     if (body.telegram_id) {
+      // Binding a telegram_id to a fresh account is a bot-only flow — without
+      // the shared secret anyone could squat arbitrary Telegram identities.
+      if (!isBotAuthorized(c.env, c.req.header("X-Bot-Api-Secret"))) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
       if (!/^\d+$/.test(body.telegram_id)) {
         return c.json({ error: "Invalid telegram_id format. Must be numeric." }, 400);
       }
@@ -473,8 +511,12 @@ app.post("/v1/link-telegram/start", async (c) => {
   );
 });
 
+const LINK_CONFIRM_RATE_LIMIT_PER_HOUR = 10;
+const LINK_CODE_MAX_ATTEMPTS = 5;
+
 app.post("/v1/link-telegram/confirm", async (c) => {
-  const { DB } = c.env;
+  const { DB, CACHE } = c.env;
+  const clientIp = c.req.header("CF-Connecting-IP") || "unknown";
   const body = await Effect.runPromise(readJsonBody<{ code: string; telegram_id: string }>(c.req));
 
   if (!body.code || !body.telegram_id) {
@@ -485,42 +527,61 @@ app.post("/v1/link-telegram/confirm", async (c) => {
     return c.json({ error: "Invalid telegram_id format. Must be numeric." }, 400);
   }
 
+  // Brute-force defense: every attempt counts against the per-IP budget,
+  // not just successful ones, so guessing codes is capped at 10/hour.
+  const rateKey = `rate_limit:link_confirm:${clientIp}`;
+  const rateData = await Effect.runPromise(cacheGet(CACHE, rateKey));
+  const rateCount = rateData ? parseInt(rateData, 10) : 0;
+  if (rateCount >= LINK_CONFIRM_RATE_LIMIT_PER_HOUR) {
+    return c.json({ error: "Rate limit exceeded. Try again later." }, 429);
+  }
+  await Effect.runPromise(cachePut(CACHE, rateKey, String(rateCount + 1), { expirationTtl: 3600 }));
+
   const linking = Effect.gen(function* () {
+    const codeRow = yield* Effect.tryPromise(() =>
+      DB.prepare(
+        `SELECT user_id, expires_at, used_at, attempts
+         FROM telegram_link_codes
+         WHERE code = ?`,
+      )
+        .bind(body.code)
+        .first(),
+    );
+
+    if (!codeRow) return c.json({ error: "Invalid code" }, 400);
+
+    // 5-strike burn: a code that absorbs too many confirm attempts is dead.
+    const attempts = typeof codeRow.attempts === "number" ? codeRow.attempts : 0;
+    if (attempts >= LINK_CODE_MAX_ATTEMPTS) {
+      return c.json({ error: "Too many attempts for this code" }, 429);
+    }
+    yield* Effect.tryPromise(() =>
+      DB.prepare("UPDATE telegram_link_codes SET attempts = attempts + 1 WHERE code = ?")
+        .bind(body.code)
+        .run(),
+    );
+
+    if (codeRow.used_at) return c.json({ error: "Code already used" }, 400);
+    const expiresAt = typeof codeRow.expires_at === "number" ? codeRow.expires_at : 0;
+    if (expiresAt <= Math.floor(Date.now() / 1000)) {
+      return c.json({ error: "Code expired" }, 400);
+    }
+
     const updateResult = yield* Effect.tryPromise(() =>
       DB.prepare(
         `UPDATE telegram_link_codes
          SET used_at = CURRENT_TIMESTAMP
-         WHERE code = ?
-           AND used_at IS NULL
-           AND expires_at > CURRENT_TIMESTAMP`,
+         WHERE code = ? AND used_at IS NULL`,
       )
         .bind(body.code)
         .run(),
     );
 
     if (!updateResult.success || updateResult.meta.changes === 0) {
-      const codeResult = yield* Effect.tryPromise(() =>
-        DB.prepare(
-          `SELECT used_at, expires_at
-           FROM telegram_link_codes
-           WHERE code = ?`,
-        )
-          .bind(body.code)
-          .first(),
-      );
-
-      if (!codeResult) return c.json({ error: "Invalid code" }, 400);
-      if (codeResult.used_at) return c.json({ error: "Code already used" }, 400);
-      if (new Date(codeResult.expires_at as string) < new Date()) {
-        return c.json({ error: "Code expired" }, 400);
-      }
-      return c.json({ error: "Linking failed" }, 500);
+      return c.json({ error: "Code already used" }, 400);
     }
 
-    const codeResult = yield* Effect.tryPromise(() =>
-      DB.prepare(`SELECT user_id FROM telegram_link_codes WHERE code = ?`).bind(body.code).first(),
-    );
-    const userId = typeof codeResult?.user_id === "string" ? codeResult.user_id : null;
+    const userId = typeof codeRow.user_id === "string" ? codeRow.user_id : null;
     if (!userId) return c.json({ error: "Linking failed" }, 500);
 
     yield* Effect.tryPromise(() =>
@@ -540,6 +601,9 @@ app.post("/v1/link-telegram/confirm", async (c) => {
 
 app.post("/v1/whoami-telegram", async (c) => {
   const { DB } = c.env;
+  if (!isBotAuthorized(c.env, c.req.header("X-Bot-Api-Secret"))) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
   const body = await Effect.runPromise(readJsonBody<{ telegram_id?: string }>(c.req));
 
   if (!body.telegram_id) {
@@ -573,6 +637,9 @@ app.post("/v1/whoami-telegram", async (c) => {
 
 app.post("/v1/register-telegram", async (c) => {
   const { DB, CACHE } = c.env;
+  if (!isBotAuthorized(c.env, c.req.header("X-Bot-Api-Secret"))) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
   const clientIp = c.req.header("CF-Connecting-IP") || "unknown";
   const body = await Effect.runPromise(
     readJsonBody<{ telegram_id?: string; first_name?: string }>(c.req),
@@ -623,6 +690,9 @@ app.post("/v1/register-telegram", async (c) => {
 
 app.post("/v1/agent-status", async (c) => {
   const { DB } = c.env;
+  if (!isBotAuthorized(c.env, c.req.header("X-Bot-Api-Secret"))) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
   const body = await Effect.runPromise(readJsonBody<{ telegram_id?: string }>(c.req));
 
   if (!body.telegram_id) {
@@ -1626,19 +1696,30 @@ app.post("/v1/revenue/log", async (c) => {
     }>(c.req),
   );
 
-  if (
-    typeof body.poolAddress !== "string" ||
-    body.poolAddress.length === 0 ||
-    typeof body.platformFeeX !== "number" ||
-    typeof body.platformFeeY !== "number"
-  ) {
-    return c.json(
-      {
-        error:
-          "Missing required fields: poolAddress (string), platformFeeX (number), platformFeeY (number)",
-      },
-      400,
-    );
+  if (typeof body.poolAddress !== "string" || body.poolAddress.length === 0) {
+    return c.json({ error: "Missing required field: poolAddress (string)" }, 400);
+  }
+
+  // Every numeric field must be a finite, non-negative number. Negative or
+  // non-finite fees would corrupt revenue accounting.
+  const numericFields: Array<readonly [string, number | undefined, boolean]> = [
+    ["platformFeeX", body.platformFeeX, true],
+    ["platformFeeY", body.platformFeeY, true],
+    ["feeX", body.feeX, false],
+    ["feeY", body.feeY, false],
+    ["operatorFeeX", body.operatorFeeX, false],
+    ["operatorFeeY", body.operatorFeeY, false],
+  ];
+  for (const [name, value, required] of numericFields) {
+    if (value === undefined) {
+      if (required) {
+        return c.json({ error: `Missing required field: ${name} (number)` }, 400);
+      }
+      continue;
+    }
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+      return c.json({ error: `Invalid ${name}: must be a finite, non-negative number` }, 400);
+    }
   }
 
   if (CACHE) {

--- a/cloudflare/workers/api/link-telegram.test.ts
+++ b/cloudflare/workers/api/link-telegram.test.ts
@@ -1,0 +1,456 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { env, createExecutionContext } from "cloudflare:test";
+import worker, { type Env } from "./index";
+
+// Shared bot secret for bot-authenticated endpoints (X-Bot-Api-Secret header).
+const BOT_SECRET = "test-bot-api-secret";
+const testEnv = { ...env, BOT_API_SECRET: BOT_SECRET } as unknown as Env;
+// Environment without the secret configured — endpoints must fail closed.
+const noSecretEnv = env as unknown as Env;
+
+function buildRequest(
+  method: string,
+  path: string,
+  body?: unknown,
+  headers?: Record<string, string>,
+): Request {
+  const init: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json", ...headers },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+  return new Request(`https://example.com${path}`, init);
+}
+
+function withBotSecret(req: Request, secret: string = BOT_SECRET): Request {
+  return new Request(req.url, {
+    method: req.method,
+    headers: { ...Object.fromEntries(req.headers), "X-Bot-Api-Secret": secret },
+    body: req.body,
+  });
+}
+
+const nowEpoch = () => Math.floor(Date.now() / 1000);
+
+async function insertUser(id: string, telegramId?: string): Promise<void> {
+  await env.DB.prepare("INSERT INTO users (id, tier, telegram_id) VALUES (?, ?, ?)")
+    .bind(id, "free", telegramId ?? null)
+    .run();
+}
+
+async function insertCode(
+  code: string,
+  userId: string,
+  expiresAtEpoch: number,
+  attempts = 0,
+): Promise<void> {
+  await env.DB.prepare(
+    "INSERT INTO telegram_link_codes (code, user_id, expires_at, attempts) VALUES (?, ?, ?, ?)",
+  )
+    .bind(code, userId, expiresAtEpoch, attempts)
+    .run();
+}
+
+describe("Telegram linking security", () => {
+  beforeAll(async () => {
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS users (
+        id TEXT PRIMARY KEY,
+        telegram_id TEXT UNIQUE,
+        tier TEXT NOT NULL DEFAULT 'free',
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+    ).run();
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS api_keys (
+        key_hash TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        last_used_at DATETIME
+      )`,
+    ).run();
+    // New schema: unixepoch expiry + per-code attempt counter (migration 0012).
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS telegram_link_codes (
+        code TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        expires_at INTEGER NOT NULL,
+        used_at DATETIME,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+      )`,
+    ).run();
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS subscriptions (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        tier TEXT NOT NULL,
+        period_start DATETIME NOT NULL,
+        period_end DATETIME NOT NULL,
+        payment_method TEXT,
+        payment_tx_signature TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+    ).run();
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS audit_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        action TEXT NOT NULL,
+        details TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+    ).run();
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS audit_event_summary (
+        user_id TEXT NOT NULL,
+        action TEXT NOT NULL,
+        event_key TEXT NOT NULL,
+        details TEXT,
+        first_seen_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        last_seen_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        occurrence_count INTEGER NOT NULL DEFAULT 1,
+        PRIMARY KEY (user_id, action, event_key)
+      )`,
+    ).run();
+  });
+
+  beforeEach(async () => {
+    await env.DB.prepare("DELETE FROM telegram_link_codes").run();
+    await env.DB.prepare("DELETE FROM subscriptions").run();
+    await env.DB.prepare("DELETE FROM audit_log").run();
+    await env.DB.prepare("DELETE FROM audit_event_summary").run();
+    await env.DB.prepare("DELETE FROM api_keys").run();
+    await env.DB.prepare("DELETE FROM users").run();
+    await env.CACHE.delete("rate_limit:link_confirm:unknown");
+    await env.CACHE.delete("rate_limit:register:unknown");
+    await env.CACHE.delete("rate_limit:register_telegram:unknown");
+  });
+
+  describe("POST /v1/link-telegram/confirm", () => {
+    it("confirms a valid unexpired code and binds the telegram_id", async () => {
+      await insertUser("user-1");
+      await insertCode("LINK-VALID1", "user-1", nowEpoch() + 600);
+
+      const response = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/confirm", {
+          code: "LINK-VALID1",
+          telegram_id: "123456789",
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { success: boolean; user_id: string };
+      expect(body.success).toBe(true);
+      expect(body.user_id).toBe("user-1");
+
+      const user = await env.DB.prepare("SELECT telegram_id FROM users WHERE id = ?")
+        .bind("user-1")
+        .first();
+      expect(user?.telegram_id).toBe("123456789");
+    });
+
+    it("rejects an expired code (unixepoch comparison)", async () => {
+      await insertUser("user-1");
+      // Expired 10 minutes ago — must be rejected even though SQLite text
+      // comparison would previously keep ISO strings valid for ~24h.
+      await insertCode("LINK-EXPIRED", "user-1", nowEpoch() - 600);
+
+      const response = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/confirm", {
+          code: "LINK-EXPIRED",
+          telegram_id: "123456789",
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toMatch(/expired/i);
+    });
+
+    it("rejects an unknown code", async () => {
+      const response = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/confirm", {
+          code: "LINK-NOSUCHCODE",
+          telegram_id: "123456789",
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toMatch(/invalid code/i);
+    });
+
+    it("burns a code after 5 attempts (6th attempt rejected)", async () => {
+      await insertUser("user-1");
+      await insertCode("LINK-BURN01", "user-1", nowEpoch() + 600);
+
+      // Attempt 1 succeeds and marks the code used; attempts 2-5 hit
+      // "already used" but still count toward the strike limit.
+      for (let i = 0; i < 5; i++) {
+        const res = await worker.fetch(
+          buildRequest("POST", "/v1/link-telegram/confirm", {
+            code: "LINK-BURN01",
+            telegram_id: "123456789",
+          }),
+          testEnv,
+          createExecutionContext(),
+        );
+        expect([200, 400]).toContain(res.status);
+      }
+
+      const sixth = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/confirm", {
+          code: "LINK-BURN01",
+          telegram_id: "123456789",
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(sixth.status).toBe(429);
+    });
+
+    it("rate-limits confirm attempts per IP (10/hour)", async () => {
+      // 10 attempts with distinct unknown codes are all counted.
+      for (let i = 0; i < 10; i++) {
+        const res = await worker.fetch(
+          buildRequest("POST", "/v1/link-telegram/confirm", {
+            code: `LINK-GUESS${String(i).padStart(2, "0")}`,
+            telegram_id: "123456789",
+          }),
+          testEnv,
+          createExecutionContext(),
+        );
+        expect(res.status).toBe(400);
+      }
+
+      const eleventh = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/confirm", {
+          code: "LINK-GUESS11",
+          telegram_id: "123456789",
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(eleventh.status).toBe(429);
+    });
+  });
+
+  describe("POST /v1/link-telegram/start", () => {
+    async function registerCliUser(): Promise<{ apiKey: string; userId: string }> {
+      const res = await worker.fetch(
+        buildRequest("POST", "/v1/register", {}),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { user_id: string; api_key: string };
+      return { apiKey: body.api_key, userId: body.user_id };
+    }
+
+    it("issues a high-entropy code (LINK- + 16 hex chars) with ISO expiresAt", async () => {
+      const { apiKey } = await registerCliUser();
+      const res = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/start", {}, {
+          Authorization: `Bearer ${apiKey}`,
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { code: string; expiresAt: string };
+      expect(body.code).toMatch(/^LINK-[0-9A-F]{16}$/);
+      // CLI parses expiresAt with new Date() — keep it an ISO string.
+      expect(Number.isNaN(new Date(body.expiresAt).getTime())).toBe(false);
+    });
+
+    it("invalidates outstanding codes when a new code is requested", async () => {
+      const { apiKey } = await registerCliUser();
+
+      const first = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/start", {}, {
+          Authorization: `Bearer ${apiKey}`,
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      const firstBody = (await first.json()) as { code: string };
+
+      const second = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/start", {}, {
+          Authorization: `Bearer ${apiKey}`,
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      const secondBody = (await second.json()) as { code: string };
+      expect(secondBody.code).not.toBe(firstBody.code);
+
+      // The first code must no longer be linkable.
+      const confirmFirst = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/confirm", {
+          code: firstBody.code,
+          telegram_id: "123456789",
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(confirmFirst.status).toBe(400);
+
+      // The second code still works.
+      const confirmSecond = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/confirm", {
+          code: secondBody.code,
+          telegram_id: "123456789",
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(confirmSecond.status).toBe(200);
+    });
+  });
+
+  describe("bot-secret authentication (X-Bot-Api-Secret)", () => {
+    it("rejects /v1/register-telegram without the bot secret", async () => {
+      const res = await worker.fetch(
+        buildRequest("POST", "/v1/register-telegram", { telegram_id: "111" }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect([401, 403]).toContain(res.status);
+    });
+
+    it("rejects /v1/register-telegram with a wrong bot secret", async () => {
+      const res = await worker.fetch(
+        withBotSecret(
+          buildRequest("POST", "/v1/register-telegram", { telegram_id: "111" }),
+          "wrong-secret",
+        ),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect([401, 403]).toContain(res.status);
+    });
+
+    it("accepts /v1/register-telegram with the bot secret", async () => {
+      const res = await worker.fetch(
+        withBotSecret(buildRequest("POST", "/v1/register-telegram", {
+          telegram_id: "111",
+          first_name: "Test",
+        })),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { user_id: string; api_key: string };
+      expect(body.api_key).toMatch(/^sk-prism-/);
+    });
+
+    it("fails closed when the server has no BOT_API_SECRET configured", async () => {
+      const res = await worker.fetch(
+        withBotSecret(buildRequest("POST", "/v1/register-telegram", { telegram_id: "111" })),
+        noSecretEnv,
+        createExecutionContext(),
+      );
+      expect([401, 403]).toContain(res.status);
+    });
+
+    it("rejects /v1/whoami-telegram without the bot secret", async () => {
+      await insertUser("user-1", "222");
+      const res = await worker.fetch(
+        buildRequest("POST", "/v1/whoami-telegram", { telegram_id: "222" }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect([401, 403]).toContain(res.status);
+    });
+
+    it("serves /v1/whoami-telegram with the bot secret", async () => {
+      await insertUser("user-1", "222");
+      const res = await worker.fetch(
+        withBotSecret(buildRequest("POST", "/v1/whoami-telegram", { telegram_id: "222" })),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { user_id: string };
+      expect(body.user_id).toBe("user-1");
+    });
+
+    it("rejects /v1/agent-status without the bot secret", async () => {
+      await insertUser("user-1", "333");
+      const res = await worker.fetch(
+        buildRequest("POST", "/v1/agent-status", { telegram_id: "333" }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect([401, 403]).toContain(res.status);
+    });
+
+    it("serves /v1/agent-status with the bot secret", async () => {
+      await insertUser("user-1", "333");
+      const res = await worker.fetch(
+        withBotSecret(buildRequest("POST", "/v1/agent-status", { telegram_id: "333" })),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects /v1/register telegram binding without the bot secret", async () => {
+      const res = await worker.fetch(
+        buildRequest("POST", "/v1/register", { telegram_id: "444" }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect([401, 403]).toContain(res.status);
+    });
+
+    it("binds telegram_id on /v1/register with the bot secret", async () => {
+      const res = await worker.fetch(
+        withBotSecret(buildRequest("POST", "/v1/register", { telegram_id: "444" })),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { user_id: string };
+      const user = await env.DB.prepare("SELECT telegram_id FROM users WHERE id = ?")
+        .bind(body.user_id)
+        .first();
+      expect(user?.telegram_id).toBe("444");
+    });
+
+    it("keeps plain CLI /v1/register working without the bot secret", async () => {
+      const res = await worker.fetch(
+        buildRequest("POST", "/v1/register", {}),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { api_key: string };
+      expect(body.api_key).toMatch(/^sk-prism-/);
+    });
+  });
+
+  describe("API key entropy", () => {
+    it("generates API keys with at least 128 bits of CSPRNG entropy", async () => {
+      const res = await worker.fetch(
+        buildRequest("POST", "/v1/register", {}),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { api_key: string };
+      // sk-prism- + 40 base36 chars from 20 random bytes (~160 bits).
+      expect(body.api_key.length).toBeGreaterThanOrEqual(9 + 32);
+      expect(body.api_key).toMatch(/^sk-prism-[a-z0-9]+$/);
+    });
+  });
+});

--- a/cloudflare/workers/api/revenue.test.ts
+++ b/cloudflare/workers/api/revenue.test.ts
@@ -151,6 +151,32 @@ describe("Revenue Tracking API", () => {
       expect(response.status).toBe(401);
     });
 
+    it("rejects negative or non-finite numeric fields", async () => {
+      const base = {
+        poolAddress: "5JvD1TW5nqSz6gJtHfVnZKq3fZmBnL5xY7u9dR2wT4k",
+        platformFeeX: 1.0,
+        platformFeeY: 2.0,
+      };
+      const invalidPayloads: Array<Record<string, unknown>> = [
+        { ...base, platformFeeX: -1 },
+        { ...base, platformFeeY: -0.001 },
+        { ...base, feeX: -5 },
+        { ...base, feeY: -5 },
+        { ...base, operatorFeeX: -1 },
+        { ...base, operatorFeeY: -1 },
+        { ...base, platformFeeX: "1.0" },
+        { ...base, feeX: "lots" },
+      ];
+      for (const payload of invalidPayloads) {
+        const ctx = createExecutionContext();
+        const request = buildRequest("POST", "/v1/revenue/log", payload, {
+          Authorization: `Bearer ${apiKey}`,
+        });
+        const response = await worker.fetch(request, testEnv, ctx);
+        expect(response.status).toBe(400);
+      }
+    });
+
     it("returns 400 on missing required fields", async () => {
       const ctx = createExecutionContext();
       const request1 = buildRequest(

--- a/cloudflare/workers/telegram-bot/index.ts
+++ b/cloudflare/workers/telegram-bot/index.ts
@@ -8,6 +8,22 @@ interface Env {
   TELEGRAM_BOT_TOKEN: string;
   TELEGRAM_WEBHOOK_SECRET?: string;
   API_BASE_URL: string;
+  // Shared secret presented as X-Bot-Api-Secret on bot->API calls. The API
+  // rejects telegram_id-keyed endpoints without it (fail closed).
+  BOT_API_SECRET?: string;
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 // Services
@@ -108,12 +124,16 @@ function callPrismApi(
   baseUrl: string,
   path: string,
   body: Record<string, unknown>,
+  botApiSecret?: string,
 ): Effect.Effect<{ ok: boolean; data?: unknown; error?: string }, never> {
   return Effect.gen(function* () {
     const response = yield* Effect.tryPromise(() =>
       fetch(`${baseUrl}${path}`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...(botApiSecret ? { "X-Bot-Api-Secret": botApiSecret } : {}),
+        },
         body: JSON.stringify(body),
       }),
     );
@@ -148,7 +168,7 @@ function handleStart(
   return sendMessage(
     botToken,
     chatId,
-    `Welcome to Prism, ${firstName}!\n\n` +
+    `Welcome to Prism, ${escapeHtml(firstName)}!\n\n` +
       `To get started, register with:\n` +
       `<code>prism register</code>\n\n` +
       `Or link your existing account with /link`,
@@ -174,12 +194,18 @@ function handleRegister(
   chatId: number,
   telegramId: string,
   firstName: string,
+  botApiSecret?: string,
 ): Effect.Effect<void, never> {
   return Effect.gen(function* () {
-    const result = yield* callPrismApi(apiBaseUrl, "/v1/register-telegram", {
-      telegram_id: telegramId,
-      first_name: firstName,
-    });
+    const result = yield* callPrismApi(
+      apiBaseUrl,
+      "/v1/register-telegram",
+      {
+        telegram_id: telegramId,
+        first_name: firstName,
+      },
+      botApiSecret,
+    );
 
     if (result.ok && result.data) {
       const data = result.data as { api_key: string; user_id: string };
@@ -223,11 +249,17 @@ function handleWhoami(
   botToken: string,
   chatId: number,
   telegramId: string,
+  botApiSecret?: string,
 ): Effect.Effect<void, never> {
   return Effect.gen(function* () {
-    const result = yield* callPrismApi(apiBaseUrl, "/v1/whoami-telegram", {
-      telegram_id: telegramId,
-    });
+    const result = yield* callPrismApi(
+      apiBaseUrl,
+      "/v1/whoami-telegram",
+      {
+        telegram_id: telegramId,
+      },
+      botApiSecret,
+    );
 
     if (result.ok && result.data) {
       const data = result.data as { user_id: string; tier: string };
@@ -247,11 +279,17 @@ function handleStatus(
   botToken: string,
   chatId: number,
   telegramId: string,
+  botApiSecret?: string,
 ): Effect.Effect<void, never> {
   return Effect.gen(function* () {
-    const result = yield* callPrismApi(apiBaseUrl, "/v1/agent-status", {
-      telegram_id: telegramId,
-    });
+    const result = yield* callPrismApi(
+      apiBaseUrl,
+      "/v1/agent-status",
+      {
+        telegram_id: telegramId,
+      },
+      botApiSecret,
+    );
 
     if (result.ok && result.data) {
       const data = result.data as { status: string; positions: number; pnl: number };
@@ -269,6 +307,10 @@ function handleStatus(
   });
 }
 
+// Commands that return credentials or account data are private-chat only —
+// in groups the reply (and any API key) would be visible to every member.
+const PRIVATE_ONLY_COMMANDS = new Set(["/register", "/whoami", "/status", "/link"]);
+
 // Process incoming Telegram update
 function processUpdate(
   db: D1Database,
@@ -279,6 +321,7 @@ function processUpdate(
 
   const message = update.message;
   const chatId = message.chat.id;
+  const isPrivateChat = message.chat.type === "private";
   const text = message.text ?? "";
   const telegramId = String(message.from.id);
   const firstName = message.from.first_name;
@@ -288,6 +331,16 @@ function processUpdate(
     if (text.startsWith("/")) {
       const rawCommand = text.split(" ")[0] ?? "";
       const command = rawCommand.split("@")[0]?.toLowerCase() ?? "";
+
+      if (!isPrivateChat && PRIVATE_ONLY_COMMANDS.has(command)) {
+        yield* sendMessage(
+          env.TELEGRAM_BOT_TOKEN,
+          chatId,
+          `For your security, ${command} is only available in a private chat with this bot. ` +
+            `Please open a direct message and try again.`,
+        );
+        return;
+      }
 
       switch (command) {
         case "/start":
@@ -300,6 +353,7 @@ function processUpdate(
             chatId,
             telegramId,
             firstName,
+            env.BOT_API_SECRET,
           );
           break;
         case "/link":
@@ -309,21 +363,48 @@ function processUpdate(
           yield* handleHelp(env.TELEGRAM_BOT_TOKEN, chatId);
           break;
         case "/whoami":
-          yield* handleWhoami(env.API_BASE_URL, env.TELEGRAM_BOT_TOKEN, chatId, telegramId);
+          yield* handleWhoami(
+            env.API_BASE_URL,
+            env.TELEGRAM_BOT_TOKEN,
+            chatId,
+            telegramId,
+            env.BOT_API_SECRET,
+          );
           break;
         case "/status":
-          yield* handleStatus(env.API_BASE_URL, env.TELEGRAM_BOT_TOKEN, chatId, telegramId);
+          yield* handleStatus(
+            env.API_BASE_URL,
+            env.TELEGRAM_BOT_TOKEN,
+            chatId,
+            telegramId,
+            env.BOT_API_SECRET,
+          );
           break;
         default:
           yield* sendMessage(env.TELEGRAM_BOT_TOKEN, chatId, "Unknown command. Try /help");
       }
-    } else if (/^LINK-[A-Z0-9]{6}$/i.test(text.trim()) || /^[A-Z0-9]{6}$/i.test(text.trim())) {
+    } else if (/^LINK-[A-Z0-9]{6,16}$/i.test(text.trim()) || /^[A-Z0-9]{6,16}$/i.test(text.trim())) {
+      if (!isPrivateChat) {
+        // A link code is a credential: confirming in a group would let any
+        // member hijack the link first.
+        yield* sendMessage(
+          env.TELEGRAM_BOT_TOKEN,
+          chatId,
+          `Link codes must be sent in a private chat with this bot for your security.`,
+        );
+        return;
+      }
       const rawCode = text.trim().toUpperCase();
       const code = rawCode.startsWith("LINK-") ? rawCode : `LINK-${rawCode}`;
-      const result = yield* callPrismApi(env.API_BASE_URL, "/v1/link-telegram/confirm", {
-        code,
-        telegram_id: telegramId,
-      });
+      const result = yield* callPrismApi(
+        env.API_BASE_URL,
+        "/v1/link-telegram/confirm",
+        {
+          code,
+          telegram_id: telegramId,
+        },
+        env.BOT_API_SECRET,
+      );
 
       if (result.ok) {
         yield* sendMessage(env.TELEGRAM_BOT_TOKEN, chatId, "Account linked successfully!");
@@ -350,12 +431,11 @@ app.get("/health", async (c) => {
 });
 
 app.post("/webhook", async (c) => {
-  // Optional: verify webhook secret
-  if (c.env.TELEGRAM_WEBHOOK_SECRET) {
-    const headerSecret = c.req.header("X-Telegram-Bot-Api-Secret-Token");
-    if (headerSecret !== c.env.TELEGRAM_WEBHOOK_SECRET) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
+  // Fail closed: an unset TELEGRAM_WEBHOOK_SECRET rejects every webhook POST.
+  const webhookSecret = c.env.TELEGRAM_WEBHOOK_SECRET;
+  const headerSecret = c.req.header("X-Telegram-Bot-Api-Secret-Token");
+  if (!webhookSecret || !headerSecret || !constantTimeEqual(headerSecret, webhookSecret)) {
+    return c.json({ error: "Unauthorized" }, 401);
   }
 
   return await Effect.runPromise(

--- a/cloudflare/workers/telegram-bot/telegram-bot.test.ts
+++ b/cloudflare/workers/telegram-bot/telegram-bot.test.ts
@@ -1,6 +1,72 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { env, createExecutionContext, SELF } from "cloudflare:test";
+import { env, createExecutionContext } from "cloudflare:test";
 import worker from "./index";
+
+// The webhook and bot->API secrets are configured in the test environment so
+// the fail-closed paths can be exercised.
+const WEBHOOK_SECRET = "test-secret";
+const BOT_API_SECRET = "test-bot-api-secret";
+const testEnv = {
+  ...env,
+  TELEGRAM_WEBHOOK_SECRET: WEBHOOK_SECRET,
+  BOT_API_SECRET,
+} as unknown as typeof env;
+
+interface TestMessage {
+  message_id: number;
+  from: { id: number; is_bot: boolean; first_name: string };
+  chat: { id: number; type: "private" | "group" | "supergroup" | "channel" };
+  text?: string;
+  date: number;
+}
+
+function postWebhook(
+  update: { update_id: number; message?: TestMessage },
+  options: { secret?: string; omitSecretHeader?: boolean } = {},
+): RequestInit & { url: string } {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (!options.omitSecretHeader) {
+    headers["X-Telegram-Bot-Api-Secret-Token"] = options.secret ?? WEBHOOK_SECRET;
+  }
+  return {
+    url: "https://example.com/webhook",
+    method: "POST",
+    headers,
+    body: JSON.stringify(update),
+  };
+}
+
+function privateMessage(updateId: number, text: string, firstName = "Test") {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: updateId,
+      from: { id: 12345, is_bot: false, first_name: firstName },
+      chat: { id: 12345, type: "private" as const },
+      text,
+      date: Date.now(),
+    },
+  };
+}
+
+function groupMessage(updateId: number, text: string) {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: updateId,
+      from: { id: 12345, is_bot: false, first_name: "Test" },
+      chat: { id: -100999, type: "supergroup" as const },
+      text,
+      date: Date.now(),
+    },
+  };
+}
+
+/** Extracts the JSON body of the nth mocked fetch call. */
+function sentJson(fetchSpy: ReturnType<typeof vi.spyOn>, callIndex: number): Record<string, unknown> {
+  const init = fetchSpy.mock.calls[callIndex]?.[1] as { body?: string } | undefined;
+  return JSON.parse(init?.body ?? "{}") as Record<string, unknown>;
+}
 
 describe("Telegram Bot Worker", () => {
   beforeEach(() => {
@@ -10,7 +76,11 @@ describe("Telegram Bot Worker", () => {
 
   describe("Health Check", () => {
     it("should return 200 OK on /health", async () => {
-      const response = await SELF.fetch("https://example.com/health");
+      const response = await worker.fetch(
+        new Request("https://example.com/health"),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
 
       const body = (await response.json()) as { status: string; timestamp: string };
@@ -21,31 +91,29 @@ describe("Telegram Bot Worker", () => {
 
   describe("Webhook Security", () => {
     it("should reject webhook without secret token when configured", async () => {
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ update_id: 1 }),
-      });
+      const { url, ...init } = postWebhook({ update_id: 1 }, { omitSecretHeader: true });
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      expect(response.status).toBe(401);
+    });
 
-      // Without webhook secret configured, should pass
-      const response = await worker.fetch(request, env, ctx);
-      expect(response.status).toBe(200);
+    it("should reject webhook with a wrong secret token", async () => {
+      const { url, ...init } = postWebhook({ update_id: 1 }, { secret: "not-the-secret" });
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      expect(response.status).toBe(401);
     });
 
     it("should accept webhook with valid secret token", async () => {
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Telegram-Bot-Api-Secret-Token": "test-secret",
-        },
-        body: JSON.stringify({ update_id: 1 }),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook({ update_id: 1 });
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
+    });
+
+    it("should fail closed when TELEGRAM_WEBHOOK_SECRET is not configured", async () => {
+      // env (without the secret) must reject every webhook POST, even ones
+      // presenting a token — an unset secret must never mean "open".
+      const { url, ...init } = postWebhook({ update_id: 1 });
+      const response = await worker.fetch(new Request(url, init), env, createExecutionContext());
+      expect(response.status).toBe(401);
     });
   });
 
@@ -55,25 +123,8 @@ describe("Telegram Bot Worker", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const update = {
-        update_id: 1,
-        message: {
-          message_id: 1,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "/start",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(1, "/start"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
 
       // Verify Telegram API was called
@@ -88,25 +139,8 @@ describe("Telegram Bot Worker", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const update = {
-        update_id: 2,
-        message: {
-          message_id: 2,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "/help",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(2, "/help"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -116,25 +150,8 @@ describe("Telegram Bot Worker", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const update = {
-        update_id: 3,
-        message: {
-          message_id: 3,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "/link",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(3, "/link"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -144,25 +161,8 @@ describe("Telegram Bot Worker", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const update = {
-        update_id: 4,
-        message: {
-          message_id: 4,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "/unknown",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(4, "/unknown"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -172,28 +172,70 @@ describe("Telegram Bot Worker", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const update = {
-        update_id: 100,
-        message: {
-          message_id: 100,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "supergroup" as const },
-          text: "/start@prism_agent_bot",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(groupMessage(100, "/start@prism_agent_bot"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       const sentBody = fetchSpy.mock.calls[0]?.[1] as { body?: string } | undefined;
       expect(sentBody?.body).toContain("Welcome to Prism");
+    });
+
+    it("should HTML-escape user-controlled first names in replies", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+      const { url, ...init } = postWebhook(privateMessage(5, "/start", "<b>Evil</b>"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      expect(response.status).toBe(200);
+      const sent = sentJson(fetchSpy, 0);
+      expect(sent.text).toContain("&lt;b&gt;Evil&lt;/b&gt;");
+      expect(sent.text).not.toContain("<b>Evil</b>");
+    });
+  });
+
+  describe("Group Chat Restrictions", () => {
+    async function expectGroupRefusal(
+      updateId: number,
+      text: string,
+    ): Promise<ReturnType<typeof vi.spyOn>> {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+      const { url, ...init } = postWebhook(groupMessage(updateId, text));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      expect(response.status).toBe(200);
+
+      // Exactly one call: the refusal message to Telegram. No Prism API call.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const callUrl = String(fetchSpy.mock.calls[0]?.[0]);
+      expect(callUrl).toContain("api.telegram.org");
+      const sent = sentJson(fetchSpy, 0);
+      expect(String(sent.text)).toMatch(/private chat/i);
+      return fetchSpy;
+    }
+
+    it("should refuse /register in a group chat without leaking an API key", async () => {
+      const fetchSpy = await expectGroupRefusal(300, "/register");
+      const sent = sentJson(fetchSpy, 0);
+      expect(String(sent.text)).not.toContain("sk-prism-");
+      expect(String(sent.text)).not.toContain("API Key");
+    });
+
+    it("should refuse /whoami in a group chat", async () => {
+      await expectGroupRefusal(301, "/whoami");
+    });
+
+    it("should refuse /status in a group chat", async () => {
+      await expectGroupRefusal(302, "/status");
+    });
+
+    it("should refuse /link in a group chat", async () => {
+      await expectGroupRefusal(303, "/link");
+    });
+
+    it("should refuse link-code confirmation in a group chat", async () => {
+      await expectGroupRefusal(304, "LINK-ABC123");
     });
   });
 
@@ -203,29 +245,11 @@ describe("Telegram Bot Worker", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const update = {
-        update_id: 200,
-        message: {
-          message_id: 200,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "LINK-ABC123",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(200, "LINK-ABC123"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
-      const sentBody = fetchSpy.mock.calls[0]?.[1] as { body?: string } | undefined;
-      const parsed = JSON.parse(sentBody?.body ?? "{}") as { code?: string };
+      const parsed = sentJson(fetchSpy, 0) as { code?: string };
       expect(parsed.code).toBe("LINK-ABC123");
     });
 
@@ -234,31 +258,25 @@ describe("Telegram Bot Worker", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const update = {
-        update_id: 201,
-        message: {
-          message_id: 201,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "abc123",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(201, "abc123"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
-      const sentBody = fetchSpy.mock.calls[0]?.[1] as { body?: string } | undefined;
-      const parsed = JSON.parse(sentBody?.body ?? "{}") as { code?: string };
+      const parsed = sentJson(fetchSpy, 0) as { code?: string };
       // The server stores codes with LINK- prefix; a bare 6-char must be
       // normalized before forwarding or the lookup will fail.
       expect(parsed.code).toBe("LINK-ABC123");
+    });
+
+    it("should accept the new 16-hex-character link code format", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+      const { url, ...init } = postWebhook(privateMessage(202, "LINK-A1B2C3D4E5F60718"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      expect(response.status).toBe(200);
+      const parsed = sentJson(fetchSpy, 0) as { code?: string };
+      expect(parsed.code).toBe("LINK-A1B2C3D4E5F60718");
     });
 
     it("should accept 6-character link code", async () => {
@@ -266,27 +284,26 @@ describe("Telegram Bot Worker", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const update = {
-        update_id: 5,
-        message: {
-          message_id: 5,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "ABC123",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(203, "ABC123"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    it("should send the bot API secret header when confirming a code", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+      const { url, ...init } = postWebhook(privateMessage(204, "LINK-ABC123"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      expect(response.status).toBe(200);
+
+      // First fetch call goes to the Prism API and must carry the shared secret.
+      const [apiUrl, apiInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(String(apiUrl)).toContain("/v1/link-telegram/confirm");
+      const headers = new Headers(apiInit.headers);
+      expect(headers.get("X-Bot-Api-Secret")).toBe(BOT_API_SECRET);
     });
 
     it("should ignore non-link-code text messages", async () => {
@@ -294,25 +311,10 @@ describe("Telegram Bot Worker", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const update = {
-        update_id: 6,
-        message: {
-          message_id: 6,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "Hello, this is a regular message",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(
+        privateMessage(6, "Hello, this is a regular message"),
+      );
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       // Should not call Telegram API for non-command, non-code messages
       expect(fetchSpy).not.toHaveBeenCalled();
@@ -330,25 +332,8 @@ describe("Telegram Bot Worker", () => {
           ),
         );
 
-      const update = {
-        update_id: 7,
-        message: {
-          message_id: 7,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "/register",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(7, "/register"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       // Should call both Prism API and Telegram API
       expect(fetchSpy).toHaveBeenCalled();
@@ -361,25 +346,8 @@ describe("Telegram Bot Worker", () => {
         }),
       );
 
-      const update = {
-        update_id: 8,
-        message: {
-          message_id: 8,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "/register",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(8, "/register"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -393,25 +361,8 @@ describe("Telegram Bot Worker", () => {
         }),
       );
 
-      const update = {
-        update_id: 9,
-        message: {
-          message_id: 9,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "/whoami",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(9, "/whoami"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -423,25 +374,8 @@ describe("Telegram Bot Worker", () => {
           new Response(JSON.stringify({ ok: false, error: "User not found" }), { status: 404 }),
         );
 
-      const update = {
-        update_id: 10,
-        message: {
-          message_id: 10,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "/whoami",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(10, "/whoami"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -459,25 +393,8 @@ describe("Telegram Bot Worker", () => {
         ),
       );
 
-      const update = {
-        update_id: 11,
-        message: {
-          message_id: 11,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "/status",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(privateMessage(11, "/status"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -489,19 +406,8 @@ describe("Telegram Bot Worker", () => {
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const update = {
-        update_id: 12,
-        // No message field
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook({ update_id: 12 });
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).not.toHaveBeenCalled();
     });
@@ -522,14 +428,8 @@ describe("Telegram Bot Worker", () => {
         },
       };
 
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
-      const response = await worker.fetch(request, env, ctx);
+      const { url, ...init } = postWebhook(update);
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       expect(fetchSpy).not.toHaveBeenCalled();
     });
@@ -540,26 +440,9 @@ describe("Telegram Bot Worker", () => {
         new Error("downstream service unavailable"),
       );
 
-      const update = {
-        update_id: 14,
-        message: {
-          message_id: 14,
-          from: { id: 12345, is_bot: false, first_name: "Test" },
-          chat: { id: 12345, type: "private" as const },
-          text: "/start",
-          date: Date.now(),
-        },
-      };
-
-      const ctx = createExecutionContext();
-      const request = new Request("https://example.com/webhook", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(update),
-      });
-
+      const { url, ...init } = postWebhook(privateMessage(14, "/start"));
       // Webhook MUST return 200; Telegram retries on >=400 which would cause a retry storm
-      const response = await worker.fetch(request, env, ctx);
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
     });
   });

--- a/cloudflare/wrangler.telegram.toml
+++ b/cloudflare/wrangler.telegram.toml
@@ -35,4 +35,5 @@ head_sampling_rate = 1
 
 # Secrets (set via wrangler secret put)
 # wrangler secret put TELEGRAM_BOT_TOKEN
-# wrangler secret put TELEGRAM_WEBHOOK_SECRET
+# wrangler secret put TELEGRAM_WEBHOOK_SECRET   # REQUIRED — webhooks fail closed without it
+# wrangler secret put BOT_API_SECRET            # must match the API worker's BOT_API_SECRET

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -48,6 +48,7 @@ head_sampling_rate = 1
 # wrangler secret put FEE_WALLET_ADDRESS
 # wrangler secret put TELEGRAM_BOT_TOKEN
 # wrangler secret put ADMIN_API_KEY
+# wrangler secret put BOT_API_SECRET   # shared with the telegram-bot worker (X-Bot-Api-Secret)
 
 # Staging environment
 [env.staging]

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -1658,6 +1658,9 @@ export const AdapterLive = Layer.effect(
         ),
 
       reportFeeCollection(event) {
+        // Revenue telemetry honors the same opt-out flag as feedback —
+        // posting fee events must not bypass PRISM_FEEDBACK_OPT_OUT.
+        if (config.feedbackOptOut) return Effect.void;
         return Effect.gen(function* () {
           const installId = yield* getOrCreateInstallId();
           const apiKey = yield* Effect.try({

--- a/engine/revenue-config-service.ts
+++ b/engine/revenue-config-service.ts
@@ -68,6 +68,7 @@ function fetchConfigFromApi(apiKey: string): Effect.Effect<RevenueConfig, unknow
     const res = yield* Effect.tryPromise(() =>
       fetch(`${API_BASE_URL}/v1/config`, {
         headers: { Authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(10_000),
       }),
     );
 


### PR DESCRIPTION
Wave 3 of `.omo/plans/prism-review-remediation.md` — fixes 5 HIGH + 2 MEDIUM Cloudflare findings and 4 MEDIUM engine/CLI findings from the security audit. Branch is based on latest `main` (e1079e6, post-#93); all citations re-verified against current code.

## Findings fixed

### Cloudflare — HIGH

1. **Broken link-code expiry** — `expires_at` was ISO-8601 text compared with SQLite `CURRENT_TIMESTAMP`; lexicographic `'T' > ' '` kept 10-minute codes valid ~24h. Now stored as unixepoch INTEGER and compared numerically. New migration `0012_link_code_security.sql` recreates the ephemeral table (existing codes are 10-minute TTL, so rows are discarded rather than migrated).
2. **Brute-forceable linking** — `/v1/link-telegram/confirm` had no rate limit and codes had ~24 bits of entropy. Now: 10 confirm attempts/hour/IP (every attempt counts, not just successes), per-code attempt counter with 5-strike burn (6th attempt → 429), codes are `LINK-` + 16 hex chars from 8 CSPRNG bytes (64 bits), and requesting a new code invalidates the user's outstanding codes.
3. **Unauthenticated telegram_id squatting** — `/v1/register-telegram`, `/v1/whoami-telegram`, `/v1/agent-status`, and the telegram-binding path of `/v1/register` accepted arbitrary `telegram_id` with no proof. All four now require the shared `BOT_API_SECRET` via `X-Bot-Api-Secret` header (constant-time compare, fail closed when unset). Plain CLI `/v1/register` (no `telegram_id`) is unchanged. Bot worker sends the header on all API calls.
4. **Webhook secret optional** — bot worker only validated `X-Telegram-Bot-Api-Secret-Token` when `TELEGRAM_WEBHOOK_SECRET` was set. Now fails closed (401 for all webhook POSTs) when unset, with constant-time comparison (replicated `constantTimeEqual` in the bot worker).
5. **API keys in group chats** — `/register`, `/whoami`, `/status`, `/link` and link-code confirmation are now refused outside private chats (polite refusal, no credential leakage). User-controlled text (first names) is HTML-escaped before interpolation into `parse_mode: HTML` replies.

### Cloudflare — MEDIUM

6. **`/v1/revenue/log` validation** — all numeric fields (`feeX`, `feeY`, `operatorFeeX/Y`, `platformFeeX/Y`) must be finite, non-negative numbers; `platformFeeX/Y` remain required. Previously only the types of two fields were checked.
7. **API key entropy** — keys were `sk-prism-` + `generateId()` (~64 bits, timestamp-prefixed). Now `sk-prism-` + 20 CSPRNG bytes (~160 bits, no timestamp). Existing keys keep working — verification is by SHA-256 hash, no migration needed.

### Engine/CLI — MEDIUM

8. **Predictable tmpdir in self-update** — `cli/update.ts` now uses `fs.mkdtempSync(join(tmpdir(), "prism-update-"))`.
9. **Revenue telemetry bypassed opt-out** — `reportFeeCollection` (engine/adapter-service.ts) now returns early when `config.feedbackOptOut` is set, honoring the same flag as feedback. Single-point change inside the adapter; zero diff in `engine/program.ts` (Lane A owns it).
10. **`prism dev` hard-failed on telemetry ping failure** — now degrades to a warning and continues (offline resilience), via exported `reportDevStartTelemetry()`.
11. **`fetchConfigFromApi` had no timeout** — added `signal: AbortSignal.timeout(10_000)` (matches the engine's other outbound fetches).

## Design notes

- **BOT_API_SECRET flow**: same wrangler secret set on both workers. Bot worker attaches it as `X-Bot-Api-Secret` inside `callPrismApi` (all four API calls). API worker checks it with `isBotAuthorized()` — fail closed when the server secret is unset, constant-time comparison otherwise. The header is also sent on `/v1/link-telegram/confirm`, which stays unauthenticated-by-design (it is rate-limited + burn-limited instead) per the audit scope.
- **Migration**: `0012` drops and recreates `telegram_link_codes` with `expires_at INTEGER`, `attempts INTEGER NOT NULL DEFAULT 0`, and a `user_id` index. Table is ephemeral link codes only; acceptable to clear (noted per plan). Applied cleanly to local D1 via `wrangler d1 migrations apply prism-db --local` (see QA transcript).
- **Fail-closed webhook**: unset `TELEGRAM_WEBHOOK_SECRET` now rejects everything; the deploy steps below are required to keep the bot functional.
- **Code format change**: codes are now `LINK-<16 hex>`. The CLI just prints what the API returns; the bot accepts 6–16 char codes (legacy 6-char inputs still normalize but will simply not match any stored code). `expiresAt` in the `/v1/link-telegram/start` response stays an ISO string — `prism link-telegram` parses it with `new Date()`.

## DEPLOY NOTES (required to keep Telegram flows working)

```bash
# 1. Apply the D1 migration (CI does this before deploy on main)
wrangler d1 migrations apply prism-db --remote

# 2. Set the shared bot secret on BOTH workers (same value)
wrangler secret put BOT_API_SECRET
wrangler secret put BOT_API_SECRET --config wrangler.telegram.toml

# 3. REQUIRED: webhook secret is now fail-closed
wrangler secret put TELEGRAM_WEBHOOK_SECRET --config wrangler.telegram.toml

# 4. Re-register the webhook so Telegram sends the secret_token header
curl "https://api.telegram.org/bot<TOKEN>/setWebhook?url=https://prism-telegram-bot.irfndi.workers.dev/webhook&secret_token=<TELEGRAM_WEBHOOK_SECRET>"
```

No secrets are committed anywhere; `cloudflare/.dev.vars.example` documents placeholders for local dev.

## Verification evidence

- `cd cloudflare && bun run typecheck` → clean (tsc --noEmit, exit 0)
- `cd cloudflare && bunx vitest run` → **112 passed (10 files)**
- root `bun run lint` → clean (tsc + oxlint)
- root `bun run build` → exit 0
- root `bun run test` → **730 passed (62 files)**
- root `bun run format:check` → clean

### Failing-first evidence (tests written before implementation)

22 Cloudflare + 4 engine tests failed against the old code, including:

```
FAIL  link-telegram.test.ts > confirms a valid unexpired code and binds the telegram_id
FAIL  link-telegram.test.ts > burns a code after 5 attempts (6th attempt rejected)
FAIL  link-telegram.test.ts > rate-limits confirm attempts per IP (10/hour)
FAIL  link-telegram.test.ts > rejects /v1/register-telegram without the bot secret
FAIL  link-telegram.test.ts > rejects /v1/whoami-telegram without the bot secret
FAIL  link-telegram.test.ts > rejects /v1/agent-status without the bot secret
FAIL  link-telegram.test.ts > rejects /v1/register telegram binding without the bot secret
FAIL  link-telegram.test.ts > fails closed when the server has no BOT_API_SECRET configured
FAIL  revenue.test.ts > rejects negative or non-finite numeric fields
FAIL  telegram-bot.test.ts > should fail closed when TELEGRAM_WEBHOOK_SECRET is not configured
FAIL  telegram-bot.test.ts > should refuse /register in a group chat without leaking an API key
FAIL  telegram-bot.test.ts > should HTML-escape user-controlled first names in replies
… (22 total)
```

Engine failing-first (implementation stashed): `cli-dev-telemetry.test.ts`, `revenue-config-service.test.ts` (timeout), `adapter-revenue-report.test.ts` → 4 tests failed, all pass after restore.

### Manual-QA transcript — `wrangler dev` + curl (local D1 with migration 0012 applied)

(a) confirm rate limit + 5-strike burn + bot-secret gating:

```
== register-telegram WITHOUT bot secret ==
{"error":"Unauthorized"} [401]
== register-telegram WITH bot secret ==
{"user_id":"...","api_key":"sk-prism-...","tier":"free"} [200]

== rate limit: 12 confirm attempts from one IP ==
attempt 01..10: {"error":"Invalid code"} [400]
attempt 11: {"error":"Rate limit exceeded. Try again later."} [429]
attempt 12: {"error":"Rate limit exceeded. Try again later."} [429]

== 5-strike burn on real code LINK-83D3F1E200156B90 ==
attempt 1: {"success":true,"user_id":"..."} [200]
attempt 2..5: {"error":"Code already used"} [400]
attempt 6: {"error":"Too many attempts for this code"} [429]

== whoami-telegram with bot secret (linked id) ==  [200]
== revenue/log negative platformFeeX ==
{"error":"Invalid platformFeeX: must be a finite, non-negative number"} [400]
```

(b) group-chat `/register` refusal (vitest transcript — the refusal is sent to the Telegram API, so this is asserted at the worker boundary):

```
✓ should refuse /register in a group chat without leaking an API key
✓ should refuse /whoami in a group chat
✓ should refuse /status in a group chat
✓ should refuse /link in a group chat
✓ should refuse link-code confirmation in a group chat
```

Cleanup receipt: `wrangler dev` process killed (`pgrep -f "wrangler dev"` → none), `.dev.vars` (dummy QA values only) deleted, local `.wrangler/` D1 state and `/tmp/prism-wrangler-dev.log` removed; `git status` shows only the files in this PR.

## Deviations from the plan

1. **Link-code confirmation is also refused in group chats** (finding 5 named only the four commands). A link code is a credential — confirming it in a group lets any member race-hijack the link. Same refusal path as the commands; covered by test.
2. **5-strike burn semantics**: the attempt counter increments on every confirm attempt against an existing code (including the successful one and subsequent "already used" retries); the 6th attempt returns 429. Failed guesses against nonexistent codes are bounded by the 10/hour/IP rate limit. Documented in code + tests.
3. **Existing `audit.test.ts` updated** to the new link-code schema (unixepoch expiry + `attempts` column) — required by the migration; behavior assertions unchanged. The pre-existing bot test that expected webhooks to pass with an unset secret was updated to the new fail-closed contract.
4. Engine item 8 (mkdtemp) has no clean unit-test seam in `cli/update.ts` (inline in the command action); verified via typecheck/lint/build + code inspection. Items 9–11 have new bench tests.

## Out of scope (per plan)

Other review findings belong to other waves; `engine/program.ts` untouched (Lane A). No refactoring beyond the findings; no weakening of existing tests (only security-contract updates noted above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strengthened Telegram/API security with shared-secret header checks, fail-closed webhooks, private-chat-only sensitive commands, and HTML-escaped names.
  * Improved Telegram linking with `LINK-<16 hex>` codes, expiry, per-code attempt limits, and per-IP rate limiting; safer CSPRNG-generated API keys.
  * Tightened revenue logging validation and made revenue telemetry respect opt-out; dev startup continues when telemetry is unavailable.
* **Bug Fixes**
  * Added a timeout to config fetch requests and improved update temp-directory creation.
* **Documentation**
  * Updated security/setup/link-code/webhook/testing guidance plus Cloudflare secret configuration examples and worker typings.
* **Tests**
  * Added/expanded unit and worker tests for link security, revenue validation, config timeouts, and telemetry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->