### PR TITLE
fix: real strategy metrics via Meteora Data API (Wave 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,9 @@ DISCOVERY_MIN_FEE_RATIO=1.5
 # Dump full pool state snapshots to DB every cycle (paper only)
 ENABLE_SNAPSHOT_CAPTURE=false
 
+# Meteora Data API base URL for real pool TVL/volume/fees (30 RPS, no auth)
+METEORA_DATA_API_URL=https://dlmm.datapi.meteora.ag
+
 # Auto-swap USDC into missing pool tokens before live ENTER (default: false)
 AUTO_SWAP_ENTRY=false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,9 +166,9 @@ Do not import service implementations directly in program logic. `Layer.provide`
 
 ### Decision loop (per cycle, per pool)
 
-1. `adapter.getPoolState` + `adapter.getBinArray` fetch on-chain data.
+1. `adapter.getPoolState` + `adapter.getBinArray` fetch on-chain data (real per-bin reserves via `dlmm.getBinsAroundActiveBin`). `meteoraDatapi.getPoolData` then overlays real TVL/volume/fees from the Meteora Data API (`statsSource: "datapi"`); on API failure it logs a warning and the adapter's heuristic stats are used (`statsSource: "heuristic"`).
 2. `blacklist.checkPool` early-rejects disallowed pools (errors swallowed).
-3. `strategy.computeMetrics` produces pure metrics (fee/IL, volume authenticity, bin utilization, TVL velocity).
+3. `strategy.computeMetrics` produces pure metrics (fee/IL, volume authenticity, bin utilization, TVL velocity vs the previous `pool_snapshots` row). Metrics whose inputs are unavailable are reported as explicit "unknown" (`volumeAuthenticityKnown` / `binUtilizationKnown` on `PoolMetrics`); unknown metrics skip their pre-filter/EXIT gates with a warning and block ENTER (fail-closed), never fabricate 1.0.
 4. Pre-filter skips pools below `MIN_POOL_TVL_USD`, `VOLUME_AUTH_THRESHOLD` or `MIN_BIN_UTILIZATION`.
 5. `memory.getRelevantContext` recalls recent warnings/patterns (errors swallowed).
 6. Decision rules evaluate, in order: `EXIT` → `REBALANCE` → `HOLD` → `ENTER`.
@@ -297,7 +297,8 @@ The `Dockerfile` builds the engine bundle with `oven/bun:canary-slim`, then copi
 | `MAX_OPEN_POSITIONS`          | `3`                                                                | Concurrent positions cap.                                                                                          |
 | `MAX_PER_POOL_ALLOCATION_PCT` | `0.4`                                                              | Max portfolio share for one pool.                                                                                  |
 | `SQLITE_DB_PATH`              | `~/.local/share/prism/prism.db` (bundled) or `./prism.db` (source) | SQLite database path.                                                                                              |
-| `ENABLE_SNAPSHOT_CAPTURE`     | `false`                                                            | Dump full snapshots every cycle (paper only).                                                                      |
+| `ENABLE_SNAPSHOT_CAPTURE`     | `false`                                                            | Store full bin-array detail in per-cycle snapshots (paper only). Lightweight per-cycle snapshot rows are always persisted — TVL velocity and IL drift need the history. |
+| `METEORA_DATA_API_URL`        | `https://dlmm.datapi.meteora.ag`                                   | Base URL for the Meteora Data API used to enrich pool TVL/volume/fees. On failure the engine falls back to heuristic stats with a warning.                              |
 | `EMBEDDINGS_BACKEND`          | `fallback`                                                         | `fallback` = deterministic hash vectors; `onnx` = Xenova/MiniLM (downloads ~80MB).                                 |
 | `AGENTIC_MODE`                | `false`                                                            | Enable agent runtime overlay.                                                                                      |
 | `AGENT_MCP_ENABLED`           | `false`                                                            | Expose stdio MCP server.                                                                                           |

--- a/bench/agent-service.test.ts
+++ b/bench/agent-service.test.ts
@@ -65,6 +65,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     feedbackOptOut: false,
     paperModeExitLive: false,
     meteoraPoolsUrl: "",
+    meteoraDatapiBaseUrl: "",
     rebalanceGasCostSol: 0.01,
     solPriceUsd: 150,
     gasAwareMinDaysOfFeesPaidAhead: 3,

--- a/bench/auto-update.test.ts
+++ b/bench/auto-update.test.ts
@@ -60,6 +60,7 @@ function buildLayer(
     paperModeExitLive: false,
     meteoraPoolsUrl:
       "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
+    meteoraDatapiBaseUrl: "https://dlmm.datapi.meteora.ag",
     rebalanceGasCostSol: 0.01,
     solPriceUsd: 150,
     gasAwareMinDaysOfFeesPaidAhead: 3,

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -79,6 +79,7 @@ function buildLayer(
     paperModeExitLive: false,
     meteoraPoolsUrl:
       "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
+    meteoraDatapiBaseUrl: "https://dlmm.datapi.meteora.ag",
     rebalanceGasCostSol: 0.01,
     solPriceUsd: 150,
     gasAwareMinDaysOfFeesPaidAhead: 3,

--- a/bench/helpers.ts
+++ b/bench/helpers.ts
@@ -125,6 +125,7 @@ export function defaultAppConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     paperModeExitLive: false,
     meteoraPoolsUrl:
       "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
+    meteoraDatapiBaseUrl: "https://dlmm.datapi.meteora.ag",
     rebalanceGasCostSol: 0.01,
     solPriceUsd: 150,
     gasAwareMinDaysOfFeesPaidAhead: 3,
@@ -201,9 +202,9 @@ export async function runAsync<T>(effect: Effect.Effect<T, unknown, never>): Pro
 
 // ─── Fetch mock ──────────────────────────────────────────────────────────────
 
-export function mockFetch(impl: typeof fetch): () => void {
+export function mockFetch(impl: unknown): () => void {
   const original = globalThis.fetch;
-  globalThis.fetch = vi.fn(impl) as unknown as typeof globalThis.fetch;
+  globalThis.fetch = vi.fn(impl as typeof fetch) as unknown as typeof globalThis.fetch;
   return () => {
     globalThis.fetch = original;
   };

--- a/bench/http-status-server.test.ts
+++ b/bench/http-status-server.test.ts
@@ -49,6 +49,7 @@ function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     feedbackOptOut: false,
     paperModeExitLive: false,
     meteoraPoolsUrl: "",
+    meteoraDatapiBaseUrl: "",
     rebalanceGasCostSol: 0.01,
     solPriceUsd: 150,
     gasAwareMinDaysOfFeesPaidAhead: 3,

--- a/bench/mcp-server.test.ts
+++ b/bench/mcp-server.test.ts
@@ -48,6 +48,7 @@ function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     feedbackOptOut: false,
     paperModeExitLive: false,
     meteoraPoolsUrl: "",
+    meteoraDatapiBaseUrl: "",
     rebalanceGasCostSol: 0.01,
     solPriceUsd: 150,
     gasAwareMinDaysOfFeesPaidAhead: 3,

--- a/bench/meteora-datapi.test.ts
+++ b/bench/meteora-datapi.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Effect, Layer } from "effect";
+import { MeteoraDatapiLive, enrichPoolWithDatapi } from "../engine/meteora-datapi-service.js";
+import { MeteoraDatapiService } from "../engine/services.js";
+import { ConfigService } from "../engine/config-service.js";
+import { defaultAppConfig, makePool, mockFetch } from "./helpers.js";
+
+const SAMPLE_POOL_RESPONSE = {
+  address: "PoolABC111",
+  name: "SOL-USDC",
+  token_x: {
+    address: "So11111111111111111111111111111111111111112",
+    symbol: "SOL",
+    freeze_authority_disabled: true,
+  },
+  token_y: {
+    address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    symbol: "USDC",
+    freeze_authority_disabled: false,
+  },
+  pool_config: { bin_step: 10, base_fee_pct: 0.2, max_fee_pct: 0, protocol_fee_pct: 5 },
+  dynamic_fee_pct: 0.05,
+  tvl: 1_234_567.89,
+  current_price: 151.25,
+  apr: 0.0042,
+  apy: 4.63,
+  has_farm: true,
+  farm_apr: 0,
+  farm_apy: 0,
+  volume: { "30m": 10, "1h": 20, "2h": 40, "4h": 80, "12h": 200, "24h": 456_789.12 },
+  fees: { "30m": 1, "1h": 2, "2h": 4, "4h": 8, "12h": 20, "24h": 1_234.56 },
+  fee_tvl_ratio: {
+    "30m": 0.0001,
+    "1h": 0.0002,
+    "2h": 0.0004,
+    "4h": 0.0008,
+    "12h": 0.002,
+    "24h": 0.001,
+  },
+  is_blacklisted: false,
+  launchpad: "",
+  tags: [],
+};
+
+function makeLayer() {
+  return Layer.provide(MeteoraDatapiLive, Layer.succeed(ConfigService, defaultAppConfig()));
+}
+
+describe("MeteoraDatapiService", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses a pool response into typed stats", async () => {
+    const restore = mockFetch(() =>
+      Promise.resolve(new Response(JSON.stringify(SAMPLE_POOL_RESPONSE), { status: 200 })),
+    );
+    try {
+      const stats = await Effect.runPromise(
+        Effect.gen(function* () {
+          const datapi = yield* MeteoraDatapiService;
+          return yield* datapi.getPoolData("PoolABC111");
+        }).pipe(Effect.provide(makeLayer())),
+      );
+      expect(stats).not.toBeNull();
+      expect(stats!.address).toBe("PoolABC111");
+      expect(stats!.tvlUsd).toBeCloseTo(1_234_567.89);
+      expect(stats!.volume24hUsd).toBeCloseTo(456_789.12);
+      expect(stats!.fees24hUsd).toBeCloseTo(1_234.56);
+      expect(stats!.feeTvlRatio24h).toBeCloseTo(0.001);
+      expect(stats!.feeTvlRatio12h).toBeCloseTo(0.002);
+      expect(stats!.feeTvlRatio1h).toBeCloseTo(0.0002);
+      expect(stats!.dynamicFeePct).toBeCloseTo(0.05);
+      expect(stats!.baseFeePct).toBeCloseTo(0.2);
+      expect(stats!.hasFarm).toBe(true);
+      expect(stats!.isBlacklisted).toBe(false);
+      expect(stats!.tokenXFreezeAuthorityDisabled).toBe(true);
+      expect(stats!.tokenYFreezeAuthorityDisabled).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("(v) fetch failure → null (fallback), warning logged, no throw", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const restore = mockFetch(() => Promise.reject(new TypeError("fetch failed")));
+    try {
+      const stats = await Effect.runPromise(
+        Effect.gen(function* () {
+          const datapi = yield* MeteoraDatapiService;
+          return yield* datapi.getPoolData("PoolABC111");
+        }).pipe(Effect.provide(makeLayer())),
+      );
+      expect(stats).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("(v-b) non-OK HTTP status → null (fallback), warning logged", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const restore = mockFetch(() => Promise.resolve(new Response("rate limited", { status: 429 })));
+    try {
+      const stats = await Effect.runPromise(
+        Effect.gen(function* () {
+          const datapi = yield* MeteoraDatapiService;
+          return yield* datapi.getPoolData("PoolABC111");
+        }).pipe(Effect.provide(makeLayer())),
+      );
+      expect(stats).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("malformed payload → null (fallback), never crashes", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const restore = mockFetch(() =>
+      Promise.resolve(new Response(JSON.stringify({ unexpected: true }), { status: 200 })),
+    );
+    try {
+      const stats = await Effect.runPromise(
+        Effect.gen(function* () {
+          const datapi = yield* MeteoraDatapiService;
+          return yield* datapi.getPoolData("PoolABC111");
+        }).pipe(Effect.provide(makeLayer())),
+      );
+      expect(stats).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("enrichPoolWithDatapi", () => {
+  it("replaces heuristic volume/fees/tvl with real Data API values", () => {
+    const pool = makePool({ tvlUsd: 50_000, volume24hUsd: 15_000, fees24hUsd: 150 });
+    const enriched = enrichPoolWithDatapi(pool, {
+      address: pool.address,
+      name: "SOL-USDC",
+      tvlUsd: 1_000_000,
+      volume24hUsd: 456_789.12,
+      fees24hUsd: 1_234.56,
+      apr: 0.0042,
+      apy: 4.63,
+      currentPrice: 151.25,
+      feeTvlRatio24h: 0.001,
+      feeTvlRatio12h: 0.002,
+      feeTvlRatio1h: 0.0002,
+      dynamicFeePct: 0.05,
+      baseFeePct: 0.2,
+      hasFarm: true,
+      isBlacklisted: false,
+      tokenXFreezeAuthorityDisabled: true,
+      tokenYFreezeAuthorityDisabled: false,
+    });
+    expect(enriched.tvlUsd).toBe(1_000_000);
+    expect(enriched.volume24hUsd).toBeCloseTo(456_789.12);
+    expect(enriched.fees24hUsd).toBeCloseTo(1_234.56);
+    expect(enriched.statsSource).toBe("datapi");
+    // On-chain identity fields are preserved.
+    expect(enriched.activeBinId).toBe(pool.activeBinId);
+    expect(enriched.currentPrice).toBe(pool.currentPrice);
+  });
+});

--- a/bench/metrics-data-path.test.ts
+++ b/bench/metrics-data-path.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { DLMMStrategy } from "../engine/strategy-service.js";
+import type { BinArray } from "../engine/types.js";
+import { makePool } from "./helpers.js";
+
+// ─── Shared fixtures ─────────────────────────────────────────────────────────
+
+/** Bin array as fabricated by the OLD adapter: every bin marked liquid. */
+export function makeFabricatedBinArray(activeBinId = 5000, halfWidth = 20): BinArray {
+  const bins = Array.from({ length: halfWidth * 2 + 1 }, (_, i) => ({
+    binId: activeBinId - halfWidth + i,
+    price: 150 * Math.pow(1.001, i - halfWidth),
+    reserveX: 0n,
+    reserveY: 0n,
+    liquiditySupply: 1n, // synthetic marker — every bin counts as active
+  }));
+  return {
+    lowerBinId: activeBinId - halfWidth,
+    upperBinId: activeBinId + halfWidth,
+    bins,
+    activeBinId,
+    binStep: 10,
+    // Real bin reserves were never fetched — must surface as "unknown".
+    reservesKnown: false,
+  };
+}
+
+/** Bin array with liquidity concentrated in 3 of 41 bins (real reserves). */
+export function makeConcentratedBinArray(activeBinId = 5000, halfWidth = 20): BinArray {
+  const bins = Array.from({ length: halfWidth * 2 + 1 }, (_, i) => {
+    const binId = activeBinId - halfWidth + i;
+    const active = Math.abs(binId - activeBinId) <= 1;
+    return {
+      binId,
+      price: 150 * Math.pow(1.001, binId - activeBinId),
+      reserveX: active ? 1_000_000n : 0n,
+      reserveY: active ? 1_000_000n : 0n,
+      liquiditySupply: active ? 1_000_000_000n : 0n,
+    };
+  });
+  return {
+    lowerBinId: activeBinId - halfWidth,
+    upperBinId: activeBinId + halfWidth,
+    bins,
+    activeBinId,
+    binStep: 10,
+    reservesKnown: true,
+  };
+}
+
+// ─── (i)+(ii) feeIlRatio must be real, not the 999 sentinel ──────────────────
+
+describe("computeFeeIlRatio with real drift data", () => {
+  it("(i) low-fee / high-drift pool scores BELOW the default minFeeIlRatio", () => {
+    // $50/day fees on $100k TVL; price drifted 3% in one 10-min cycle.
+    const pool = makePool({
+      tvlUsd: 100_000,
+      fees24hUsd: 50,
+      currentPrice: 154.5,
+      timestamp: 1_800_000_000_000,
+    });
+    const binArray = makeConcentratedBinArray();
+    const ratio = DLMMStrategy.computeFeeIlRatio(pool, binArray, {
+      previousPrice: 150,
+      previousTimestamp: 1_800_000_000_000 - 600_000,
+    });
+    // Old code returned the 999 sentinel whenever drift-from-range-center was 0.
+    expect(ratio).not.toBe(999);
+    expect(ratio).toBeLessThan(1.2); // default MIN_FEE_IL_RATIO
+  });
+
+  it("(ii) pools with different fee/drift profiles get DIFFERENT ratios", () => {
+    const timestamp = 1_800_000_000_000;
+    const calmPool = makePool({
+      tvlUsd: 100_000,
+      fees24hUsd: 500,
+      currentPrice: 150.3,
+      timestamp,
+    });
+    const wildPool = makePool({ tvlUsd: 100_000, fees24hUsd: 50, currentPrice: 157.5, timestamp });
+    const binArray = makeConcentratedBinArray();
+    const ctx = { previousPrice: 150, previousTimestamp: timestamp - 600_000 };
+
+    const calmRatio = DLMMStrategy.computeFeeIlRatio(calmPool, binArray, ctx);
+    const wildRatio = DLMMStrategy.computeFeeIlRatio(wildPool, binArray, ctx);
+
+    expect(calmRatio).not.toBe(wildRatio);
+    // High fees + low drift must outrank low fees + high drift.
+    expect(calmRatio).toBeGreaterThan(wildRatio);
+  });
+
+  it("(ii-b) bin-step proxy varies across pools when no price history exists", () => {
+    const pool = makePool({ tvlUsd: 100_000, fees24hUsd: 100 });
+    const narrowStep = makeConcentratedBinArray();
+    const wideStep: BinArray = { ...makeConcentratedBinArray(), binStep: 100 };
+    const narrowRatio = DLMMStrategy.computeFeeIlRatio(pool, narrowStep);
+    const wideRatio = DLMMStrategy.computeFeeIlRatio(pool, wideStep);
+    expect(narrowRatio).not.toBe(wideRatio);
+  });
+});
+
+// ─── (iv) bin utilization must not be fabricated to 1.0 ──────────────────────
+
+describe("bin utilization with explicit unknown state", () => {
+  it("(iv-a) concentrated real liquidity yields binUtilization < 1", () => {
+    const pool = makePool();
+    const metrics = DLMMStrategy.computeMetrics(pool, makeConcentratedBinArray(), 0);
+    expect(metrics.binUtilization).toBeLessThan(1);
+    expect(metrics.binUtilization).toBeCloseTo(3 / 41, 5);
+    expect(metrics.binUtilizationKnown).toBe(true);
+  });
+
+  it("(iv-b) fabricated bin reserves surface as unknown — never 1.0", () => {
+    const pool = makePool();
+    const metrics = DLMMStrategy.computeMetrics(pool, makeFabricatedBinArray(), 0);
+    expect(metrics.binUtilization).not.toBe(1.0);
+    expect(metrics.binUtilizationKnown).toBe(false);
+  });
+
+  it("(iv-c) unknown bin utilization skips the pre-filter gate instead of passing it", () => {
+    const pool = makePool({ tvlUsd: 100_000 });
+    // Old behavior: fabricated 1.0 utilization passed every gate.
+    // New behavior: unknown utilization skips the gate (with warning upstream).
+    expect(DLMMStrategy.passesPreFilter(pool, 0.9, 0, 50_000, 0.7, 0.3, true, false)).toBe(true);
+    // ...but a KNOWN low utilization still fails the gate.
+    expect(DLMMStrategy.passesPreFilter(pool, 0.9, 0.1, 50_000, 0.7, 0.3, true, true)).toBe(false);
+  });
+});

--- a/bench/metrics-tvl-exit.test.ts
+++ b/bench/metrics-tvl-exit.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import { Effect, Layer } from "effect";
+import { StrategyLive } from "../engine/strategy-service.js";
+import { program } from "../engine/program.js";
+import { DbLive } from "../engine/db-service.js";
+import { MemoryLive } from "../engine/memory-service.js";
+import { RiskLive } from "../engine/risk-service.js";
+import { AuditLive } from "../engine/audit-service.js";
+import { AgentNoOp } from "../engine/agent-service.js";
+import { AgentStateMutable } from "../engine/state-service.js";
+import { ConfigService } from "../engine/config-service.js";
+import {
+  AdapterService,
+  BlacklistService,
+  AuditService,
+  ScreenerService,
+  DbService,
+  RevenueService,
+  RevenueConfigService,
+  ReferralService,
+  AgentService,
+  McpServerService,
+  HttpStatusServerService,
+  EntryPrepService,
+  MeteoraDatapiService,
+  type AdapterApi,
+  type MeteoraDatapiApi,
+} from "../engine/services.js";
+import type { PoolSnapshot } from "../engine/types.js";
+import { defaultAppConfig, makePool, makeBinArray, makePosition } from "./helpers.js";
+
+// ─── (iii) TVL-drop EXIT at the evaluatePool level ───────────────────────────
+
+describe("evaluatePool TVL-drop EXIT (integration)", () => {
+  const POOL = "PoolTvlDrop1111111111111111111111111111111111";
+
+  function makeAdapter(): AdapterApi {
+    return {
+      hasWallet: () => false,
+      getWalletAddress: () => null,
+      getWalletBalanceUsd: () => Effect.succeed(10_000),
+      getNativeSolBalance: () => Effect.succeed(0n),
+      getPoolState: () =>
+        Effect.succeed(
+          makePool({ address: POOL, tvlUsd: 60_000, currentPrice: 150, fees24hUsd: 300 }),
+        ),
+      getBinArray: () => Effect.succeed(makeBinArray()),
+      getPositions: () => Effect.succeed([]),
+      getAllWalletPositions: () => Effect.succeed([]),
+      simulateRebalance: () =>
+        Effect.succeed({ estimatedIlUsd: 0, estimatedFeesUsd: 0, netBenefitUsd: 0 }),
+      enterPosition: () => Effect.succeed({ positionPubKey: "mock-pos", txSignature: "mock-tx" }),
+      exitPosition: () => Effect.succeed({ txSignature: "mock-tx" }),
+      rebalancePosition: () =>
+        Effect.succeed({ newPositionPubKey: "mock-pos", txSignatures: ["mock-tx"] }),
+      claimFees: () =>
+        Effect.succeed({
+          txSignature: "mock-tx",
+          feeX: 0,
+          feeY: 0,
+          platformFeeX: 0,
+          platformFeeY: 0,
+          netFeeX: 0,
+          netFeeY: 0,
+        }),
+      discoverPools: () => Effect.succeed([]),
+      reportFeeCollection: () => Effect.void,
+      swapUSDCForSOL: () => Effect.void,
+      getTokenBalance: () => Effect.succeed(0n),
+      getTokenPrices: () => Effect.succeed({}),
+      getTokenDecimals: () => Effect.succeed(9),
+      quoteSwapUSDCForToken: () => Effect.succeed({}),
+      swapUSDCForToken: () => Effect.succeed("mock-swap-tx"),
+    };
+  }
+
+  function makeDatapi(): MeteoraDatapiApi {
+    // Data API unavailable → heuristic fallback path; cycle must still complete.
+    return { getPoolData: () => Effect.succeed(null) };
+  }
+
+  function makeTestLayer() {
+    const config = defaultAppConfig({
+      watchlistPools: [POOL],
+      scanIntervalMs: 3_600_000,
+      paperTrading: true,
+      tvlDropExitPct: 0.3,
+      agentMcpEnabled: false,
+      agentHttpPort: 0,
+    });
+    const dbLayer = DbLive(":memory:");
+    return Layer.mergeAll(
+      Layer.succeed(ConfigService, config),
+      Layer.succeed(AdapterService, makeAdapter()),
+      StrategyLive,
+      Layer.provide(MemoryLive, dbLayer),
+      RiskLive({ confidenceThreshold: 0.65, maxRebalanceRangeBins: 50, stopLossPct: 0.15 }),
+      Layer.succeed(BlacklistService, {
+        isDeployerBlacklisted: () => false,
+        isTokenBlacklisted: () => false,
+        checkPool: () => Effect.void,
+      }),
+      Layer.provide(AuditLive, dbLayer),
+      Layer.succeed(ScreenerService, { screenPools: () => Effect.succeed([]) }),
+      dbLayer,
+      Layer.succeed(RevenueService, {
+        calculateTier: () => "free",
+        calculatePlatformFee: () => ({ platformFeeUsd: 0, netFeeX: 0, netFeeY: 0 }),
+        calculateCreditDiscount: () => 0,
+      }),
+      Layer.succeed(RevenueConfigService, {
+        getConfig: () =>
+          Effect.succeed({
+            tier: "free",
+            platformFeeRate: 0,
+            revenueShareEnabled: false,
+            revenueShareOperatorPct: 0,
+            feeWalletAddress: "",
+          }),
+        refreshConfig: () =>
+          Effect.succeed({
+            tier: "free",
+            platformFeeRate: 0,
+            revenueShareEnabled: false,
+            revenueShareOperatorPct: 0,
+            feeWalletAddress: "",
+          }),
+      }),
+      Layer.succeed(ReferralService, {
+        generateCode: () => Effect.succeed("code"),
+        validateCode: () => Effect.succeed({ valid: false }),
+        applyReferral: () => Effect.void,
+        getReferralCount: () => Effect.succeed(0),
+      }),
+      Layer.succeed(AgentService, AgentNoOp),
+      AgentStateMutable({ maxPendingProposals: 50 }).layer,
+      Layer.succeed(McpServerService, { start: () => Effect.void, stop: () => Effect.void }),
+      Layer.succeed(HttpStatusServerService, { start: () => Effect.void, stop: () => Effect.void }),
+      Layer.succeed(EntryPrepService, { prepareEntryTokens: () => Effect.void }),
+      Layer.succeed(MeteoraDatapiService, makeDatapi()),
+    );
+  }
+
+  it("(iii) held position in a pool whose TVL dropped > TVL_DROP_EXIT_PCT exits", async () => {
+    const layer = makeTestLayer();
+    const previousSnapshot: PoolSnapshot = {
+      poolAddress: POOL,
+      timestamp: Date.now() - 600_000,
+      activeBinId: 5000,
+      tvlUsd: 100_000, // → -40% vs current 60k (threshold 30%)
+      volume24hUsd: 30_000,
+      fees24hUsd: 300,
+      apr: 60,
+      currentPrice: 150,
+      binStep: 10,
+      tokenXSymbol: "SOL",
+      tokenYSymbol: "USDC",
+      binArray: makeBinArray(),
+    };
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(
+        makePosition({
+          poolAddress: POOL,
+          positionPubKey: null,
+          lowerBinId: 4980,
+          upperBinId: 5020,
+          depositedUsd: 1_000,
+          currentValueUsd: 1_000,
+        }),
+      );
+      yield* db.saveSnapshot(previousSnapshot);
+      // program loops forever on the scheduler; race it against a timer so the
+      // first (immediate) scan cycle runs and then we interrupt it.
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const audit = yield* AuditService;
+      return yield* audit.getRecentDecisions(50);
+    });
+
+    const decisions = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<
+        ReadonlyArray<{ action: string; reasoning: string }>,
+        unknown,
+        never
+      >,
+    );
+
+    const tvlExit = decisions.find(
+      (d) => d.action === "EXIT" && d.reasoning.includes("TVL dropped"),
+    );
+    expect(
+      tvlExit,
+      `expected a TVL-drop EXIT decision, got: ${JSON.stringify(decisions.map((d) => `${d.action}: ${d.reasoning}`))}`,
+    ).toBeDefined();
+  }, 15_000);
+});

--- a/bench/openclaw-webhook-transport.test.ts
+++ b/bench/openclaw-webhook-transport.test.ts
@@ -42,6 +42,8 @@ function makeContext(): AgentRuntimeContext {
     feeIlRatio: 1.5,
     volumeAuthenticity: 0.9,
     binUtilization: 0.5,
+    volumeAuthenticityKnown: true,
+    binUtilizationKnown: true,
   };
 
   const warnings: MemoryEntry[] = [];

--- a/bench/program.test.ts
+++ b/bench/program.test.ts
@@ -154,6 +154,8 @@ describe("executeLive", () => {
           volumeAuthenticity: 0.9,
           binUtilization: 0.5,
           tvlVelocity: 0,
+          volumeAuthenticityKnown: true,
+          binUtilizationKnown: true,
         }) as import("../engine/types.js").PoolMetrics,
       checkVolumeAuthenticity: () => ({ score: 0.9, flags: [] }),
       computeBinUtilization: () => 0.5,

--- a/bench/revenue-split.test.ts
+++ b/bench/revenue-split.test.ts
@@ -53,6 +53,7 @@ function buildLayer() {
     paperModeExitLive: false,
     meteoraPoolsUrl:
       "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
+    meteoraDatapiBaseUrl: "https://dlmm.datapi.meteora.ag",
     rebalanceGasCostSol: 0.01,
     solPriceUsd: 150,
     gasAwareMinDaysOfFeesPaidAhead: 3,

--- a/bench/risk-service.test.ts
+++ b/bench/risk-service.test.ts
@@ -70,6 +70,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     feedbackOptOut: false,
     paperModeExitLive: false,
     meteoraPoolsUrl: "https://dlmm.datapi.meteora.ag",
+    meteoraDatapiBaseUrl: "https://dlmm.datapi.meteora.ag",
     rebalanceGasCostSol: 0.005,
     solPriceUsd: 20,
     gasAwareMinDaysOfFeesPaidAhead: 3,

--- a/bench/screener-discover.test.ts
+++ b/bench/screener-discover.test.ts
@@ -59,6 +59,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     paperModeExitLive: false,
     meteoraPoolsUrl:
       "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
+    meteoraDatapiBaseUrl: "https://dlmm.datapi.meteora.ag",
     rebalanceGasCostSol: 0.01,
     solPriceUsd: 150,
     gasAwareMinDaysOfFeesPaidAhead: 3,

--- a/bench/signal-weights.test.ts
+++ b/bench/signal-weights.test.ts
@@ -37,6 +37,8 @@ function makeMetrics(overrides: Partial<PoolMetrics> = {}): PoolMetrics {
     feeIlRatio: overrides.feeIlRatio ?? 1.5,
     volumeAuthenticity: overrides.volumeAuthenticity ?? 0.85,
     binUtilization: overrides.binUtilization ?? 0.6,
+    volumeAuthenticityKnown: overrides.volumeAuthenticityKnown ?? true,
+    binUtilizationKnown: overrides.binUtilizationKnown ?? true,
   };
 }
 

--- a/bench/update-check.test.ts
+++ b/bench/update-check.test.ts
@@ -62,6 +62,7 @@ function buildLayer(
     paperModeExitLive: false,
     meteoraPoolsUrl:
       "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
+    meteoraDatapiBaseUrl: "https://dlmm.datapi.meteora.ag",
     rebalanceGasCostSol: 0.01,
     solPriceUsd: 150,
     gasAwareMinDaysOfFeesPaidAhead: 3,

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -1115,6 +1115,10 @@ export const AdapterLive = Layer.effect(
             binStep: lbPair.binStep,
             currentPrice: Number(activeBin.price),
             timestamp: Date.now(),
+            // tvl comes from on-chain reserves × price, but volume/fees are
+            // modeled — see fetchPoolStats. The Meteora Data API overlay in
+            // program.ts upgrades this to "datapi" when available.
+            statsSource: "heuristic" as const,
           };
         }).pipe(
           Effect.catchAll((err) =>
@@ -1137,21 +1141,50 @@ export const AdapterLive = Layer.effect(
           const upperBinId = activeBin.binId + halfRange;
           const binStep = Number(dlmm.lbPair.binStep);
 
-          const bins: BinData[] = [];
-          const basePrice = Number(activeBin.price);
-          for (let i = lowerBinId; i <= upperBinId; i++) {
-            const price = basePrice * Math.pow(1 + binStep / 10000, i - activeBin.binId);
-            bins.push({
-              binId: i,
-              price,
-              reserveX: 0n,
-              reserveY: 0n,
-              // Synthetic bins lack real reserves; 1n is required so
-              // computeBinUtilization counts them as active. Without this,
-              // passesPreFilter rejects every pool (bin util == 0).
-              liquiditySupply: 1n,
-            });
+          // Real per-bin reserves from the on-chain bin arrays. The SDK fills
+          // uninitialized bins with zero-amount placeholders, which is the
+          // truthful "empty bin" representation.
+          const realBins = yield* Effect.tryPromise(() =>
+            dlmm.getBinsAroundActiveBin(halfRange, halfRange),
+          ).pipe(
+            Effect.catchAll((err) => {
+              logger.warn(
+                "Real bin reserves unavailable — bin-derived metrics will be marked unknown",
+                { pool: poolAddress, error: String(err) },
+              );
+              return Effect.succeed(null);
+            }),
+          );
+
+          if (realBins === null) {
+            // Explicit unknown state: metrics skip the auth/utilization gates
+            // with a warning instead of consuming fabricated 1.0 values.
+            return {
+              lowerBinId,
+              upperBinId,
+              bins: [],
+              activeBinId: activeBin.binId,
+              binStep,
+              reservesKnown: false,
+            };
           }
+
+          const basePrice = Number(activeBin.price);
+          const bins: BinData[] = realBins.bins
+            .filter((b) => b.binId >= lowerBinId && b.binId <= upperBinId)
+            .map((b) => {
+              const parsedPrice = Number(b.price);
+              return {
+                binId: b.binId,
+                price:
+                  Number.isFinite(parsedPrice) && parsedPrice > 0
+                    ? parsedPrice
+                    : basePrice * Math.pow(1 + binStep / 10000, b.binId - activeBin.binId),
+                reserveX: BigInt(b.xAmount.toString()),
+                reserveY: BigInt(b.yAmount.toString()),
+                liquiditySupply: BigInt(b.supply.toString()),
+              };
+            });
 
           return {
             lowerBinId,
@@ -1159,6 +1192,7 @@ export const AdapterLive = Layer.effect(
             bins,
             activeBinId: activeBin.binId,
             binStep,
+            reservesKnown: true,
           };
         }),
 

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -53,6 +53,7 @@ export interface AppConfig {
   // env var; falls back to the official DLMM Data API (dlmm.datapi.meteora.ag)
   // if the env var is unset or empty.
   readonly meteoraPoolsUrl: string;
+  readonly meteoraDatapiBaseUrl: string;
 
   // ─── F1: Gas-aware rebalancing ──────────────────────────────────────────────
   /** Estimated SOL cost of a single rebalance tx (entry + close). */
@@ -543,6 +544,9 @@ const loadConfig = Effect.gen(function* () {
   const meteoraPoolsUrl =
     meteoraPoolsUrlRaw ||
     "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc";
+  const meteoraDatapiBaseUrl = yield* Config.string("METEORA_DATA_API_URL").pipe(
+    Effect.orElseSucceed(() => "https://dlmm.datapi.meteora.ag"),
+  );
 
   const watchlistPools = watchlistPoolsRaw
     .split(",")
@@ -591,6 +595,7 @@ const loadConfig = Effect.gen(function* () {
     feedbackOptOut,
     paperModeExitLive,
     meteoraPoolsUrl,
+    meteoraDatapiBaseUrl,
 
     rebalanceGasCostSol,
     solPriceUsd,

--- a/engine/meteora-datapi-service.ts
+++ b/engine/meteora-datapi-service.ts
@@ -1,0 +1,147 @@
+import { Effect, Layer } from "effect";
+import { ConfigService } from "./config-service.js";
+import { MeteoraDatapiService, type MeteoraDatapiApi, type MeteoraPoolStats } from "./services.js";
+import type { PoolState } from "./types.js";
+import { createLogger } from "./logger.js";
+import { retryEffectWithBackoff } from "./adapter-retry.js";
+
+const logger = createLogger("meteora-datapi");
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RETRIES = 2;
+
+// ─── Response validation ─────────────────────────────────────────────────────
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readNumber(obj: Record<string, unknown>, key: string): number | null {
+  const value = obj[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readBoolean(obj: Record<string, unknown>, key: string): boolean | null {
+  const value = obj[key];
+  return typeof value === "boolean" ? value : null;
+}
+
+function readWindow(obj: Record<string, unknown>, key: string, window: string): number | null {
+  const nested = obj[key];
+  if (!isObject(nested)) return null;
+  return readNumber(nested, window);
+}
+
+/**
+ * Parse one pool object from the Data API. Returns null when required numeric
+ * fields are missing (likely an upstream schema change) so the caller falls
+ * back to heuristic metrics instead of consuming garbage.
+ */
+export function parseMeteoraPoolStats(raw: unknown): MeteoraPoolStats | null {
+  if (!isObject(raw)) return null;
+  const address = raw["address"];
+  const tvl = readNumber(raw, "tvl");
+  const volume24h = readWindow(raw, "volume", "24h");
+  const fees24h = readWindow(raw, "fees", "24h");
+  const apr = readNumber(raw, "apr");
+  if (typeof address !== "string" || address.length === 0) return null;
+  if (tvl === null || volume24h === null || fees24h === null || apr === null) return null;
+
+  const tokenX = isObject(raw["token_x"]) ? raw["token_x"] : {};
+  const tokenY = isObject(raw["token_y"]) ? raw["token_y"] : {};
+  const poolConfig = isObject(raw["pool_config"]) ? raw["pool_config"] : {};
+
+  return {
+    address,
+    name: typeof raw["name"] === "string" ? raw["name"] : "",
+    tvlUsd: tvl,
+    volume24hUsd: volume24h,
+    fees24hUsd: fees24h,
+    apr,
+    apy: readNumber(raw, "apy") ?? 0,
+    currentPrice: readNumber(raw, "current_price") ?? 0,
+    feeTvlRatio24h: readWindow(raw, "fee_tvl_ratio", "24h"),
+    feeTvlRatio12h: readWindow(raw, "fee_tvl_ratio", "12h"),
+    feeTvlRatio1h: readWindow(raw, "fee_tvl_ratio", "1h"),
+    dynamicFeePct: readNumber(raw, "dynamic_fee_pct"),
+    baseFeePct: readNumber(poolConfig, "base_fee_pct"),
+    hasFarm: readBoolean(raw, "has_farm"),
+    isBlacklisted: readBoolean(raw, "is_blacklisted"),
+    tokenXFreezeAuthorityDisabled: readBoolean(tokenX, "freeze_authority_disabled"),
+    tokenYFreezeAuthorityDisabled: readBoolean(tokenY, "freeze_authority_disabled"),
+  };
+}
+
+// ─── Pool enrichment ─────────────────────────────────────────────────────────
+
+/**
+ * Replace heuristic tvl/volume/fees with real Data API values. On-chain
+ * identity fields (mints, symbols, active bin, price, bin step) always come
+ * from the adapter and are preserved. APR is recomputed into the engine's
+ * annualized-percent convention (the API's `apr` is a daily fee/TVL rate).
+ */
+export function enrichPoolWithDatapi(pool: PoolState, stats: MeteoraPoolStats): PoolState {
+  const aprAnnualizedPct =
+    stats.tvlUsd > 0 && stats.fees24hUsd > 0
+      ? ((stats.fees24hUsd * 365) / stats.tvlUsd) * 100
+      : pool.apr;
+  return {
+    ...pool,
+    tvlUsd: stats.tvlUsd > 0 ? stats.tvlUsd : pool.tvlUsd,
+    volume24hUsd: stats.volume24hUsd,
+    fees24hUsd: stats.fees24hUsd,
+    apr: aprAnnualizedPct,
+    statsSource: "datapi",
+  };
+}
+
+// ─── Live layer ──────────────────────────────────────────────────────────────
+
+export const MeteoraDatapiLive = Layer.effect(
+  MeteoraDatapiService,
+  Effect.gen(function* () {
+    const config = yield* ConfigService;
+    const baseUrl = config.meteoraDatapiBaseUrl.replace(/\/+$/, "");
+
+    const getPoolData = (poolAddress: string): Effect.Effect<MeteoraPoolStats | null, never> => {
+      const url = `${baseUrl}/pools/${poolAddress}`;
+      const fetchJson = retryEffectWithBackoff(
+        Effect.tryPromise({
+          try: () => fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) }),
+          catch: (cause) => cause,
+        }).pipe(
+          Effect.flatMap((res) =>
+            res.ok
+              ? Effect.tryPromise({
+                  try: () => res.json() as Promise<unknown>,
+                  catch: (cause) => cause,
+                })
+              : Effect.fail(new Error(`Meteora Data API HTTP ${res.status} for ${url}`)),
+          ),
+        ),
+        { maxRetries: MAX_RETRIES },
+      );
+
+      return fetchJson.pipe(
+        Effect.flatMap((json) => {
+          const parsed = parseMeteoraPoolStats(json);
+          return parsed === null
+            ? Effect.fail(new Error(`Meteora Data API returned an invalid pool payload for ${url}`))
+            : Effect.succeed(parsed);
+        }),
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            logger.warn("Meteora Data API unavailable — falling back to heuristic pool stats", {
+              pool: poolAddress,
+              error: String(err),
+            });
+            return null;
+          }),
+        ),
+      );
+    };
+
+    const api: MeteoraDatapiApi = { getPoolData };
+    return api;
+  }),
+);

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -62,6 +62,7 @@ import {
   McpServerService,
   HttpStatusServerService,
   EntryPrepService,
+  MeteoraDatapiService,
   type AdapterApi,
   type DbApi,
   type MemoryApi,
@@ -71,12 +72,14 @@ import {
   type EntryPrepApi,
   type AgentStateApi,
 } from "./services.js";
+import { MeteoraDatapiLive, enrichPoolWithDatapi } from "./meteora-datapi-service.js";
 import type {
   AgentDecision,
   AgentProposal,
   AgentProposalMode,
   AgentCycle,
   PoolMetrics,
+  PoolSnapshot,
   PoolState,
   Position,
   RebalanceParams,
@@ -100,6 +103,13 @@ import {
 } from "./proposal-backoff.js";
 
 const logger = createLogger("program");
+
+/**
+ * How far back to look for a previous pool snapshot when computing TVL
+ * velocity / IL drift. Wide enough to survive a day of downtime; the query is
+ * indexed on (pool_address, timestamp) so this stays cheap.
+ */
+const PREVIOUS_SNAPSHOT_WINDOW_MS = 26 * 60 * 60 * 1000;
 
 export function isProposalStale(proposal: AgentProposal, staleMs: number, now: number): boolean {
   return now > proposal.proposedAt + staleMs || now > proposal.expiresAt;
@@ -439,7 +449,8 @@ type AllServices =
   | AgentStateService
   | McpServerService
   | HttpStatusServerService
-  | EntryPrepService;
+  | EntryPrepService
+  | MeteoraDatapiService;
 
 export function buildLayer(cfg?: AppConfig): Layer.Layer<AllServices, never, never> {
   const dbLayer = DbLive(cfg?.sqliteDbPath);
@@ -448,6 +459,7 @@ export function buildLayer(cfg?: AppConfig): Layer.Layer<AllServices, never, nev
   const adapter = Layer.provide(AdapterLive, configLayer);
   const memory = Layer.provide(MemoryLive, dbLayer);
   const audit = Layer.provide(AuditLive, dbLayer);
+  const meteoraDatapi = Layer.provide(MeteoraDatapiLive, configLayer);
 
   const screenerDeps = Layer.merge(adapter, StrategyLive);
   const screener = Layer.provide(
@@ -488,6 +500,7 @@ export function buildLayer(cfg?: AppConfig): Layer.Layer<AllServices, never, nev
   const merged10 = Layer.merge(merged9, ReferralLive);
   const merged11 = Layer.merge(merged10, revenueConfig);
   const merged11a = Layer.merge(merged11, entryPrep);
+  const merged11b = Layer.merge(merged11a, meteoraDatapi);
 
   const agentLayer = cfg?.agentiveMode ? AgentLive(cfg) : Layer.succeed(AgentService, AgentNoOp);
 
@@ -507,7 +520,7 @@ export function buildLayer(cfg?: AppConfig): Layer.Layer<AllServices, never, nev
           stop: () => Effect.void,
         });
 
-  const merged12 = Layer.merge(merged11a, agentLayer);
+  const merged12 = Layer.merge(merged11b, agentLayer);
   const merged13 = Layer.merge(merged12, agentStateLayer);
   const merged14 = Layer.merge(merged13, mcpLayer);
   const merged15 = Layer.merge(merged14, httpLayer);
@@ -935,6 +948,7 @@ export const program = Effect.gen(function* () {
   const agentState = yield* AgentStateService;
   const mcpServer = yield* McpServerService;
   const httpStatusServer = yield* HttpStatusServerService;
+  const meteoraDatapi = yield* MeteoraDatapiService;
 
   // Load persisted positions at startup
   const allPositions = yield* db.getAllPositions().pipe(Effect.catchAll(() => Effect.succeed([])));
@@ -1528,33 +1542,58 @@ export const program = Effect.gen(function* () {
       let proposalValidated = false;
       /** The deterministic decision before an applied proposal replaced it. */
       let preApplyDecision: AgentDecision | undefined;
-      const pool = yield* adapter.getPoolState(poolAddress);
+      const rawPool = yield* adapter.getPoolState(poolAddress);
       const binArray = yield* adapter.getBinArray(poolAddress);
-      pushBinHistory(poolAddress, pool.activeBinId);
+      pushBinHistory(poolAddress, rawPool.activeBinId);
 
-      if (config.enableSnapshotCapture && config.paperTrading) {
-        yield* db
-          .saveSnapshot({
-            poolAddress,
-            timestamp: pool.timestamp,
-            activeBinId: pool.activeBinId,
-            tvlUsd: pool.tvlUsd,
-            volume24hUsd: pool.volume24hUsd,
-            fees24hUsd: pool.fees24hUsd,
-            apr: pool.apr,
-            currentPrice: pool.currentPrice,
-            binStep: pool.binStep,
-            tokenXSymbol: pool.tokenXSymbol,
-            tokenYSymbol: pool.tokenYSymbol,
-            binArray: { ...binArray, binStep: pool.binStep },
-          })
-          .pipe(
-            Effect.catchAll((err) => {
-              console.warn("Snapshot save failed", { pool: poolAddress, err });
-              return Effect.void;
-            }),
-          );
-      }
+      // Real pool stats from the Meteora Data API; falls back to the
+      // adapter's heuristic stats (with a logged warning) when unavailable.
+      const datapiStats = yield* meteoraDatapi.getPoolData(poolAddress);
+      const pool = datapiStats === null ? rawPool : enrichPoolWithDatapi(rawPool, datapiStats);
+
+      // TVL velocity + IL price-drift need a previous reference point, so the
+      // previous snapshot must be read BEFORE persisting the current one.
+      const previousSnapshots = yield* db
+        .getSnapshots(poolAddress, pool.timestamp - PREVIOUS_SNAPSHOT_WINDOW_MS, pool.timestamp)
+        .pipe(Effect.catchAll(() => Effect.succeed([] as ReadonlyArray<PoolSnapshot>)));
+      const previousSnapshot =
+        previousSnapshots.length > 0 ? previousSnapshots[previousSnapshots.length - 1] : undefined;
+
+      // Persist a snapshot every cycle (both paper and live): TVL velocity and
+      // the TVL-drop EXIT are dead code without per-cycle history. The full
+      // bin-array detail is only stored under ENABLE_SNAPSHOT_CAPTURE (paper)
+      // as before; routine rows stay lightweight.
+      yield* db
+        .saveSnapshot({
+          poolAddress,
+          timestamp: pool.timestamp,
+          activeBinId: pool.activeBinId,
+          tvlUsd: pool.tvlUsd,
+          volume24hUsd: pool.volume24hUsd,
+          fees24hUsd: pool.fees24hUsd,
+          apr: pool.apr,
+          currentPrice: pool.currentPrice,
+          binStep: pool.binStep,
+          tokenXSymbol: pool.tokenXSymbol,
+          tokenYSymbol: pool.tokenYSymbol,
+          binArray:
+            config.enableSnapshotCapture && config.paperTrading
+              ? { ...binArray, binStep: pool.binStep }
+              : {
+                  lowerBinId: binArray.lowerBinId,
+                  upperBinId: binArray.upperBinId,
+                  bins: [],
+                  activeBinId: binArray.activeBinId,
+                  binStep: pool.binStep,
+                  reservesKnown: binArray.reservesKnown,
+                },
+        })
+        .pipe(
+          Effect.catchAll((err) => {
+            console.warn("Snapshot save failed", { pool: poolAddress, err });
+            return Effect.void;
+          }),
+        );
 
       // Blacklist check (token mints only; deployer info not yet fetched)
       // TODO: fetch token deployer/authority from on-chain metadata and pass to checkPool
@@ -1562,7 +1601,25 @@ export const program = Effect.gen(function* () {
         .checkPool(poolAddress, pool.tokenX, pool.tokenY)
         .pipe(Effect.catchAll(() => Effect.void));
 
-      const metrics = strategy.computeMetrics(pool, binArray, 0);
+      const metrics = strategy.computeMetrics(
+        pool,
+        binArray,
+        previousSnapshot?.tvlUsd ?? 0,
+        previousSnapshot
+          ? {
+              previousPrice: previousSnapshot.currentPrice,
+              previousTimestamp: previousSnapshot.timestamp,
+            }
+          : undefined,
+      );
+
+      if (!metrics.volumeAuthenticityKnown || !metrics.binUtilizationKnown) {
+        logger.warn("Metric data unavailable — skipping the affected gates for this pool", {
+          pool: poolAddress,
+          volumeAuthenticityKnown: metrics.volumeAuthenticityKnown,
+          binUtilizationKnown: metrics.binUtilizationKnown,
+        });
+      }
 
       // Pre-filter
       if (
@@ -1573,6 +1630,8 @@ export const program = Effect.gen(function* () {
           config.minPoolTvlUsd,
           evolvedThresholds.volumeAuthThreshold,
           evolvedThresholds.minBinUtilization,
+          metrics.volumeAuthenticityKnown,
+          metrics.binUtilizationKnown,
         )
       ) {
         console.debug("Pool failed pre-filter", { pool: poolAddress });
@@ -1684,7 +1743,10 @@ export const program = Effect.gen(function* () {
           `TVL dropped ${(Math.abs(tvlVelocity) * 100).toFixed(1)}% on ${pool.tokenXSymbol}/${pool.tokenYSymbol} — capital protection EXIT triggered`,
           { pool, metrics, position: pos ?? undefined },
         );
-      } else if (volumeAuth < evolvedThresholds.volumeAuthThreshold) {
+      } else if (
+        metrics.volumeAuthenticityKnown &&
+        volumeAuth < evolvedThresholds.volumeAuthThreshold
+      ) {
         decision = {
           action: "EXIT",
           poolAddress,
@@ -2097,7 +2159,9 @@ export const program = Effect.gen(function* () {
 
             if (
               feeIlRatio > evolvedThresholds.minFeeIlRatio * 1.5 &&
+              metrics.volumeAuthenticityKnown &&
               volumeAuth > 0.8 &&
+              metrics.binUtilizationKnown &&
               binUtilization > 0.4 &&
               pool.tvlUsd > config.minPoolTvlUsd * 2
             ) {

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -14,6 +14,7 @@ import type {
   PoolSnapshot,
   PoolState,
   Position,
+  PriceDriftContext,
   SignalSnapshot,
   SignalWeights,
 } from "./types.js";
@@ -187,13 +188,18 @@ export interface StrategyApi {
     pool: PoolState,
     binArray: BinArray,
     previousTvlUsd: number,
+    priceDrift?: PriceDriftContext,
   ) => PoolMetrics;
   readonly checkVolumeAuthenticity: (pool: PoolState) => {
     score: number;
     flags: ReadonlyArray<string>;
   };
   readonly computeBinUtilization: (binArray: BinArray) => number;
-  readonly computeFeeIlRatio: (pool: PoolState, binArray: BinArray) => number;
+  readonly computeFeeIlRatio: (
+    pool: PoolState,
+    binArray: BinArray,
+    priceDrift?: PriceDriftContext,
+  ) => number;
   readonly recommendBinRange: (
     activeBinId: number,
     binStep: number,
@@ -205,12 +211,51 @@ export interface StrategyApi {
     minTvlUsd: number,
     minAuthScore: number,
     minBinUtilization: number,
+    authKnown?: boolean,
+    binUtilizationKnown?: boolean,
   ) => boolean;
 }
 
 export class StrategyService extends Context.Tag("StrategyService")<
   StrategyService,
   StrategyApi
+>() {}
+
+// ─── Meteora Data API Service ────────────────────────────────────────────────
+
+/** Real pool statistics from the Meteora Data API (dlmm.datapi.meteora.ag). */
+export interface MeteoraPoolStats {
+  readonly address: string;
+  readonly name: string;
+  readonly tvlUsd: number;
+  readonly volume24hUsd: number;
+  readonly fees24hUsd: number;
+  readonly apr: number;
+  readonly apy: number;
+  readonly currentPrice: number;
+  readonly feeTvlRatio24h: number | null;
+  readonly feeTvlRatio12h: number | null;
+  readonly feeTvlRatio1h: number | null;
+  readonly dynamicFeePct: number | null;
+  readonly baseFeePct: number | null;
+  readonly hasFarm: boolean | null;
+  readonly isBlacklisted: boolean | null;
+  readonly tokenXFreezeAuthorityDisabled: boolean | null;
+  readonly tokenYFreezeAuthorityDisabled: boolean | null;
+}
+
+export interface MeteoraDatapiApi {
+  /**
+   * Fetch real stats for one pool. Never fails: on any network/HTTP/schema
+   * error it logs a warning and returns null so callers fall back to
+   * heuristic metrics without crashing the scan cycle.
+   */
+  readonly getPoolData: (poolAddress: string) => Effect.Effect<MeteoraPoolStats | null, never>;
+}
+
+export class MeteoraDatapiService extends Context.Tag("MeteoraDatapiService")<
+  MeteoraDatapiService,
+  MeteoraDatapiApi
 >() {}
 
 // ─── Memory Service ──────────────────────────────────────────────────────────

--- a/engine/strategy-service.ts
+++ b/engine/strategy-service.ts
@@ -1,12 +1,119 @@
 import { Context, Layer } from "effect";
 import { StrategyService, type StrategyApi } from "./services.js";
-import type { BinArray, PoolMetrics, PoolState, SignalWeights } from "./types.js";
+import type {
+  BinArray,
+  PoolMetrics,
+  PoolState,
+  PriceDriftContext,
+  SignalWeights,
+} from "./types.js";
+
+/**
+ * Upper bound for the fee/IL ratio. Also the value reported when observed
+ * price drift is zero (no IL measured → fees dominate by construction).
+ * Replaces the old hardcoded `999` sentinel which made every fee/IL gate
+ * vacuous. Kept in sync with the weightedEntryScore cap below.
+ */
+export const MAX_FEE_IL_RATIO = 20;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Reference half-width (bins) for the concentration multiplier: the half-range
+ * the adapter fetches around the active bin. Liquidity squeezed into a
+ * narrower effective width experiences amplified IL per unit of price drift.
+ */
+const CONCENTRATION_REFERENCE_HALF_WIDTH = 20;
+const MAX_CONCENTRATION_MULTIPLIER = 10;
+
+/** Assumed daily drift per unit of bin step when no price history exists yet. */
+const BIN_STEP_DRIFT_PROXY_PER_DAY = 10;
+
+/** IL fraction of a full-range LP position after price moves by ratio r. */
+function impermanentLossFraction(priceRatio: number): number {
+  return Math.abs((2 * Math.sqrt(priceRatio)) / (1 + priceRatio) - 1);
+}
+
+/**
+ * Liquidity-weighted mean distance (in bins) of stocked bins from the active
+ * bin, expressed as an IL amplification factor vs the reference half-width.
+ * Returns 1 when bin reserves are unknown or no bin holds liquidity.
+ */
+function computeConcentrationMultiplier(binArray: BinArray): number {
+  if (binArray.reservesKnown === false) return 1;
+
+  let weightSum = 0;
+  let distanceSum = 0;
+  for (const b of binArray.bins) {
+    const weight = Number(b.liquiditySupply);
+    if (!Number.isFinite(weight) || weight <= 0) continue;
+    weightSum += weight;
+    distanceSum += weight * Math.abs(b.binId - binArray.activeBinId);
+  }
+  if (weightSum <= 0) return 1;
+
+  const effectiveHalfWidth = Math.max(distanceSum / weightSum, 1);
+  return Math.min(
+    Math.max(CONCENTRATION_REFERENCE_HALF_WIDTH / effectiveHalfWidth, 1),
+    MAX_CONCENTRATION_MULTIPLIER,
+  );
+}
+
+/**
+ * Estimated daily impermanent loss in USD for liquidity in this pool.
+ *
+ * Primary model (price history available): take the per-cycle endpoint drift
+ * r = price/prevPrice, convert to the full-range IL fraction, scale to a day
+ * by the number of elapsed-cycle equivalents, and amplify by the liquidity
+ * concentration multiplier. This is a conservative upper-bound ranking
+ * signal: it assumes every cycle drifts like the last one and ignores
+ * intra-cycle mean reversion.
+ *
+ * Fallback (first cycle after startup — no previous snapshot): assume a daily
+ * drift of BIN_STEP_DRIFT_PROXY_PER_DAY × binStep, so the estimate still
+ * varies across pools with different volatility profiles instead of
+ * collapsing to the old `/365`-amortized ~0 that produced the 999 sentinel.
+ */
+export function estimateDailyIlUsd(
+  pool: PoolState,
+  binArray: BinArray,
+  priceDrift?: PriceDriftContext,
+): number {
+  const concentration = computeConcentrationMultiplier(binArray);
+
+  const previousPrice = priceDrift?.previousPrice;
+  const previousTimestamp = priceDrift?.previousTimestamp;
+  const hasDrift =
+    previousPrice !== undefined &&
+    previousPrice > 0 &&
+    previousTimestamp !== undefined &&
+    pool.timestamp > previousTimestamp &&
+    pool.currentPrice > 0;
+
+  if (hasDrift) {
+    const ratio = Math.min(Math.max(pool.currentPrice / previousPrice, 0.5), 2);
+    const elapsedMs = pool.timestamp - previousTimestamp;
+    const cyclesPerDay = MS_PER_DAY / elapsedMs;
+    const ilDailyFraction = impermanentLossFraction(ratio) * cyclesPerDay * concentration;
+    return pool.tvlUsd * ilDailyFraction;
+  }
+
+  const binStepBps = binArray.binStep ?? pool.binStep ?? 10;
+  const assumedDailyDrift = (binStepBps / 10_000) * BIN_STEP_DRIFT_PROXY_PER_DAY;
+  const ilDailyFraction = impermanentLossFraction(1 + assumedDailyDrift) * concentration;
+  return pool.tvlUsd * ilDailyFraction;
+}
 
 export const DLMMStrategy: StrategyApi = {
-  computeMetrics(pool: PoolState, binArray: BinArray, previousTvlUsd: number): PoolMetrics {
+  computeMetrics(
+    pool: PoolState,
+    binArray: BinArray,
+    previousTvlUsd: number,
+    priceDrift?: PriceDriftContext,
+  ): PoolMetrics {
     const tvlVelocity = previousTvlUsd > 0 ? (pool.tvlUsd - previousTvlUsd) / previousTvlUsd : 0;
 
-    const feeIlRatio = DLMMStrategy.computeFeeIlRatio(pool, binArray);
+    const feeIlRatio = DLMMStrategy.computeFeeIlRatio(pool, binArray, priceDrift);
     const volumeAuthenticity = DLMMStrategy.checkVolumeAuthenticity(pool);
     const binUtilization = DLMMStrategy.computeBinUtilization(binArray);
 
@@ -17,26 +124,19 @@ export const DLMMStrategy: StrategyApi = {
       feeIlRatio,
       volumeAuthenticity: volumeAuthenticity.score,
       binUtilization,
+      // Volume authenticity is only meaningful on real (Data API) stats;
+      // heuristic volume/fees would just re-validate their own assumptions.
+      volumeAuthenticityKnown: pool.statsSource === "datapi",
+      binUtilizationKnown: binArray.reservesKnown !== false,
     };
   },
 
-  computeFeeIlRatio(pool: PoolState, binArray: BinArray): number {
+  computeFeeIlRatio(pool: PoolState, binArray: BinArray, priceDrift?: PriceDriftContext): number {
     if (pool.tvlUsd === 0) return 0;
 
-    const activeBin = binArray.bins.find((b) => b.binId === binArray.activeBinId);
-    if (!activeBin) return 0;
-
-    const rangeCenter = (binArray.lowerBinId + binArray.upperBinId) / 2;
-    const binsDrifted = Math.abs(binArray.activeBinId - rangeCenter);
-    const binStep = binArray.binStep ?? 10;
-
-    const priceRatio = Math.pow(1 + binStep / 10_000, binsDrifted);
-    const ilFraction = (2 * Math.sqrt(priceRatio)) / (1 + priceRatio) - 1;
-    const estimatedIlUsd = pool.tvlUsd * Math.abs(ilFraction);
-    const estimatedIlDaily = estimatedIlUsd / 365;
-
-    if (estimatedIlDaily === 0) return pool.fees24hUsd > 0 ? 999 : 0;
-    return pool.fees24hUsd / estimatedIlDaily;
+    const estimatedIlDailyUsd = estimateDailyIlUsd(pool, binArray, priceDrift);
+    if (estimatedIlDailyUsd <= 0) return pool.fees24hUsd > 0 ? MAX_FEE_IL_RATIO : 0;
+    return Math.min(pool.fees24hUsd / estimatedIlDailyUsd, MAX_FEE_IL_RATIO);
   },
 
   checkVolumeAuthenticity(pool: PoolState): {
@@ -77,6 +177,10 @@ export const DLMMStrategy: StrategyApi = {
   },
 
   computeBinUtilization(binArray: BinArray): number {
+    // Unknown reserves must report 0 (and binUtilizationKnown=false upstream)
+    // — never fabricate 1.0 from synthetic bins.
+    if (binArray.reservesKnown === false) return 0;
+
     const total = binArray.bins.length;
     if (total === 0) return 0;
 
@@ -105,12 +209,16 @@ export const DLMMStrategy: StrategyApi = {
     minTvlUsd: number,
     minAuthScore: number,
     minBinUtilization: number,
+    authKnown = true,
+    binUtilizationKnown = true,
   ): boolean {
     return (
       pool.tvlUsd > 0 &&
       pool.tvlUsd >= minTvlUsd &&
-      authScore >= minAuthScore &&
-      binUtilization >= minBinUtilization
+      // Unknown metrics skip their gate (a warning is logged by the caller);
+      // they must neither auto-pass nor auto-fail the pre-filter.
+      (!authKnown || authScore >= minAuthScore) &&
+      (!binUtilizationKnown || binUtilization >= minBinUtilization)
     );
   },
 };
@@ -384,13 +492,14 @@ function clampWeight(value: number, floor: number, ceiling: number): number {
   return Math.max(floor, Math.min(ceiling, value));
 }
 
-const MAX_FEE_IL_RATIO = 20;
-
 export function weightedEntryScore(metrics: PoolMetrics, weights: SignalWeights): number {
   const cappedFeeIlRatio = Math.min(metrics.feeIlRatio, MAX_FEE_IL_RATIO);
   const feeContrib = cappedFeeIlRatio * weights.feeIlRatio;
-  const authContrib = metrics.volumeAuthenticity * weights.volumeAuthenticity;
-  const binContrib = metrics.binUtilization * weights.binUtilization;
+  // Unknown metrics contribute 0 (fail-closed) rather than a fabricated 1.0.
+  const authContrib =
+    (metrics.volumeAuthenticityKnown ? metrics.volumeAuthenticity : 0) * weights.volumeAuthenticity;
+  const binContrib =
+    (metrics.binUtilizationKnown ? metrics.binUtilization : 0) * weights.binUtilization;
   const tvlContrib = Math.min(metrics.pool.tvlUsd / 1_000_000, 1) * weights.tvlUsd;
   const velContrib = (1 / (1 + Math.abs(metrics.tvlVelocity))) * weights.tvlVelocity * 0.1;
 

--- a/engine/types.ts
+++ b/engine/types.ts
@@ -14,6 +14,13 @@ export interface BinArray {
   bins: BinData[];
   activeBinId: number;
   binStep?: number;
+  /**
+   * False when per-bin reserves were NOT fetched from on-chain bin arrays
+   * (e.g. the SDK call failed). Metrics must treat bin-derived signals as
+   * "unknown" rather than fabricating them. Undefined is treated as known
+   * for backward compatibility with stored snapshots and test fixtures.
+   */
+  reservesKnown?: boolean | undefined;
 }
 
 export interface PoolState {
@@ -30,6 +37,12 @@ export interface PoolState {
   binStep: number;
   currentPrice: number;
   timestamp: number;
+  /**
+   * Where tvl/volume/fees came from. "datapi" = real Meteora Data API values;
+   * "heuristic" = on-chain reserves × price with modeled turnover (fabricated
+   * volume/fees). Volume-authenticity is only meaningful for "datapi" stats.
+   */
+  statsSource?: "datapi" | "heuristic" | undefined;
 }
 
 export interface PoolSnapshot {
@@ -52,8 +65,18 @@ export interface PoolMetrics {
   binArray: BinArray;
   tvlVelocity: number; // % change in TVL over last N intervals
   feeIlRatio: number;
-  volumeAuthenticity: number; // 0–1 score
-  binUtilization: number; // active bins / total bins
+  volumeAuthenticity: number; // 0–1 score (0 when unknown)
+  binUtilization: number; // active bins / total bins (0 when unknown)
+  /** False when volume/fees are heuristic estimates — auth gates must skip. */
+  readonly volumeAuthenticityKnown: boolean;
+  /** False when real per-bin reserves were unavailable — util gates must skip. */
+  readonly binUtilizationKnown: boolean;
+}
+
+/** Recent price reference used to estimate impermanent loss from drift. */
+export interface PriceDriftContext {
+  readonly previousPrice?: number | undefined;
+  readonly previousTimestamp?: number | undefined;
 }
 
 // ─── Signal Staging ──────────────────────────────────────────────────────────


### PR DESCRIPTION
# fix: real strategy metrics via Meteora Data API (Wave 1)

Wave 1 of `.omo/plans/prism-review-remediation.md`.

Fixes the 3 CRITICAL findings from the review: the strategy's core metrics were fabricated constants, so every gate keyed on them was vacuous or dead.

## Findings fixed

1. **`feeIlRatio` was a constant `999`.** `computeMetrics` measured IL from drift vs the *synthetic* range center (always 0 bins drifted) and amortized it `/365`, so `estimatedIlDaily` was ~0 and any pool with fees>0 got `999`. ENTER (`feeIlRatio > minFeeIlRatio*1.5`), EXIT (`< 0.5`), HOLD and `weightedEntryScore` were all vacuous. (Re-verified post-#93/#94: `engine/strategy-service.ts` old line 38.)
2. **`tvlVelocity` was always 0.** `program.ts` called `strategy.computeMetrics(pool, binArray, 0)` — the `TVL_DROP_EXIT_PCT` capital-protection EXIT was dead code. (Re-verified: old `engine/program.ts:1565`.)
3. **`volumeAuthenticity` ≈ 1.0 and `binUtilization` = 1.0 always.** `getBinArray` synthesized 41 bins with `reserveX: 0n, reserveY: 0n, liquiditySupply: 1n` so every bin counted as active, and volume/fees came from a `turnoverRate`/`feeRate` heuristic in `fetchPoolStats`, so the authenticity score validated its own assumptions. (Re-verified: old `engine/adapter-service.ts:1140-1162`, `1021-1068`.)

## Design notes

**Meteora Data API service** (`engine/meteora-datapi-service.ts`, new)
- Client for `https://dlmm.datapi.meteora.ag` (base URL verified live; also already used by `discoverPools`). Per-pool `GET /pools/{address}`, exposing `fee_tvl_ratio` 1h/12h/24h windows, `apr`/`apy`, `dynamic_fee_pct`, `base_fee_pct`, `has_farm`, `is_blacklisted`, and per-token `freeze_authority_disabled`. New env `METEORA_DATA_API_URL` (documented in AGENTS.md + `.env.example`).
- 10s `AbortSignal.timeout`, `retryEffectWithBackoff` (max 2 retries, same conventions as `adapter-retry.ts`), no new npm dependencies (global `fetch`).
- **Fallback:** any network/HTTP/schema failure logs `logger.warn` and returns `null`; the cycle continues on heuristic stats (`statsSource: "heuristic"`). Never crashes the scan cycle.
- When data arrives, `enrichPoolWithDatapi` replaces heuristic TVL/volume/fees with real values (`statsSource: "datapi"`). APR is recomputed into the engine's annualized-percent convention (the API's `apr` is a daily fee/TVL rate). Registered as `MeteoraDatapiService` Tag and wired in `buildLayer`.

**feeIlRatio** (`engine/strategy-service.ts`)
- New documented model `estimateDailyIlUsd`: per-cycle endpoint drift `r = price/prevPrice` (from the previous `pool_snapshots` row) → full-range IL fraction `2√r/(1+r) − 1` → scaled to a day by elapsed time → amplified by a liquidity-concentration multiplier (liquidity-weighted mean bin distance vs the ±20 reference half-width, clamped 1–10) from the real bin distribution. Conservative upper-bound ranking signal; documented as such.
- First cycle after startup (no previous snapshot): bin-step drift proxy (`10 × binStep` daily drift) so the metric still varies across pools instead of collapsing to a sentinel.
- `/365` amortization removed. The `999` sentinel is now the named export `MAX_FEE_IL_RATIO = 20` — the same value `weightedEntryScore` already used as its cap, so one constant governs both.

**tvlVelocity** (`engine/program.ts`)
- Per-cycle snapshots are now persisted unconditionally (paper *and* live — the TVL-drop EXIT needs history in live too). Full bin-array detail stays gated on `ENABLE_SNAPSHOT_CAPTURE` (paper); routine rows are lightweight (`bins: []`). AGENTS.md env table updated accordingly.
- `evaluatePool` reads the most recent snapshot within a 26h window **before** saving the current one, and passes `previousTvlUsd` + `{previousPrice, previousTimestamp}` into `computeMetrics`. Velocity = pct change vs that snapshot; first cycle after startup is 0 by construction (documented).

**Real bins + explicit unknown state** (`engine/adapter-service.ts`, `engine/strategy-service.ts`)
- `getBinArray` uses the SDK 1.9.13 `dlmm.getBinsAroundActiveBin(20, 20)` — real `xAmount`/`yAmount`/`supply` per bin (SDK fills uninitialized bins with zero placeholders, the truthful "empty" representation).
- If the SDK call fails: `BinArray.reservesKnown = false` and `PoolMetrics.binUtilizationKnown = false`; likewise `volumeAuthenticityKnown = (statsSource === "datapi")`. Unknown metrics **skip** their pre-filter / volume-auth EXIT gates with a `logger.warn`, and **block ENTER** (fail-closed). Nothing fabricates 1.0 anymore. `weightedEntryScore` treats unknown as 0 contribution.
- Item (e) checked: the LSP-reported `map()` callback at `adapter-service.ts:626` uniformly returns `void` on every path (side-effect-only cache fill); the repo lint chain (`tsc` + `oxlint`) does not flag it — benign editor-only diagnostic, not touched.

## Verification (all run in the worktree)

**Failing-first** — tests written first, run against unpatched code (`46e5817`):

```
Test Files  3 failed (3)   Tests  7 failed (7)
× (i)  AssertionError: expected 999 not to be 999                       (sentinel proven)
× (ii) both pools returned 999 → equal                                  (vacuous metric proven)
× (iii) expected a TVL-drop EXIT decision, got: ["HOLD: Fee/IL 58458406.22 above threshold. Holding."]
× (iv-a/b/c) binUtilizationKnown undefined; fabricated bins → utilization 1.0; unknown-skip gate missing
× (v)  Cannot find module '../engine/meteora-datapi-service.js'
```

Note (iii): the old code even reports `feeIlRatio = 58,458,406` there — the `/365` amortization nonsense on full display.

**After implementation** (same command, `8fdae4e`):

```
Test Files  3 passed (3)   Tests  12 passed (12)
```

**Full gates:**

```
$ bun run lint     → tsc --noEmit && oxlint engine ops bench cli   (exit 0)
$ bun run build    → ✔ Build complete (dist/index.mjs 1.68 MB)     (exit 0)
$ bun run test     → Test Files 63 passed (63), Tests 737 passed (737)  (exit 0)
$ bun run format:check → All matched files use the correct format  (exit 0)
```

**Manual-QA evidence** — standalone script (stubbed `fetch`, 3 pool profiles; deleted after capture, not committed):

```
pool | feeIlRatio | tvlVelocity | binUtil | volAuth | known(auth/util)
A: calm high-fee pool, tiny drift, wide liquidity
  -> feeIl=20.0000 tvlVel=0.0000 binUtil=0.902 volAuth=1.00 known=true/true src=datapi
B: wild low-fee pool, 4% drift/10min, concentrated liquidity
  -> feeIl=0.0018 tvlVel=-0.3750 binUtil=0.122 volAuth=1.00 known=true/true src=datapi
[WARN] [meteora-datapi] Meteora Data API unavailable — falling back to heuristic pool stats { pool: "PoolBroken1" }
C: Data API down → heuristic fallback (unknown auth), broken bins
  -> feeIl=1.6834 tvlVel=0.1111 binUtil=0.000 volAuth=1.00 known=false/false src=heuristic
```

Three different pools → three different metric sets (fee/IL spans 0.0018–20.0), TVL velocity −37.5% would trigger the revived TVL-drop EXIT, and the API-down path falls back with a warning and explicit unknown flags.

## Notes / deviations

- Review line numbers were from `d9b5b2c`; all three findings re-verified against `e1079e6` (post-#93/#94) and adapted — same defects, shifted line numbers (`strategy-service.ts` ~38 → old 23–40, `program.ts` ~875 → old 1565, `adapter-service.ts` ~899-990 → old 1021–1162).
- Behavior change (required for fix 2): lightweight `pool_snapshots` rows are now persisted every cycle in paper **and** live mode; `ENABLE_SNAPSHOT_CAPTURE` now only controls full bin-array detail (paper). Documented in AGENTS.md.
- Scope held: no Wave 2+ items (blacklist gating, phantom EXITs, risk gate order, portfolio math, HOLD spam, safety screening, screener `minBinUtilization`) touched; no cloudflare/ or mcp-server/ changes; no new `as any`/`@ts-ignore`; no new dependencies.
