### PR TITLE
fix: decision-loop correctness + safety screening (Wave 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,9 @@ DISCOVERY_MIN_FEE_RATIO=1.5
 # Dump full pool state snapshots to DB every cycle (paper only)
 ENABLE_SNAPSHOT_CAPTURE=false
 
+# Days of pool snapshot history to keep; older rows are pruned daily (default: 14)
+SNAPSHOT_RETENTION_DAYS=14
+
 # Meteora Data API base URL for real pool TVL/volume/fees (30 RPS, no auth)
 METEORA_DATA_API_URL=https://dlmm.datapi.meteora.ag
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,12 +167,12 @@ Do not import service implementations directly in program logic. `Layer.provide`
 ### Decision loop (per cycle, per pool)
 
 1. `adapter.getPoolState` + `adapter.getBinArray` fetch on-chain data (real per-bin reserves via `dlmm.getBinsAroundActiveBin`). `meteoraDatapi.getPoolData` then overlays real TVL/volume/fees from the Meteora Data API (`statsSource: "datapi"`); on API failure it logs a warning and the adapter's heuristic stats are used (`statsSource: "heuristic"`).
-2. `blacklist.checkPool` early-rejects disallowed pools (errors swallowed).
+2. Safety screening early-rejects the pool with a recorded rejected decision + audit + warning: (a) Data API `is_blacklisted=true` or `freeze_authority_disabled=false`; (b) on-chain freeze authority set on either mint (`adapter.getMintAuthorities`, mint authority doubles as the deployer fallback); (c) `blacklist.checkPool` hits the token or deployer blacklist. Positive signals fail closed; transport/IO errors (blacklist load, RPC metadata fetch, Data API down) fail open with a warning.
 3. `strategy.computeMetrics` produces pure metrics (fee/IL, volume authenticity, bin utilization, TVL velocity vs the previous `pool_snapshots` row). Metrics whose inputs are unavailable are reported as explicit "unknown" (`volumeAuthenticityKnown` / `binUtilizationKnown` on `PoolMetrics`); unknown metrics skip their pre-filter/EXIT gates with a warning and block ENTER (fail-closed), never fabricate 1.0.
 4. Pre-filter skips pools below `MIN_POOL_TVL_USD`, `VOLUME_AUTH_THRESHOLD` or `MIN_BIN_UTILIZATION`.
 5. `memory.getRelevantContext` recalls recent warnings/patterns (errors swallowed).
-6. Decision rules evaluate, in order: `EXIT` → `REBALANCE` → `HOLD` → `ENTER`.
-7. `risk.evaluate` gates execution.
+6. Decision rules evaluate, in order: `EXIT` → `REBALANCE` → `HOLD` → `ENTER`. Deterministic `EXIT` conditions (TVL drop, low fee/IL, volume authenticity, volatility gate, trailing stop) only fire for pools with a tracked position — positionless pools take the ENTER/HOLD path only.
+7. `risk.evaluate` gates execution: `EXIT` is always approved first (capital protection beats the confidence gate), then the confidence gate and remaining structural checks. `HOLD` skips risk evaluation entirely (it executes nothing; rejections used to spam warning memory and suppress the good-HOLD branch). Portfolio value for the drawdown/allocation/size gates is `walletBalanceUsd + Σ openPositions.currentValueUsd`.
 8. `audit.recordDecision` logs every decision (errors swallowed).
 9. Execution updates the in-memory `trackedPositions` Map and persists to SQLite via `db.savePosition` / `db.deletePosition`.
 
@@ -302,6 +302,7 @@ The `Dockerfile` builds the engine bundle with `oven/bun:canary-slim`, then copi
 | `MAX_PER_POOL_ALLOCATION_PCT` | `0.4`                                                              | Max portfolio share for one pool.                                                                                  |
 | `SQLITE_DB_PATH`              | `~/.local/share/prism/prism.db` (bundled) or `./prism.db` (source) | SQLite database path.                                                                                              |
 | `ENABLE_SNAPSHOT_CAPTURE`     | `false`                                                            | Store full bin-array detail in per-cycle snapshots (paper only). Lightweight per-cycle snapshot rows are always persisted — TVL velocity and IL drift need the history. |
+| `SNAPSHOT_RETENTION_DAYS`     | `14`                                                               | Days of `pool_snapshots` history to keep; older rows are pruned once per day (first cycle prunes immediately). |
 | `METEORA_DATA_API_URL`        | `https://dlmm.datapi.meteora.ag`                                   | Base URL for the Meteora Data API used to enrich pool TVL/volume/fees. On failure the engine falls back to heuristic stats with a warning.                              |
 | `EMBEDDINGS_BACKEND`          | `fallback`                                                         | `fallback` = deterministic hash vectors; `onnx` = Xenova/MiniLM (downloads ~80MB).                                 |
 | `AGENTIC_MODE`                | `false`                                                            | Enable agent runtime overlay.                                                                                      |
@@ -327,7 +328,7 @@ In test mode (`NODE_ENV=test` or `VITEST=true`), missing `HELIUS_API_KEY` defaul
 - **Embeddings default to fallback.** The ONNX backend downloads ~80MB on first use and can crash with BigInt serialization errors in Node; the engine automatically falls back.
 - **Bundled blacklists are empty.** `engine/data/deployer-blacklist.json` and `engine/data/token-blacklist.json` ship as `[]`. Override with `DEPLOYER_BLACKLIST_PATH` / `TOKEN_BLACKLIST_PATH`.
 - **Live discovery is opt-in.** Keep `ENABLE_POOL_DISCOVERY=false` and configure `WATCHLIST_POOLS` with approved pools. Automatic discovery also excludes Meteora launchpad pools.
-- **Deployer blacklist is half-wired.** `blacklist.checkPool()` accepts deployer addresses, but deployers are not currently fetched from on-chain metadata.
+- **Deployer blacklist uses the mint-authority fallback.** Each cycle the engine fetches on-chain mint authorities (`adapter.getMintAuthorities`, 1h cache) and passes the mint authority to `blacklist.checkPool()` as the deployer fallback; Metaplex update-authority metadata is not fetched. Pools flagged by the Data API (`is_blacklisted`, `freeze_authority_disabled=false`) or with an on-chain freeze authority set are rejected before metric evaluation — note this screens out freeze-authority-enabled tokens (e.g. USDC) by design.
 - **One ENTER per live cycle.** In live mode, `ENTER` is silently skipped if any position is already open.
 - **Live entry balance policy.** Live entries fail closed when requested token amount exceeds the wallet balance; they are not silently downsized.
 - **Live entry retry policy.** Deterministic insufficient-token failures are exponentially backed off per pool (30 minutes to 6 hours) to avoid repeating doomed entries and amplifying RPC load.
@@ -335,6 +336,8 @@ In test mode (`NODE_ENV=test` or `VITEST=true`), missing `HELIUS_API_KEY` defaul
 - **Scan failure semantics.** `failed` counts processing or execution failures; risk and backoff gates are rejected decisions recorded in the audit trail, not execution failures.
 - **sqlite-vec extension.** Source installs rely on `scripts/generate-vec-embed.ts` to create `engine/sqlite-vec-embedded.ts`; bundled installs provide the native extension via `PRISM_VEC0_PATH`.
 - **Backtest is a simplified simulation.** It does not replicate the full decision loop (no risk gates, memory, dynamic ENTER/EXIT sizing, trailing stop). Use it as a regression baseline, not a performance forecast.
+- **Screener bin-utilization filter is bounded.** Discovery data comes from the Data API without per-bin data, so `minBinUtilization` is enforced only for the first 10 screened candidates via an on-chain `getBinArray` probe; the rest pass through and the per-pool scan loop re-applies the gate.
+- **Risk size cap follows `MAX_PER_POOL_ALLOCATION_PCT`.** The per-position cap in `risk-service.ts` is the configured allocation pct (default 40%), not a hardcoded constant.
 - **`.env.example` is stale in places.** For example, its `UPDATE_R2_PUBLIC_URL` default does not match the code fallback. Always verify against `engine/config-service.ts`.
 
 ## Where to look first

--- a/README.md
+++ b/README.md
@@ -222,14 +222,16 @@ This returns a short markdown summary with emojis and bullets, formatted for cha
 
 Decisions pass through checks in order before any on-chain action:
 
-1. Confidence below `CONFIDENCE_THRESHOLD` -> reject
-2. Max concurrent positions reached -> reject ENTER
+1. EXIT -> always approved (capital protection beats the confidence gate)
+2. Confidence below `CONFIDENCE_THRESHOLD` -> reject
+3. Max concurrent positions reached -> reject ENTER
    - **Duplicate pool guard** -> reject ENTER if same pool already held
-3. EXIT -> always approved (capital protection)
 4. Portfolio drawdown > 10% -> pause new entries
 5. Stop-loss triggered (`STOP_LOSS_PCT` exceeded) -> reject HOLD/REBALANCE
-6. Position size > 30% of portfolio -> cap and allow
+6. Position size > `MAX_PER_POOL_ALLOCATION_PCT` (default 40%) of portfolio -> cap and allow
 7. Rebalance range > `MAX_REBALANCE_RANGE_BINS` -> reject REBALANCE
+
+HOLD executes nothing, so it skips risk evaluation entirely. Deterministic EXIT conditions only fire for pools with a tracked position.
 
 ### Rebalance-specific gates (run inside the decision loop, not at execution)
 

--- a/bench/agent-service.test.ts
+++ b/bench/agent-service.test.ts
@@ -123,6 +123,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     signalWeightCeiling: 2.5,
     weightedEntryScoreThreshold: 1.8,
     autoSwapEntry: false,
+    snapshotRetentionDays: 14,
     ...overrides,
   };
 }

--- a/bench/auto-update.test.ts
+++ b/bench/auto-update.test.ts
@@ -118,6 +118,7 @@ function buildLayer(
     signalWeightCeiling: 2.5,
     weightedEntryScoreThreshold: 1.8,
     autoSwapEntry: false,
+    snapshotRetentionDays: 14,
   });
   return Layer.merge(mockConfig, DbLive(":memory:"));
 }

--- a/bench/decision-loop-exit.test.ts
+++ b/bench/decision-loop-exit.test.ts
@@ -150,7 +150,12 @@ function makeTestLayer(opts: {
     opts.memoryRecorded
       ? Layer.succeed(MemoryService, makeRecordingMemory(opts.memoryRecorded))
       : Layer.provide(MemoryLive, dbLayer),
-    RiskLive({ confidenceThreshold: 0.65, maxRebalanceRangeBins: 50, stopLossPct: 0.15 }),
+    RiskLive({
+      confidenceThreshold: 0.65,
+      maxRebalanceRangeBins: 50,
+      stopLossPct: 0.15,
+      maxPerPoolAllocationPct: 0.4,
+    }),
     Layer.succeed(BlacklistService, {
       isDeployerBlacklisted: () => false,
       isTokenBlacklisted: () => false,

--- a/bench/decision-loop-exit.test.ts
+++ b/bench/decision-loop-exit.test.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect } from "vitest";
+import { Effect, Layer } from "effect";
+import { StrategyLive } from "../engine/strategy-service.js";
+import { program } from "../engine/program.js";
+import { DbLive } from "../engine/db-service.js";
+import { MemoryLive } from "../engine/memory-service.js";
+import { RiskLive } from "../engine/risk-service.js";
+import { AuditLive } from "../engine/audit-service.js";
+import { AgentNoOp } from "../engine/agent-service.js";
+import { AgentStateMutable } from "../engine/state-service.js";
+import { ConfigService, type AppConfig } from "../engine/config-service.js";
+import {
+  AdapterService,
+  BlacklistService,
+  AuditService,
+  ScreenerService,
+  DbService,
+  MemoryService,
+  RevenueService,
+  RevenueConfigService,
+  ReferralService,
+  AgentService,
+  McpServerService,
+  HttpStatusServerService,
+  EntryPrepService,
+  MeteoraDatapiService,
+  type AdapterApi,
+  type MemoryApi,
+  type MeteoraDatapiApi,
+  type MeteoraPoolStats,
+} from "../engine/services.js";
+import type { PoolSnapshot } from "../engine/types.js";
+import { defaultAppConfig, makePool, makeBinArray, makePosition } from "./helpers.js";
+import { stringifySafe } from "../engine/bigint-json.js";
+
+// ─── Wave 2: phantom EXITs, portfolio math, HOLD spam, snapshot retention ────
+
+type MintAuthorities = { mintAuthority: string | null; freezeAuthority: string | null };
+const NO_AUTHORITIES: MintAuthorities = { mintAuthority: null, freezeAuthority: null };
+
+function makeDatapiStats(overrides: Partial<MeteoraPoolStats> = {}): MeteoraPoolStats {
+  return {
+    address: "unset",
+    name: "TEST",
+    tvlUsd: 200_000,
+    volume24hUsd: 40_000,
+    fees24hUsd: 400,
+    apr: 20,
+    apy: 20,
+    currentPrice: 150,
+    feeTvlRatio24h: null,
+    feeTvlRatio12h: null,
+    feeTvlRatio1h: null,
+    dynamicFeePct: null,
+    baseFeePct: null,
+    hasFarm: null,
+    isBlacklisted: null,
+    tokenXFreezeAuthorityDisabled: null,
+    tokenYFreezeAuthorityDisabled: null,
+    ...overrides,
+  };
+}
+
+function makeAdapter(
+  pools: Record<string, ReturnType<typeof makePool>>,
+  overrides: Partial<AdapterApi> = {},
+): AdapterApi {
+  return {
+    hasWallet: () => false,
+    getWalletAddress: () => null,
+    getWalletBalanceUsd: () => Effect.succeed(10_000),
+    getNativeSolBalance: () => Effect.succeed(0n),
+    getPoolState: (addr: string) => {
+      const pool = pools[addr];
+      return pool ? Effect.succeed(pool) : Effect.fail(new Error(`unknown pool ${addr}`));
+    },
+    getBinArray: () => Effect.succeed(makeBinArray()),
+    getPositions: () => Effect.succeed([]),
+    getAllWalletPositions: () => Effect.succeed([]),
+    simulateRebalance: () =>
+      Effect.succeed({ estimatedIlUsd: 0, estimatedFeesUsd: 0, netBenefitUsd: 0 }),
+    enterPosition: () => Effect.succeed({ positionPubKey: "mock-pos", txSignature: "mock-tx" }),
+    exitPosition: () => Effect.succeed({ txSignature: "mock-tx" }),
+    rebalancePosition: () =>
+      Effect.succeed({ newPositionPubKey: "mock-pos", txSignatures: ["mock-tx"] }),
+    claimFees: () =>
+      Effect.succeed({
+        txSignature: "mock-tx",
+        feeX: 0,
+        feeY: 0,
+        platformFeeX: 0,
+        platformFeeY: 0,
+        netFeeX: 0,
+        netFeeY: 0,
+      }),
+    discoverPools: () => Effect.succeed([]),
+    reportFeeCollection: () => Effect.void,
+    swapUSDCForSOL: () => Effect.void,
+    getTokenBalance: () => Effect.succeed(0n),
+    getTokenPrices: () => Effect.succeed({}),
+    getTokenDecimals: () => Effect.succeed(9),
+    quoteSwapUSDCForToken: () => Effect.succeed({}),
+    swapUSDCForToken: () => Effect.succeed("mock-swap-tx"),
+    getMintAuthorities: () => Effect.succeed(NO_AUTHORITIES),
+    ...overrides,
+  } as AdapterApi;
+}
+
+interface RecordedMemory {
+  category: string;
+  content: string;
+  poolAddress?: string | undefined;
+}
+
+function makeRecordingMemory(record: RecordedMemory[]): MemoryApi {
+  return {
+    initialize: () => Effect.void,
+    upsert: (entry) =>
+      Effect.sync(() => {
+        record.push({
+          category: entry.category,
+          content: entry.content,
+          poolAddress: entry.poolAddress,
+        });
+      }),
+    getRelevantContext: () => Effect.succeed([]),
+    pruneExpired: () => Effect.succeed(0),
+    recordOutcome: () => Effect.void,
+  };
+}
+
+function makeTestLayer(opts: {
+  adapter: AdapterApi;
+  memoryRecorded?: RecordedMemory[];
+  datapi?: MeteoraDatapiApi;
+  configOverrides?: Partial<AppConfig>;
+}) {
+  const config = defaultAppConfig({
+    scanIntervalMs: 3_600_000,
+    paperTrading: true,
+    agentMcpEnabled: false,
+    agentHttpPort: 0,
+    ...opts.configOverrides,
+  });
+  const dbLayer = DbLive(":memory:");
+  return Layer.mergeAll(
+    Layer.succeed(ConfigService, config),
+    Layer.succeed(AdapterService, opts.adapter),
+    StrategyLive,
+    opts.memoryRecorded
+      ? Layer.succeed(MemoryService, makeRecordingMemory(opts.memoryRecorded))
+      : Layer.provide(MemoryLive, dbLayer),
+    RiskLive({ confidenceThreshold: 0.65, maxRebalanceRangeBins: 50, stopLossPct: 0.15 }),
+    Layer.succeed(BlacklistService, {
+      isDeployerBlacklisted: () => false,
+      isTokenBlacklisted: () => false,
+      checkPool: () => Effect.void,
+    }),
+    Layer.provide(AuditLive, dbLayer),
+    Layer.succeed(ScreenerService, { screenPools: () => Effect.succeed([]) }),
+    dbLayer,
+    Layer.succeed(RevenueService, {
+      calculateTier: () => "free",
+      calculatePlatformFee: () => ({ platformFeeUsd: 0, netFeeX: 0, netFeeY: 0 }),
+      calculateCreditDiscount: () => 0,
+    }),
+    Layer.succeed(RevenueConfigService, {
+      getConfig: () =>
+        Effect.succeed({
+          tier: "free",
+          platformFeeRate: 0,
+          revenueShareEnabled: false,
+          revenueShareOperatorPct: 0,
+          feeWalletAddress: "",
+        }),
+      refreshConfig: () =>
+        Effect.succeed({
+          tier: "free",
+          platformFeeRate: 0,
+          revenueShareEnabled: false,
+          revenueShareOperatorPct: 0,
+          feeWalletAddress: "",
+        }),
+    }),
+    Layer.succeed(ReferralService, {
+      generateCode: () => Effect.succeed("code"),
+      validateCode: () => Effect.succeed({ valid: false }),
+      applyReferral: () => Effect.void,
+      getReferralCount: () => Effect.succeed(0),
+    }),
+    Layer.succeed(AgentService, AgentNoOp),
+    AgentStateMutable({ maxPendingProposals: 50 }).layer,
+    Layer.succeed(McpServerService, { start: () => Effect.void, stop: () => Effect.void }),
+    Layer.succeed(HttpStatusServerService, { start: () => Effect.void, stop: () => Effect.void }),
+    Layer.succeed(EntryPrepService, { prepareEntryTokens: () => Effect.void }),
+    Layer.succeed(MeteoraDatapiService, opts.datapi ?? { getPoolData: () => Effect.succeed(null) }),
+  );
+}
+
+type DecisionRow = {
+  poolAddress: string;
+  action: string;
+  reasoning: string;
+  executed: boolean;
+  riskResult: { approved: boolean; reason: string };
+};
+
+async function runCycles(
+  layer: ReturnType<typeof makeTestLayer>,
+  sleepMs = 2_000,
+): Promise<ReadonlyArray<DecisionRow>> {
+  const test = Effect.gen(function* () {
+    yield* Effect.raceFirst(program, Effect.sleep(sleepMs));
+    const audit = yield* AuditService;
+    return yield* audit.getRecentDecisions(200);
+  });
+  return Effect.runPromise(
+    Effect.provide(test, layer) as Effect.Effect<ReadonlyArray<DecisionRow>, unknown, never>,
+  );
+}
+
+describe("phantom EXIT gating (Wave 2)", () => {
+  const POOL = "PoolPhantomTvl111111111111111111111111111111";
+
+  function previousSnapshot(): PoolSnapshot {
+    return {
+      poolAddress: POOL,
+      timestamp: Date.now() - 600_000,
+      activeBinId: 5000,
+      tvlUsd: 100_000, // → -40% vs current 60k (threshold 30%)
+      volume24hUsd: 30_000,
+      fees24hUsd: 300,
+      apr: 60,
+      currentPrice: 150,
+      binStep: 10,
+      tokenXSymbol: "SOL",
+      tokenYSymbol: "USDC",
+      binArray: makeBinArray(),
+    };
+  }
+
+  it("does NOT record an EXIT for a positionless pool whose TVL dropped", async () => {
+    const layer = makeTestLayer({
+      adapter: makeAdapter({ [POOL]: makePool({ address: POOL, tvlUsd: 60_000 }) }),
+      configOverrides: { watchlistPools: [POOL], tvlDropExitPct: 0.3 },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.saveSnapshot(previousSnapshot());
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const audit = yield* AuditService;
+      const decisions = yield* audit.getRecentDecisions(50);
+      const evolutionCount = yield* db
+        .getMetadata("threshold_evolution_count")
+        .pipe(Effect.catchAll(() => Effect.succeed(null)));
+      return { decisions, evolutionCount };
+    });
+    const { decisions, evolutionCount } = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<
+        { decisions: ReadonlyArray<DecisionRow>; evolutionCount: string | null },
+        unknown,
+        never
+      >,
+    );
+
+    const exits = decisions.filter((d) => d.poolAddress === POOL && d.action === "EXIT");
+    expect(
+      exits,
+      `phantom EXIT recorded for positionless pool: ${stringifySafe(exits)}`,
+    ).toHaveLength(0);
+    expect(evolutionCount === null || evolutionCount === "0").toBe(true);
+  }, 15_000);
+
+  it("DOES record an EXIT for a held pool whose TVL dropped (control)", async () => {
+    const layer = makeTestLayer({
+      adapter: makeAdapter({ [POOL]: makePool({ address: POOL, tvlUsd: 60_000 }) }),
+      configOverrides: { watchlistPools: [POOL], tvlDropExitPct: 0.3 },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(
+        makePosition({ poolAddress: POOL, depositedUsd: 1_000, currentValueUsd: 1_000 }),
+      );
+      yield* db.saveSnapshot(previousSnapshot());
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const audit = yield* AuditService;
+      return yield* audit.getRecentDecisions(50);
+    });
+    const decisions = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<ReadonlyArray<DecisionRow>, unknown, never>,
+    );
+
+    const tvlExit = decisions.find(
+      (d) => d.poolAddress === POOL && d.action === "EXIT" && d.reasoning.includes("TVL dropped"),
+    );
+    expect(tvlExit, "held pool with a TVL drop must still EXIT").toBeDefined();
+  }, 15_000);
+
+  it("does NOT set a pool cooldown for a low-yield phantom EXIT (no position)", async () => {
+    const layer = makeTestLayer({
+      // fees24hUsd 1 → fee/IL far below 0.5
+      adapter: makeAdapter({
+        [POOL]: makePool({ address: POOL, tvlUsd: 100_000, fees24hUsd: 1 }),
+      }),
+      configOverrides: { watchlistPools: [POOL] },
+    });
+
+    const test = Effect.gen(function* () {
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const audit = yield* AuditService;
+      const decisions = yield* audit.getRecentDecisions(50);
+      const db = yield* DbService;
+      const cooldown = yield* db
+        .getPoolCooldown(POOL)
+        .pipe(Effect.catchAll(() => Effect.succeed(null)));
+      return { decisions, cooldown };
+    });
+    const { decisions, cooldown } = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<
+        { decisions: ReadonlyArray<DecisionRow>; cooldown: unknown },
+        unknown,
+        never
+      >,
+    );
+
+    const exits = decisions.filter((d) => d.poolAddress === POOL && d.action === "EXIT");
+    expect(
+      exits,
+      `phantom low-yield EXIT recorded for positionless pool: ${stringifySafe(exits)}`,
+    ).toHaveLength(0);
+    expect(cooldown, `phantom EXIT set a pool cooldown: ${stringifySafe(cooldown)}`).toBeNull();
+  }, 15_000);
+});
+
+describe("portfolio value math (Wave 2)", () => {
+  const POOL_HELD = "PoolHeld111111111111111111111111111111111";
+  const POOL_NEW = "PoolNew1111111111111111111111111111111111";
+
+  it("computes the ENTER drawdown gate against wallet + open positions", async () => {
+    // Wallet: $100. Open position: deposited $950, now worth ~$902 (drifted 2
+    // bins off center) → unrealized PnL ≈ -$47.50. Against a wallet-only
+    // "portfolio" of $100 that is a 47% drawdown (ENTER blocked); against the
+    // real portfolio of ~$1002 it is ~4.7% (ENTER allowed).
+    const adapter = makeAdapter({
+      [POOL_HELD]: makePool({ address: POOL_HELD, activeBinId: 5002, fees24hUsd: 100 }),
+      [POOL_NEW]: makePool({ address: POOL_NEW }),
+    });
+    const datapi: MeteoraDatapiApi = {
+      getPoolData: (addr: string) =>
+        Effect.succeed(addr === POOL_NEW ? makeDatapiStats({ address: POOL_NEW }) : null),
+    };
+    const layer = makeTestLayer({
+      adapter,
+      datapi,
+      configOverrides: {
+        watchlistPools: [POOL_HELD, POOL_NEW],
+        paperPortfolioUsd: 100,
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(
+        makePosition({
+          poolAddress: POOL_HELD,
+          depositedUsd: 950,
+          currentValueUsd: 950,
+          lowerBinId: 4980,
+          upperBinId: 5020,
+        }),
+      );
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const audit = yield* AuditService;
+      return yield* audit.getRecentDecisions(50);
+    });
+    const decisions = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<ReadonlyArray<DecisionRow>, unknown, never>,
+    );
+
+    const enter = decisions.find((d) => d.poolAddress === POOL_NEW && d.action === "ENTER");
+    expect(
+      enter,
+      `expected an ENTER decision for the strong pool, got: ${stringifySafe(decisions.map((d) => `${d.poolAddress}:${d.action}:${d.riskResult.reason}`))}`,
+    ).toBeDefined();
+    expect(
+      enter!.riskResult.approved,
+      `ENTER wrongly rejected — drawdown gate must use wallet+positions, got: ${enter!.riskResult.reason}`,
+    ).toBe(true);
+  }, 15_000);
+});
+
+describe("HOLD decisions skip risk evaluation (Wave 2)", () => {
+  const POOL = "PoolQuiet1111111111111111111111111111111111";
+
+  it("produces no risk-rejection audit rows and no warning memories over multiple cycles", async () => {
+    const recordedMemory: RecordedMemory[] = [];
+    const layer = makeTestLayer({
+      adapter: makeAdapter({ [POOL]: makePool({ address: POOL }) }),
+      memoryRecorded: recordedMemory,
+      configOverrides: {
+        watchlistPools: [POOL],
+        scanIntervalMs: 300, // several cycles inside the 1.2s race window
+      },
+    });
+
+    const decisions = await runCycles(layer, 1_200);
+    const forPool = decisions.filter((d) => d.poolAddress === POOL);
+    expect(forPool.length, "expected at least one decision for the quiet pool").toBeGreaterThan(0);
+
+    const rejectedHolds = forPool.filter(
+      (d) => d.action === "HOLD" && d.riskResult.approved === false,
+    );
+    expect(
+      rejectedHolds,
+      `HOLD decisions were risk-rejected: ${stringifySafe(rejectedHolds.map((d) => d.riskResult.reason))}`,
+    ).toHaveLength(0);
+
+    const warnings = recordedMemory.filter((m) => m.category === "warning");
+    expect(
+      warnings,
+      `warning memories written for HOLD rejections: ${stringifySafe(warnings)}`,
+    ).toHaveLength(0);
+  }, 15_000);
+});
+
+describe("pool snapshot retention (Wave 2)", () => {
+  const POOL = "PoolRetention11111111111111111111111111111";
+
+  it("prunes snapshots older than the retention window and keeps recent ones", async () => {
+    const now = Date.now();
+    const layer = makeTestLayer({
+      adapter: makeAdapter({ [POOL]: makePool({ address: POOL }) }),
+      configOverrides: { watchlistPools: [POOL] },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.saveSnapshot({
+        poolAddress: POOL,
+        timestamp: now - 30 * 86_400_000, // 30 days old — beyond the 14d default
+        activeBinId: 5000,
+        tvlUsd: 90_000,
+        volume24hUsd: 30_000,
+        fees24hUsd: 300,
+        apr: 60,
+        currentPrice: 150,
+        binStep: 10,
+        tokenXSymbol: "SOL",
+        tokenYSymbol: "USDC",
+        binArray: makeBinArray(),
+      });
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const oldRows = yield* db.getSnapshots(POOL, 0, now - 14 * 86_400_000);
+      const recentRows = yield* db.getSnapshots(POOL, now - 14 * 86_400_000, now + 60_000);
+      return { oldRows, recentRows };
+    });
+    const { oldRows, recentRows } = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<
+        { oldRows: ReadonlyArray<PoolSnapshot>; recentRows: ReadonlyArray<PoolSnapshot> },
+        unknown,
+        never
+      >,
+    );
+
+    expect(oldRows, "30-day-old snapshot was not pruned").toHaveLength(0);
+    expect(recentRows.length, "fresh per-cycle snapshot must be retained").toBeGreaterThan(0);
+  }, 15_000);
+});

--- a/bench/decision-loop-screening.test.ts
+++ b/bench/decision-loop-screening.test.ts
@@ -142,7 +142,12 @@ function makeTestLayer(opts: {
     Layer.succeed(AdapterService, opts.adapter),
     StrategyLive,
     Layer.provide(MemoryLive, dbLayer),
-    RiskLive({ confidenceThreshold: 0.65, maxRebalanceRangeBins: 50, stopLossPct: 0.15 }),
+    RiskLive({
+      confidenceThreshold: 0.65,
+      maxRebalanceRangeBins: 50,
+      stopLossPct: 0.15,
+      maxPerPoolAllocationPct: 0.4,
+    }),
     Layer.succeed(BlacklistService, opts.blacklist),
     Layer.provide(AuditLive, dbLayer),
     Layer.succeed(ScreenerService, { screenPools: () => Effect.succeed([]) }),
@@ -369,9 +374,10 @@ describe("safety screening + blacklist enforcement (Wave 2)", () => {
 
     const decisions = await runOneCycle(layer);
     const forPool = decisions.filter((d) => d.poolAddress === POOL);
-    expect(forPool.length, "pool should still be processed when metadata is unavailable").toBeGreaterThan(
-      0,
-    );
+    expect(
+      forPool.length,
+      "pool should still be processed when metadata is unavailable",
+    ).toBeGreaterThan(0);
     expect(
       forPool.every((d) => d.riskResult.approved),
       `expected no screening rejections, got: ${stringifySafe(forPool.map((d) => d.riskResult))}`,

--- a/bench/decision-loop-screening.test.ts
+++ b/bench/decision-loop-screening.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import { Effect, Layer } from "effect";
+import { StrategyLive } from "../engine/strategy-service.js";
+import { program } from "../engine/program.js";
+import { DbLive } from "../engine/db-service.js";
+import { MemoryLive } from "../engine/memory-service.js";
+import { RiskLive } from "../engine/risk-service.js";
+import { AuditLive } from "../engine/audit-service.js";
+import { AgentNoOp } from "../engine/agent-service.js";
+import { AgentStateMutable } from "../engine/state-service.js";
+import { ConfigService, type AppConfig } from "../engine/config-service.js";
+import { BlacklistLive } from "../engine/blacklist-service.js";
+import {
+  AdapterService,
+  BlacklistService,
+  AuditService,
+  ScreenerService,
+  DbService,
+  RevenueService,
+  RevenueConfigService,
+  ReferralService,
+  AgentService,
+  McpServerService,
+  HttpStatusServerService,
+  EntryPrepService,
+  MeteoraDatapiService,
+  type AdapterApi,
+  type BlacklistApi,
+  type MeteoraDatapiApi,
+  type MeteoraPoolStats,
+} from "../engine/services.js";
+import { defaultAppConfig, makePool, makeBinArray } from "./helpers.js";
+import { stringifySafe } from "../engine/bigint-json.js";
+
+// ─── Wave 2: blacklist unswallow + safety screening ──────────────────────────
+
+const POOL = "PoolScreen11111111111111111111111111111111111";
+const TOKEN_X = "So11111111111111111111111111111111111111112";
+const TOKEN_Y = "FakeToken1111111111111111111111111111111111";
+const BAD_DEPLOYER = "BadDeployer111111111111111111111111111111";
+
+const tmpDir = path.resolve("bench/tmp-wave2-screening");
+const deployerPath = path.join(tmpDir, "deployer-blacklist.json");
+const tokenPath = path.join(tmpDir, "token-blacklist.json");
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeBlacklistFiles(deployers: ReadonlyArray<string>, tokens: ReadonlyArray<string>) {
+  fs.mkdirSync(tmpDir, { recursive: true });
+  fs.writeFileSync(deployerPath, stringifySafe(deployers));
+  fs.writeFileSync(tokenPath, stringifySafe(tokens));
+}
+
+type MintAuthorities = { mintAuthority: string | null; freezeAuthority: string | null };
+
+function makeAdapter(hooks: {
+  getMintAuthorities?: (mint: string) => Effect.Effect<MintAuthorities, unknown>;
+}): AdapterApi {
+  return {
+    hasWallet: () => false,
+    getWalletAddress: () => null,
+    getWalletBalanceUsd: () => Effect.succeed(10_000),
+    getNativeSolBalance: () => Effect.succeed(0n),
+    getPoolState: () => Effect.succeed(makePool({ address: POOL })),
+    getBinArray: () => Effect.succeed(makeBinArray()),
+    getPositions: () => Effect.succeed([]),
+    getAllWalletPositions: () => Effect.succeed([]),
+    simulateRebalance: () =>
+      Effect.succeed({ estimatedIlUsd: 0, estimatedFeesUsd: 0, netBenefitUsd: 0 }),
+    enterPosition: () => Effect.succeed({ positionPubKey: "mock-pos", txSignature: "mock-tx" }),
+    exitPosition: () => Effect.succeed({ txSignature: "mock-tx" }),
+    rebalancePosition: () =>
+      Effect.succeed({ newPositionPubKey: "mock-pos", txSignatures: ["mock-tx"] }),
+    claimFees: () =>
+      Effect.succeed({
+        txSignature: "mock-tx",
+        feeX: 0,
+        feeY: 0,
+        platformFeeX: 0,
+        platformFeeY: 0,
+        netFeeX: 0,
+        netFeeY: 0,
+      }),
+    discoverPools: () => Effect.succeed([]),
+    reportFeeCollection: () => Effect.void,
+    swapUSDCForSOL: () => Effect.void,
+    getTokenBalance: () => Effect.succeed(0n),
+    getTokenPrices: () => Effect.succeed({}),
+    getTokenDecimals: () => Effect.succeed(9),
+    quoteSwapUSDCForToken: () => Effect.succeed({}),
+    swapUSDCForToken: () => Effect.succeed("mock-swap-tx"),
+    getMintAuthorities:
+      hooks.getMintAuthorities ??
+      (() => Effect.succeed({ mintAuthority: null, freezeAuthority: null })),
+  } as AdapterApi;
+}
+
+function makeDatapiStats(overrides: Partial<MeteoraPoolStats> = {}): MeteoraPoolStats {
+  return {
+    address: POOL,
+    name: "TEST",
+    tvlUsd: 200_000,
+    volume24hUsd: 40_000,
+    fees24hUsd: 400,
+    apr: 20,
+    apy: 20,
+    currentPrice: 150,
+    feeTvlRatio24h: null,
+    feeTvlRatio12h: null,
+    feeTvlRatio1h: null,
+    dynamicFeePct: null,
+    baseFeePct: null,
+    hasFarm: null,
+    isBlacklisted: null,
+    tokenXFreezeAuthorityDisabled: null,
+    tokenYFreezeAuthorityDisabled: null,
+    ...overrides,
+  };
+}
+
+function makeTestLayer(opts: {
+  adapter: AdapterApi;
+  blacklist: BlacklistApi;
+  datapi?: MeteoraDatapiApi;
+  configOverrides?: Partial<AppConfig>;
+}) {
+  const config = defaultAppConfig({
+    watchlistPools: [POOL],
+    scanIntervalMs: 3_600_000,
+    paperTrading: true,
+    agentMcpEnabled: false,
+    agentHttpPort: 0,
+    ...opts.configOverrides,
+  });
+  const dbLayer = DbLive(":memory:");
+  return Layer.mergeAll(
+    Layer.succeed(ConfigService, config),
+    Layer.succeed(AdapterService, opts.adapter),
+    StrategyLive,
+    Layer.provide(MemoryLive, dbLayer),
+    RiskLive({ confidenceThreshold: 0.65, maxRebalanceRangeBins: 50, stopLossPct: 0.15 }),
+    Layer.succeed(BlacklistService, opts.blacklist),
+    Layer.provide(AuditLive, dbLayer),
+    Layer.succeed(ScreenerService, { screenPools: () => Effect.succeed([]) }),
+    dbLayer,
+    Layer.succeed(RevenueService, {
+      calculateTier: () => "free",
+      calculatePlatformFee: () => ({ platformFeeUsd: 0, netFeeX: 0, netFeeY: 0 }),
+      calculateCreditDiscount: () => 0,
+    }),
+    Layer.succeed(RevenueConfigService, {
+      getConfig: () =>
+        Effect.succeed({
+          tier: "free",
+          platformFeeRate: 0,
+          revenueShareEnabled: false,
+          revenueShareOperatorPct: 0,
+          feeWalletAddress: "",
+        }),
+      refreshConfig: () =>
+        Effect.succeed({
+          tier: "free",
+          platformFeeRate: 0,
+          revenueShareEnabled: false,
+          revenueShareOperatorPct: 0,
+          feeWalletAddress: "",
+        }),
+    }),
+    Layer.succeed(ReferralService, {
+      generateCode: () => Effect.succeed("code"),
+      validateCode: () => Effect.succeed({ valid: false }),
+      applyReferral: () => Effect.void,
+      getReferralCount: () => Effect.succeed(0),
+    }),
+    Layer.succeed(AgentService, AgentNoOp),
+    AgentStateMutable({ maxPendingProposals: 50 }).layer,
+    Layer.succeed(McpServerService, { start: () => Effect.void, stop: () => Effect.void }),
+    Layer.succeed(HttpStatusServerService, { start: () => Effect.void, stop: () => Effect.void }),
+    Layer.succeed(EntryPrepService, { prepareEntryTokens: () => Effect.void }),
+    Layer.succeed(MeteoraDatapiService, opts.datapi ?? { getPoolData: () => Effect.succeed(null) }),
+  );
+}
+
+async function runOneCycle(layer: ReturnType<typeof makeTestLayer>) {
+  const test = Effect.gen(function* () {
+    // program loops forever on the scheduler; race it against a timer so the
+    // first (immediate) scan cycle runs and then we interrupt it.
+    yield* Effect.raceFirst(program, Effect.sleep(2_000));
+    const audit = yield* AuditService;
+    return yield* audit.getRecentDecisions(50);
+  });
+  return Effect.runPromise(
+    Effect.provide(test, layer) as Effect.Effect<
+      ReadonlyArray<{
+        poolAddress: string;
+        action: string;
+        reasoning: string;
+        riskResult: { approved: boolean; reason: string };
+      }>,
+      unknown,
+      never
+    >,
+  );
+}
+
+describe("safety screening + blacklist enforcement (Wave 2)", () => {
+  it("rejects a pool whose token mint is blacklisted (fail-closed, recorded)", async () => {
+    writeBlacklistFiles([], [TOKEN_Y]);
+    const layer = makeTestLayer({
+      adapter: makeAdapter({}),
+      blacklist: Effect.runSync(
+        Effect.provide(
+          Effect.gen(function* () {
+            return yield* BlacklistService;
+          }),
+          BlacklistLive({ deployerBlacklistPath: deployerPath, tokenBlacklistPath: tokenPath }),
+        ),
+      ),
+    });
+
+    const decisions = await runOneCycle(layer);
+    const forPool = decisions.filter((d) => d.poolAddress === POOL);
+    expect(
+      forPool,
+      `expected exactly one recorded (rejected) decision, got: ${stringifySafe(forPool)}`,
+    ).toHaveLength(1);
+    expect(forPool[0]!.riskResult.approved).toBe(false);
+    expect(forPool[0]!.reasoning.toLowerCase()).toContain("blacklist");
+  }, 15_000);
+
+  it("rejects a pool whose token deployer (on-chain mint authority) is blacklisted", async () => {
+    writeBlacklistFiles([BAD_DEPLOYER], []);
+    const layer = makeTestLayer({
+      adapter: makeAdapter({
+        getMintAuthorities: (mint: string) =>
+          Effect.succeed({
+            mintAuthority: mint === TOKEN_X ? BAD_DEPLOYER : null,
+            freezeAuthority: null,
+          }),
+      }),
+      blacklist: Effect.runSync(
+        Effect.provide(
+          Effect.gen(function* () {
+            return yield* BlacklistService;
+          }),
+          BlacklistLive({ deployerBlacklistPath: deployerPath, tokenBlacklistPath: tokenPath }),
+        ),
+      ),
+    });
+
+    const decisions = await runOneCycle(layer);
+    const forPool = decisions.filter((d) => d.poolAddress === POOL);
+    expect(
+      forPool,
+      `expected exactly one recorded (rejected) decision, got: ${stringifySafe(forPool)}`,
+    ).toHaveLength(1);
+    expect(forPool[0]!.riskResult.approved).toBe(false);
+    expect(forPool[0]!.reasoning.toLowerCase()).toContain("deployer");
+  }, 15_000);
+
+  it("fails open when the blacklist service throws a non-BlacklistError (transport error)", async () => {
+    const layer = makeTestLayer({
+      adapter: makeAdapter({}),
+      blacklist: {
+        isDeployerBlacklisted: () => false,
+        isTokenBlacklisted: () => false,
+        checkPool: () => Effect.fail(new Error("disk on fire")),
+      },
+    });
+
+    const decisions = await runOneCycle(layer);
+    const forPool = decisions.filter((d) => d.poolAddress === POOL);
+    expect(
+      forPool.length,
+      "pool should still be processed when the blacklist transport fails",
+    ).toBeGreaterThan(0);
+    expect(
+      forPool.every((d) => d.riskResult.approved),
+      `expected no risk/screening rejections, got: ${stringifySafe(forPool.map((d) => d.riskResult))}`,
+    ).toBe(true);
+  }, 15_000);
+
+  it("rejects a pool the Meteora Data API flags as is_blacklisted", async () => {
+    const layer = makeTestLayer({
+      adapter: makeAdapter({}),
+      blacklist: {
+        isDeployerBlacklisted: () => false,
+        isTokenBlacklisted: () => false,
+        checkPool: () => Effect.void,
+      },
+      datapi: { getPoolData: () => Effect.succeed(makeDatapiStats({ isBlacklisted: true })) },
+    });
+
+    const decisions = await runOneCycle(layer);
+    const forPool = decisions.filter((d) => d.poolAddress === POOL);
+    expect(
+      forPool,
+      `expected exactly one recorded (rejected) decision, got: ${stringifySafe(forPool)}`,
+    ).toHaveLength(1);
+    expect(forPool[0]!.riskResult.approved).toBe(false);
+    expect(forPool[0]!.reasoning.toLowerCase()).toContain("blacklist");
+  }, 15_000);
+
+  it("rejects a pool whose token has freeze authority enabled per the Data API", async () => {
+    const layer = makeTestLayer({
+      adapter: makeAdapter({}),
+      blacklist: {
+        isDeployerBlacklisted: () => false,
+        isTokenBlacklisted: () => false,
+        checkPool: () => Effect.void,
+      },
+      datapi: {
+        getPoolData: () =>
+          Effect.succeed(makeDatapiStats({ tokenXFreezeAuthorityDisabled: false })),
+      },
+    });
+
+    const decisions = await runOneCycle(layer);
+    const forPool = decisions.filter((d) => d.poolAddress === POOL);
+    expect(
+      forPool,
+      `expected exactly one recorded (rejected) decision, got: ${stringifySafe(forPool)}`,
+    ).toHaveLength(1);
+    expect(forPool[0]!.riskResult.approved).toBe(false);
+    expect(forPool[0]!.reasoning.toLowerCase()).toContain("freeze authority");
+  }, 15_000);
+
+  it("rejects a pool whose token has an on-chain freeze authority set", async () => {
+    const layer = makeTestLayer({
+      adapter: makeAdapter({
+        getMintAuthorities: (mint: string) =>
+          Effect.succeed({
+            mintAuthority: null,
+            freezeAuthority: mint === TOKEN_Y ? "FreezeAuth1111111111111111111111111" : null,
+          }),
+      }),
+      blacklist: {
+        isDeployerBlacklisted: () => false,
+        isTokenBlacklisted: () => false,
+        checkPool: () => Effect.void,
+      },
+    });
+
+    const decisions = await runOneCycle(layer);
+    const forPool = decisions.filter((d) => d.poolAddress === POOL);
+    expect(
+      forPool,
+      `expected exactly one recorded (rejected) decision, got: ${stringifySafe(forPool)}`,
+    ).toHaveLength(1);
+    expect(forPool[0]!.riskResult.approved).toBe(false);
+    expect(forPool[0]!.reasoning.toLowerCase()).toContain("freeze authority");
+  }, 15_000);
+
+  it("fails open when the mint-authority RPC lookup fails (metadata unavailable)", async () => {
+    const layer = makeTestLayer({
+      adapter: makeAdapter({
+        getMintAuthorities: () => Effect.fail(new Error("RPC unreachable")),
+      }),
+      blacklist: {
+        isDeployerBlacklisted: () => false,
+        isTokenBlacklisted: () => false,
+        checkPool: () => Effect.void,
+      },
+    });
+
+    const decisions = await runOneCycle(layer);
+    const forPool = decisions.filter((d) => d.poolAddress === POOL);
+    expect(forPool.length, "pool should still be processed when metadata is unavailable").toBeGreaterThan(
+      0,
+    );
+    expect(
+      forPool.every((d) => d.riskResult.approved),
+      `expected no screening rejections, got: ${stringifySafe(forPool.map((d) => d.riskResult))}`,
+    ).toBe(true);
+  }, 15_000);
+});

--- a/bench/entry-prep.test.ts
+++ b/bench/entry-prep.test.ts
@@ -63,6 +63,7 @@ function makeAdapter(mock: Partial<AdapterApi> = {}): AdapterApi {
     getTokenBalance: (mint: string) => Effect.succeed(mint === USDC_MINT ? 10_000_000_000n : 0n),
     getTokenPrices: () => Effect.succeed({ [TOKEN_X]: 150, [TOKEN_Y]: 1 }),
     getTokenDecimals: () => Effect.succeed(9),
+    getMintAuthorities: () => Effect.succeed({ mintAuthority: null, freezeAuthority: null }),
     quoteSwapUSDCForToken: () =>
       Effect.succeed({ routePlan: [{ swapInfo: {} }], outAmount: "10000000000000" }),
     swapUSDCForToken: () => Effect.succeed("mock-swap-tx"),

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -137,6 +137,7 @@ function buildLayer(
     signalWeightCeiling: 2.5,
     weightedEntryScoreThreshold: 1.8,
     autoSwapEntry: false,
+    snapshotRetentionDays: 14,
   });
   const baseLayer = Layer.merge(mockConfig, DbLive(":memory:"));
   return Layer.provide(FeedbackLive, baseLayer) as Layer.Layer<FeedbackService, never, never>;

--- a/bench/helpers.ts
+++ b/bench/helpers.ts
@@ -183,6 +183,7 @@ export function defaultAppConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     signalWeightCeiling: 2.5,
     weightedEntryScoreThreshold: 1.8,
     autoSwapEntry: false,
+    snapshotRetentionDays: 14,
     ...overrides,
   };
 }

--- a/bench/http-status-server.test.ts
+++ b/bench/http-status-server.test.ts
@@ -107,6 +107,7 @@ function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     signalWeightCeiling: 2.5,
     weightedEntryScoreThreshold: 1.8,
     autoSwapEntry: false,
+    snapshotRetentionDays: 14,
     ...overrides,
   };
 }

--- a/bench/mcp-server.test.ts
+++ b/bench/mcp-server.test.ts
@@ -106,6 +106,7 @@ function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     signalWeightCeiling: 2.5,
     weightedEntryScoreThreshold: 1.8,
     autoSwapEntry: false,
+    snapshotRetentionDays: 14,
     ...overrides,
   };
 }

--- a/bench/metrics-tvl-exit.test.ts
+++ b/bench/metrics-tvl-exit.test.ts
@@ -69,6 +69,7 @@ describe("evaluatePool TVL-drop EXIT (integration)", () => {
       getTokenBalance: () => Effect.succeed(0n),
       getTokenPrices: () => Effect.succeed({}),
       getTokenDecimals: () => Effect.succeed(9),
+      getMintAuthorities: () => Effect.succeed({ mintAuthority: null, freezeAuthority: null }),
       quoteSwapUSDCForToken: () => Effect.succeed({}),
       swapUSDCForToken: () => Effect.succeed("mock-swap-tx"),
     };
@@ -94,7 +95,12 @@ describe("evaluatePool TVL-drop EXIT (integration)", () => {
       Layer.succeed(AdapterService, makeAdapter()),
       StrategyLive,
       Layer.provide(MemoryLive, dbLayer),
-      RiskLive({ confidenceThreshold: 0.65, maxRebalanceRangeBins: 50, stopLossPct: 0.15 }),
+      RiskLive({
+        confidenceThreshold: 0.65,
+        maxRebalanceRangeBins: 50,
+        stopLossPct: 0.15,
+        maxPerPoolAllocationPct: 0.4,
+      }),
       Layer.succeed(BlacklistService, {
         isDeployerBlacklisted: () => false,
         isTokenBlacklisted: () => false,

--- a/bench/program.test.ts
+++ b/bench/program.test.ts
@@ -119,6 +119,7 @@ describe("executeLive", () => {
       getTokenBalance: () => Effect.succeed(0n),
       getTokenPrices: () => Effect.succeed({}),
       getTokenDecimals: () => Effect.succeed(9),
+      getMintAuthorities: () => Effect.succeed({ mintAuthority: null, freezeAuthority: null }),
       quoteSwapUSDCForToken: () =>
         Effect.succeed({ routePlan: [{ swapInfo: {} }], outAmount: "10000000000000" }),
       swapUSDCForToken: () => Effect.succeed("mock-swap-tx"),

--- a/bench/reconcile-positions.test.ts
+++ b/bench/reconcile-positions.test.ts
@@ -19,6 +19,7 @@ function makeMockAdapter(overrides: Partial<AdapterApi> = {}): AdapterApi {
     getTokenBalance: () => Effect.succeed(0n),
     getTokenPrices: () => Effect.succeed({}),
     getTokenDecimals: () => Effect.succeed(6),
+    getMintAuthorities: () => Effect.succeed({ mintAuthority: null, freezeAuthority: null }),
     quoteSwapUSDCForToken: () => Effect.fail("not implemented"),
     swapUSDCForToken: () => Effect.fail("not implemented"),
     getPoolState: () => Effect.fail("not implemented"),

--- a/bench/revenue-reporter.test.ts
+++ b/bench/revenue-reporter.test.ts
@@ -40,6 +40,7 @@ function makeTestAdapterLayer() {
     getTokenBalance: () => Effect.succeed(0n),
     getTokenPrices: () => Effect.succeed({}),
     getTokenDecimals: () => Effect.succeed(6),
+    getMintAuthorities: () => Effect.succeed({ mintAuthority: null, freezeAuthority: null }),
     quoteSwapUSDCForToken: () => Effect.fail("not implemented"),
     swapUSDCForToken: () => Effect.fail("not implemented"),
     getPoolState: () => Effect.fail("not implemented"),

--- a/bench/revenue-split.test.ts
+++ b/bench/revenue-split.test.ts
@@ -111,6 +111,7 @@ function buildLayer() {
     signalWeightCeiling: 2.5,
     weightedEntryScoreThreshold: 1.8,
     autoSwapEntry: false,
+    snapshotRetentionDays: 14,
   });
   const baseLayer = Layer.merge(mockConfig, DbLive(":memory:"));
   return Layer.merge(Layer.provide(AuditLive, DbLive(":memory:")), baseLayer);

--- a/bench/risk-service.test.ts
+++ b/bench/risk-service.test.ts
@@ -57,6 +57,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     sqliteDbPath: ":memory:",
     enableSnapshotCapture: false,
     autoSwapEntry: false,
+    snapshotRetentionDays: 14,
     autoUpdate: true,
     updateCheckIntervalMs: 86_400_000,
     updateChannel: "stable",

--- a/bench/risk.test.ts
+++ b/bench/risk.test.ts
@@ -51,6 +51,7 @@ describe("RiskEngine", () => {
     confidenceThreshold: 0.65,
     maxRebalanceRangeBins: 50,
     stopLossPct: 0.15,
+    maxPerPoolAllocationPct: 0.3,
   };
 
   describe("confidence gate", () => {
@@ -74,6 +75,21 @@ describe("RiskEngine", () => {
       const result = evaluateRisk(riskConfig, decision, makeContext({ recentPnlUsd: -5000 }));
       expect(result.approved).toBe(true);
     });
+
+    it("approves EXIT below the confidence threshold (capital protection beats confidence)", () => {
+      const strictConfig = { ...riskConfig, confidenceThreshold: 0.9 };
+      const decision = makeDecision({ action: "EXIT", confidence: 0.3 });
+      const result = evaluateRisk(strictConfig, decision, makeContext());
+      expect(result.approved).toBe(true);
+    });
+
+    it("rejects ENTER below the confidence threshold", () => {
+      const strictConfig = { ...riskConfig, confidenceThreshold: 0.9 };
+      const decision = makeDecision({ action: "ENTER", confidence: 0.3, positionSizeUsd: 100 });
+      const result = evaluateRisk(strictConfig, decision, makeContext());
+      expect(result.approved).toBe(false);
+      expect(result.reason).toContain("Confidence");
+    });
   });
 
   describe("drawdown gate", () => {
@@ -95,6 +111,19 @@ describe("RiskEngine", () => {
       const result = evaluateRisk(riskConfig, decision, makeContext({ portfolioValueUsd: 10_000 }));
       expect(result.approved).toBe(true);
       expect(result.adjustedSizeUsd).toBe(3000);
+    });
+
+    it("derives the cap from maxPerPoolAllocationPct (config, not hardcode)", () => {
+      const config25 = { ...riskConfig, maxPerPoolAllocationPct: 0.25 };
+      const decision = makeDecision({ action: "ENTER", confidence: 0.8, positionSizeUsd: 5000 });
+      const result = evaluateRisk(
+        config25,
+        decision,
+        makeContext({ portfolioValueUsd: 10_000 }),
+      );
+      expect(result.approved).toBe(true);
+      expect(result.adjustedSizeUsd).toBe(2500);
+      expect(result.reason).toContain("25%");
     });
   });
 

--- a/bench/risk.test.ts
+++ b/bench/risk.test.ts
@@ -116,11 +116,7 @@ describe("RiskEngine", () => {
     it("derives the cap from maxPerPoolAllocationPct (config, not hardcode)", () => {
       const config25 = { ...riskConfig, maxPerPoolAllocationPct: 0.25 };
       const decision = makeDecision({ action: "ENTER", confidence: 0.8, positionSizeUsd: 5000 });
-      const result = evaluateRisk(
-        config25,
-        decision,
-        makeContext({ portfolioValueUsd: 10_000 }),
-      );
+      const result = evaluateRisk(config25, decision, makeContext({ portfolioValueUsd: 10_000 }));
       expect(result.approved).toBe(true);
       expect(result.adjustedSizeUsd).toBe(2500);
       expect(result.reason).toContain("25%");

--- a/bench/screener-discover.test.ts
+++ b/bench/screener-discover.test.ts
@@ -240,4 +240,57 @@ describe("ScreenerService.screenPools", () => {
       restore();
     }
   });
+
+  it("filters out candidates whose on-chain bin utilization is below minBinUtilization", async () => {
+    const POOL_A = "PoolHighUtil11111111111111111111111111111";
+    const POOL_B = "PoolLowUtil111111111111111111111111111111";
+    const discovered = [POOL_A, POOL_B].map((address) => ({
+      address,
+      tvlUsd: 2_000_000,
+      volume24hUsd: 1_000_000,
+      fees24hUsd: 10_000,
+      apr: 180,
+      binStep: 10,
+      tokenX: "TokenX111111111111111111111111111111111111",
+      tokenY: "TokenY111111111111111111111111111111111111",
+    }));
+    const makeBins = (activeCount: number) => ({
+      lowerBinId: 4990,
+      upperBinId: 4999,
+      activeBinId: 5000,
+      bins: Array.from({ length: 10 }, (_, i) => ({
+        binId: 4990 + i,
+        price: 150,
+        reserveX: i < activeCount ? BigInt(1_000_000) : 0n,
+        reserveY: i < activeCount ? BigInt(1_000_000) : 0n,
+        liquiditySupply: i < activeCount ? BigInt(1_000_000_000) : 0n,
+      })),
+    });
+    const adapterLayer = Layer.succeed(AdapterService, {
+      discoverPools: () => Effect.succeed(discovered),
+      getBinArray: (address: string) =>
+        Effect.succeed(address === POOL_A ? makeBins(10) : makeBins(1)),
+    } as never);
+    const configLayer = Layer.succeed(ConfigService, makeConfig());
+    const layer = Layer.provide(
+      ScreenerLive({
+        minTvlUsd: 100_000,
+        minFeeRatio: 1.5,
+        volumeAuthThreshold: 0.7,
+        minBinUtilization: 0.3,
+      }),
+      Layer.merge(configLayer, Layer.merge(adapterLayer, StrategyLive)),
+    );
+
+    const program = Effect.gen(function* () {
+      const screener = yield* ScreenerService;
+      return yield* screener.screenPools();
+    });
+    const screened = await Effect.runPromise(Effect.provide(program, layer));
+    const addresses = screened.map((p) => p.address);
+    expect(
+      addresses,
+      `low-utilization pool must be filtered out, got: ${JSON.stringify(addresses)}`,
+    ).toEqual([POOL_A]);
+  });
 });

--- a/bench/screener-discover.test.ts
+++ b/bench/screener-discover.test.ts
@@ -117,6 +117,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     signalWeightCeiling: 2.5,
     weightedEntryScoreThreshold: 1.8,
     autoSwapEntry: false,
+    snapshotRetentionDays: 14,
 
     ...overrides,
   };

--- a/bench/update-check.test.ts
+++ b/bench/update-check.test.ts
@@ -120,6 +120,7 @@ function buildLayer(
     signalWeightCeiling: 2.5,
     weightedEntryScoreThreshold: 1.8,
     autoSwapEntry: false,
+    snapshotRetentionDays: 14,
   });
   return Layer.merge(mockConfig, DbLive(":memory:"));
 }

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -435,6 +435,45 @@ export const AdapterLive = Layer.effect(
     const tokenMetaCache = new Map<string, TokenMeta>();
     const HELIUS_ASSET_CACHE_TTL_MS = 5 * 60 * 1000;
 
+    // Mint authorities are quasi-static (revocation is one-way), so a long TTL
+    // is safe and keeps the per-cycle safety screening to one RPC call per
+    // mint per hour.
+    const MINT_AUTHORITIES_CACHE_TTL_MS = 60 * 60 * 1000;
+    interface MintAuthoritiesEntry {
+      readonly mintAuthority: string | null;
+      readonly freezeAuthority: string | null;
+      readonly fetchedAt: number;
+    }
+    const mintAuthoritiesCache = new Map<string, MintAuthoritiesEntry>();
+
+    function getMintAuthorities(
+      mintAddress: string,
+    ): Effect.Effect<{ mintAuthority: string | null; freezeAuthority: string | null }, unknown> {
+      return Effect.gen(function* () {
+        const cached = mintAuthoritiesCache.get(mintAddress);
+        if (cached && Date.now() - cached.fetchedAt < MINT_AUTHORITIES_CACHE_TTL_MS) {
+          return { mintAuthority: cached.mintAuthority, freezeAuthority: cached.freezeAuthority };
+        }
+        const mintPubkey = new PublicKey(mintAddress);
+        const info = yield* rpcCall((conn) => conn.getParsedAccountInfo(mintPubkey));
+        const parsed = (
+          info.value?.data as {
+            parsed?: { info?: { mintAuthority?: unknown; freezeAuthority?: unknown } };
+          }
+        )?.parsed?.info;
+        const mintAuthority =
+          typeof parsed?.mintAuthority === "string" ? parsed.mintAuthority : null;
+        const freezeAuthority =
+          typeof parsed?.freezeAuthority === "string" ? parsed.freezeAuthority : null;
+        mintAuthoritiesCache.set(mintAddress, {
+          mintAuthority,
+          freezeAuthority,
+          fetchedAt: Date.now(),
+        });
+        return { mintAuthority, freezeAuthority };
+      });
+    }
+
     function readHeliusPrice(asset: HeliusAssetResponse): number | undefined {
       const priceInfo = asset.result?.token_info?.price_info;
       const price = priceInfo?.price_per_token;
@@ -1088,6 +1127,8 @@ export const AdapterLive = Layer.effect(
 
       getTokenDecimals: (mintAddress: string) =>
         getTokenMeta(mintAddress).pipe(Effect.map((m) => m.decimals)),
+
+      getMintAuthorities: (mintAddress: string) => getMintAuthorities(mintAddress),
 
       getPoolState: (poolAddress) =>
         Effect.gen(function* () {

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -33,6 +33,8 @@ export interface AppConfig {
   readonly tokenBlacklistPath: string;
   readonly sqliteDbPath: string;
   readonly enableSnapshotCapture: boolean;
+  /** Days of pool_snapshots history to keep; older rows are pruned daily. Default 14. */
+  readonly snapshotRetentionDays: number;
   // Auto-update settings
   readonly autoUpdate: boolean;
   readonly updateCheckIntervalMs: number;
@@ -499,6 +501,7 @@ const loadConfig = Effect.gen(function* () {
   const enableSnapshotCapture = yield* Config.boolean("ENABLE_SNAPSHOT_CAPTURE").pipe(
     Effect.orElseSucceed(() => false),
   );
+  const snapshotRetentionDays = yield* validatedNumber("SNAPSHOT_RETENTION_DAYS", 1, 14);
 
   // Auto-update config
   const autoUpdate = yield* Config.boolean("AUTO_UPDATE").pipe(Effect.orElseSucceed(() => true));
@@ -582,6 +585,7 @@ const loadConfig = Effect.gen(function* () {
     tokenBlacklistPath,
     sqliteDbPath,
     enableSnapshotCapture,
+    snapshotRetentionDays,
     autoUpdate,
     updateCheckIntervalMs,
     updateChannel,

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -39,7 +39,7 @@ import { shouldDiscoverPools } from "./pool-policy.js";
 
 import { checkForAutoUpdate } from "./update-check.js";
 import type { PositionRecord } from "./db-service.js";
-import { DiscoverPoolsError } from "./errors.js";
+import { BlacklistError, DiscoverPoolsError } from "./errors.js";
 import {
   GAS_TOP_UP_USDC,
   SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS,
@@ -66,6 +66,7 @@ import {
   type AdapterApi,
   type DbApi,
   type MemoryApi,
+  type RiskResult,
   type ScreenedPool,
   type StrategyApi,
   type RevenueConfigApi,
@@ -110,6 +111,9 @@ const logger = createLogger("program");
  * indexed on (pool_address, timestamp) so this stays cheap.
  */
 const PREVIOUS_SNAPSHOT_WINDOW_MS = 26 * 60 * 60 * 1000;
+
+/** How often pool_snapshots pruning runs (rows older than the retention window are deleted). */
+const SNAPSHOT_PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 export function isProposalStale(proposal: AgentProposal, staleMs: number, now: number): boolean {
   return now > proposal.proposedAt + staleMs || now > proposal.expiresAt;
@@ -476,6 +480,7 @@ export function buildLayer(cfg?: AppConfig): Layer.Layer<AllServices, never, nev
     confidenceThreshold: cfg?.confidenceThreshold ?? 0.65,
     maxRebalanceRangeBins: cfg?.maxRebalanceRangeBins ?? 50,
     stopLossPct: cfg?.stopLossPct ?? 0.15,
+    maxPerPoolAllocationPct: cfg?.maxPerPoolAllocationPct ?? 0.4,
   });
   const blacklist = BlacklistLive({
     deployerBlacklistPath: cfg?.deployerBlacklistPath ?? "./engine/data/deployer-blacklist.json",
@@ -963,6 +968,7 @@ export const program = Effect.gen(function* () {
   let scanCount = 0;
   let lastAgentCheckinAt = 0;
   let lastWalletBalanceUsd = config.paperPortfolioUsd;
+  let lastSnapshotPruneAt = 0;
 
   // F2: per-pool recent active-bin history (in-memory ring buffer; resets on restart)
   const binHistoryCap = Math.max(
@@ -1358,6 +1364,23 @@ export const program = Effect.gen(function* () {
       // Prune expired memories after each cycle
       yield* memory.pruneExpired().pipe(Effect.catchAll(() => Effect.void));
 
+      // Prune pool_snapshots past the retention window (they grow every
+      // cycle). Runs at most once per day; the first cycle prunes immediately.
+      const nowForPrune = Date.now();
+      if (nowForPrune - lastSnapshotPruneAt > SNAPSHOT_PRUNE_INTERVAL_MS) {
+        lastSnapshotPruneAt = nowForPrune;
+        const cutoff = nowForPrune - config.snapshotRetentionDays * 86_400_000;
+        const pruned = yield* db
+          .pruneSnapshots(cutoff)
+          .pipe(Effect.catchAll(() => Effect.succeed(0)));
+        if (pruned > 0) {
+          console.info("[snapshot-retention] Pruned old pool snapshots", {
+            pruned,
+            retentionDays: config.snapshotRetentionDays,
+          });
+        }
+      }
+
       scanCount += 1;
       yield* maybeSendAgentCheckin("periodic").pipe(Effect.catchAll(() => Effect.void));
       yield* refreshAgentState();
@@ -1595,11 +1618,98 @@ export const program = Effect.gen(function* () {
           }),
         );
 
-      // Blacklist check (token mints only; deployer info not yet fetched)
-      // TODO: fetch token deployer/authority from on-chain metadata and pass to checkPool
-      yield* blacklist
-        .checkPool(poolAddress, pool.tokenX, pool.tokenY)
-        .pipe(Effect.catchAll(() => Effect.void));
+      // Safety screening (fail-closed on positive signals, fail-open on
+      // transport errors):
+      // 1. Meteora Data API flags: is_blacklisted, freeze_authority_disabled.
+      // 2. On-chain mint accounts: freeze authority enabled → reject; mint
+      //    authority doubles as the documented deployer fallback for the
+      //    deployer blacklist.
+      // 3. Token + deployer blacklist: a loaded blacklist hit rejects the
+      //    pool; only unexpected transport/IO errors are swallowed.
+      const rejectForSafety = (reason: string): Effect.Effect<null> =>
+        Effect.gen(function* () {
+          logger.warn("Pool rejected by safety screening", { pool: poolAddress, reason });
+          yield* audit
+            .recordDecision({
+              timestamp: Date.now(),
+              cycleId,
+              poolAddress,
+              action: "HOLD",
+              confidence: 0,
+              reasoning: `[safety] ${reason}`,
+              riskResult: { approved: false, reason: `[safety] ${reason}` },
+              executed: false,
+              paperTrading: config.paperTrading,
+            })
+            .pipe(Effect.catchAll(() => Effect.void));
+          yield* memory
+            .upsert({
+              category: "warning",
+              content: `Safety screening rejected ${poolAddress}: ${reason}`,
+              poolAddress,
+            })
+            .pipe(Effect.catchAll(() => Effect.void));
+          return null;
+        });
+
+      if (datapiStats?.isBlacklisted === true) {
+        return yield* rejectForSafety("Meteora Data API flags pool as blacklisted");
+      }
+
+      const fetchAuthorities = (mint: string) =>
+        adapter.getMintAuthorities(mint).pipe(
+          Effect.catchAll((err) => {
+            logger.warn(
+              "Mint authority fetch failed — skipping on-chain authority screening (fail-open)",
+              { pool: poolAddress, mint, err: String(err) },
+            );
+            return Effect.succeed(null);
+          }),
+        );
+      const [authX, authY] = yield* Effect.all([
+        fetchAuthorities(pool.tokenX),
+        fetchAuthorities(pool.tokenY),
+      ]);
+
+      const freezeEnabledX =
+        datapiStats?.tokenXFreezeAuthorityDisabled === false || authX?.freezeAuthority != null;
+      const freezeEnabledY =
+        datapiStats?.tokenYFreezeAuthorityDisabled === false || authY?.freezeAuthority != null;
+      if (freezeEnabledX || freezeEnabledY) {
+        const which = [
+          freezeEnabledX ? `token X (${pool.tokenXSymbol})` : null,
+          freezeEnabledY ? `token Y (${pool.tokenYSymbol})` : null,
+        ]
+          .filter((s) => s !== null)
+          .join(" and ");
+        return yield* rejectForSafety(`Freeze authority enabled on ${which}`);
+      }
+
+      const blacklistRejection = yield* blacklist
+        .checkPool(
+          poolAddress,
+          pool.tokenX,
+          pool.tokenY,
+          authX?.mintAuthority ?? undefined,
+          authY?.mintAuthority ?? undefined,
+        )
+        .pipe(
+          Effect.as(null as string | null),
+          Effect.catchIf(
+            (err): err is BlacklistError => err instanceof BlacklistError,
+            (err) => Effect.succeed(err.message),
+          ),
+          Effect.catchAll((err) => {
+            logger.warn("Blacklist check failed — proceeding (fail-open)", {
+              pool: poolAddress,
+              err: String(err),
+            });
+            return Effect.succeed(null);
+          }),
+        );
+      if (blacklistRejection !== null) {
+        return yield* rejectForSafety(blacklistRejection);
+      }
 
       const metrics = strategy.computeMetrics(
         pool,
@@ -1722,8 +1832,11 @@ export const program = Effect.gen(function* () {
         yield* db.savePosition(pos).pipe(Effect.catchAll(() => Effect.void));
       }
 
-      // EXIT conditions (capital protection)
-      if (tvlVelocity < -config.tvlDropExitPct) {
+      // EXIT conditions (capital protection). Gated on hasPosition: pools
+      // without a position take the ENTER/HOLD path only — a positionless
+      // "EXIT" would be a phantom record that also arms cooldowns and the
+      // threshold-evolution counter for capital we never deployed.
+      if (hasPosition && tvlVelocity < -config.tvlDropExitPct) {
         decision = {
           action: "EXIT",
           poolAddress,
@@ -1744,6 +1857,7 @@ export const program = Effect.gen(function* () {
           { pool, metrics, position: pos ?? undefined },
         );
       } else if (
+        hasPosition &&
         metrics.volumeAuthenticityKnown &&
         volumeAuth < evolvedThresholds.volumeAuthThreshold
       ) {
@@ -1759,7 +1873,7 @@ export const program = Effect.gen(function* () {
           `Volume authenticity ${volumeAuth.toFixed(2)} below threshold on ${pool.tokenXSymbol}/${pool.tokenYSymbol} — EXIT`,
           { pool, metrics, position: pos ?? undefined },
         );
-      } else if (feeIlRatio < 0.5) {
+      } else if (hasPosition && feeIlRatio < 0.5) {
         decision = {
           action: "EXIT",
           poolAddress,
@@ -1895,6 +2009,14 @@ export const program = Effect.gen(function* () {
           )
         : config.paperPortfolioUsd;
       lastWalletBalanceUsd = walletBalanceUsd;
+
+      // Portfolio value = wallet + open positions (mirrors refreshAgentState).
+      // Using the wallet alone shrinks the drawdown/allocation/size gates as
+      // positions grow, tightening risk limits exactly when capital is deployed.
+      const openPositions = Array.from(trackedPositions.values()).map(toRiskPosition);
+      const portfolioValueUsd =
+        walletBalanceUsd + openPositions.reduce((sum, p) => sum + p.currentValueUsd, 0);
+      const recentPnlUsd = openPositions.reduce((sum, pos) => sum + pos.unrealizedPnlUsd, 0);
 
       // REBALANCE check
       if (!decision) {
@@ -2191,13 +2313,11 @@ export const program = Effect.gen(function* () {
 
               // F5: per-pool allocation cap — split across maxOpenPositions pools
               // so a single SOL/USDC exposure doesn't dominate the portfolio.
-              // F5 fix: use the actual fetched wallet balance (live) or paper
-              // portfolio default (paper) as portfolioValueUsd. Previously this
-              // hardcoded config.paperPortfolioUsd which made live caps wrong.
+              // portfolioValueUsd includes open positions (see above).
               const allocation = evaluatePerPoolAllocation({
                 proposedDepositUsd: proposedSizeUsd,
-                portfolioValueUsd: walletBalanceUsd,
-                openPositions: Array.from(trackedPositions.values()).map(toRiskPosition),
+                portfolioValueUsd,
+                openPositions,
                 maxPerPoolAllocationPct: config.maxPerPoolAllocationPct,
                 maxOpenPositions: config.maxOpenPositions,
               });
@@ -2248,10 +2368,6 @@ export const program = Effect.gen(function* () {
           reasoning: `No strong signal. Fee/IL: ${feeIlRatio.toFixed(2)}`,
         };
       }
-
-      const openPositions = Array.from(trackedPositions.values()).map(toRiskPosition);
-      const portfolioValueUsd = walletBalanceUsd;
-      const recentPnlUsd = openPositions.reduce((sum, pos) => sum + pos.unrealizedPnlUsd, 0);
 
       if (config.agentiveMode) {
         const proposalMode = config.agentProposalMode;
@@ -2594,7 +2710,10 @@ export const program = Effect.gen(function* () {
         };
       }
 
-      // Risk evaluation
+      // Risk evaluation. HOLD executes nothing, so risk gates are skipped for
+      // it — every rejection used to write a 60-day warning memory, and those
+      // warnings then suppressed the good-HOLD branch (hasRecentWarning),
+      // feeding a self-sustaining spam loop that flooded vector memory.
       const riskCtx = {
         openPositions,
         portfolioValueUsd,
@@ -2602,7 +2721,10 @@ export const program = Effect.gen(function* () {
         poolAddress,
         activeBinId: pool.activeBinId,
       };
-      const riskResult = risk.evaluate(decision, riskCtx);
+      const riskResult: RiskResult =
+        decision.action === "HOLD"
+          ? { approved: true, reason: "HOLD — no execution; risk gates skipped" }
+          : risk.evaluate(decision, riskCtx);
 
       // Apply risk-adjusted position size cap
       if (riskResult.adjustedSizeUsd && decision.action === "ENTER") {

--- a/engine/risk-service.ts
+++ b/engine/risk-service.ts
@@ -14,6 +14,7 @@ export interface RiskConfig {
   readonly confidenceThreshold: number;
   readonly maxRebalanceRangeBins: number;
   readonly stopLossPct: number;
+  readonly maxPerPoolAllocationPct: number;
 }
 
 export function evaluateRisk(
@@ -21,7 +22,14 @@ export function evaluateRisk(
   decision: AgentDecision,
   ctx: RiskContext,
 ): RiskResult {
-  // 1. Confidence gate
+  // 1. EXIT always approved — capital protection must not be gated on
+  // confidence: a high CONFIDENCE_THRESHOLD would otherwise block
+  // capital-protection exits.
+  if (decision.action === "EXIT") {
+    return { approved: true, reason: "EXIT approved: capital protection" };
+  }
+
+  // 2. Confidence gate
   if (decision.confidence < riskConfig.confidenceThreshold) {
     return {
       approved: false,
@@ -29,9 +37,9 @@ export function evaluateRisk(
     };
   }
 
-  // 2. Concurrent positions cap is enforced upstream by evaluatePerPoolAllocation.
+  // 3. Concurrent positions cap is enforced upstream by evaluatePerPoolAllocation.
 
-  // 2a. Duplicate pool guard
+  // 3a. Duplicate pool guard
   if (decision.action === "ENTER" && decision.poolAddress) {
     const duplicate = ctx.openPositions.find((p) => p.poolAddress === decision.poolAddress);
     if (duplicate) {
@@ -40,11 +48,6 @@ export function evaluateRisk(
         reason: `Already holding position in pool ${decision.poolAddress} — use REBALANCE instead`,
       };
     }
-  }
-
-  // 3. EXIT always approved
-  if (decision.action === "EXIT") {
-    return { approved: true, reason: "EXIT approved: capital protection" };
   }
 
   // 4. Drawdown check
@@ -72,14 +75,16 @@ export function evaluateRisk(
     }
   }
 
-  // 6. Position size validation
+  // 6. Position size validation — the cap is the configured per-pool
+  // allocation (single source of truth: MAX_PER_POOL_ALLOCATION_PCT).
   if (decision.action === "ENTER" && decision.positionSizeUsd !== undefined) {
-    const maxSize = ctx.portfolioValueUsd * 0.3;
+    const capPct = riskConfig.maxPerPoolAllocationPct;
+    const maxSize = ctx.portfolioValueUsd * capPct;
     if (decision.positionSizeUsd > maxSize) {
       const adjustedSizeUsd = maxSize;
       return {
         approved: true,
-        reason: `Size capped to 30% of portfolio ($${adjustedSizeUsd.toFixed(0)})`,
+        reason: `Size capped to ${(capPct * 100).toFixed(0)}% of portfolio ($${adjustedSizeUsd.toFixed(0)})`,
         adjustedSizeUsd,
       };
     }

--- a/engine/screener-service.ts
+++ b/engine/screener-service.ts
@@ -14,6 +14,15 @@ export interface ScreenerConfig {
   readonly minBinUtilization: number;
 }
 
+/**
+ * Bin utilization is not part of the Data API discovery payload, so the
+ * screener enriches at most this many surviving candidates with on-chain bin
+ * data and applies minBinUtilization only where reserves are known. Candidates
+ * beyond the cap (or whose bin fetch fails) pass through unfiltered — the
+ * per-pool scan loop re-applies the gate with full data before any ENTER.
+ */
+const MAX_BIN_UTILIZATION_CHECKS = 10;
+
 export const ScreenerLive = (screenerConfig: ScreenerConfig) =>
   Layer.effect(
     ScreenerService,
@@ -93,7 +102,39 @@ export const ScreenerLive = (screenerConfig: ScreenerConfig) =>
               if (candidate) screened.push(candidate);
             }
 
-            return screened.sort((a, b) => b.feeIlRatio - a.feeIlRatio);
+            const sorted = screened.sort((a, b) => b.feeIlRatio - a.feeIlRatio);
+
+            // minBinUtilization filter: only applied where on-chain bin data
+            // exists (see MAX_BIN_UTILIZATION_CHECKS). Fail-open otherwise.
+            const enriched: ScreenedPool[] = [];
+            for (const candidate of sorted.slice(0, MAX_BIN_UTILIZATION_CHECKS)) {
+              const binArray = yield* adapter.getBinArray(candidate.address).pipe(
+                Effect.catchAll((err) => {
+                  logger.warn("Bin data unavailable for candidate — skipping utilization gate", {
+                    pool: candidate.address,
+                    error: String(err),
+                  });
+                  return Effect.succeed(null);
+                }),
+              );
+              if (binArray === null || binArray.reservesKnown === false) {
+                enriched.push(candidate);
+                continue;
+              }
+              const utilization = strategy.computeBinUtilization(binArray);
+              if (utilization < screenerConfig.minBinUtilization) {
+                logger.info("Candidate filtered by bin utilization", {
+                  pool: candidate.address,
+                  utilization: utilization.toFixed(2),
+                  minBinUtilization: screenerConfig.minBinUtilization,
+                });
+                continue;
+              }
+              enriched.push({ ...candidate, binUtilization: utilization });
+            }
+            enriched.push(...sorted.slice(MAX_BIN_UTILIZATION_CHECKS));
+
+            return enriched;
           }),
       };
 

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -154,6 +154,16 @@ export interface AdapterApi {
     mints: ReadonlyArray<string>,
   ) => Effect.Effect<Record<string, number>, unknown>;
   readonly getTokenDecimals: (mintAddress: string) => Effect.Effect<number, unknown>;
+  /**
+   * On-chain mint/freeze authority for a token mint, from the parsed mint
+   * account. The mint authority doubles as the documented deployer fallback
+   * for the deployer blacklist; the freeze authority feeds the safety
+   * screening (freeze-authority-enabled tokens are rejected). Callers treat
+   * RPC failures as fail-open.
+   */
+  readonly getMintAuthorities: (
+    mintAddress: string,
+  ) => Effect.Effect<{ mintAuthority: string | null; freezeAuthority: string | null }, unknown>;
   readonly quoteSwapUSDCForToken: (
     outputMint: string,
     amountAtomic: bigint,


### PR DESCRIPTION
## Summary

Wave 2 of `.omo/plans/prism-review-remediation.md` — fixes 6 MAJOR decision-loop bugs plus the P0 safety-screening gap. Builds on Wave 1 (real metrics) and Wave 3 (security); no re-work of either.

## Findings fixed (numbered per plan)

1. **Blacklist rejection was swallowed** — `blacklist.checkPool` sat under `Effect.catchAll(() => Effect.void)`, so blacklisted pools proceeded. Now a `BlacklistError` skips the pool with a recorded rejected decision + audit + warning; only unexpected transport/IO errors fail open (a *loaded* blacklist hit always rejects).
2. **Phantom EXITs** — TVL-drop / low-fee-IL / volume-auth EXIT conditions fired for pools with **no position**, recording executed EXITs, arming 4h cooldowns, and bumping the threshold-evolution counter. All deterministic EXIT conditions are now gated on `hasPosition`; positionless pools take the ENTER/HOLD path only.
3. **Risk gate order** — the confidence gate ran before the "EXIT always approved" override, so a high `CONFIDENCE_THRESHOLD` blocked capital-protection exits. EXIT is now approved first (structural checks only), confidence gate applies to other actions.
4. **Portfolio math** — `portfolioValueUsd = walletBalanceUsd` excluded open positions, shrinking drawdown/allocation/size gates as positions grew. Now `wallet + Σ trackedPositions.currentValueUsd` (mirrors `refreshAgentState`), used by both the risk context and the F5 allocation gate.
5. **HOLD rejection spam** — the fallback HOLD (confidence 0.5 < 0.65) was risk-rejected every cycle, each rejection writing a 60-day warning memory; those warnings then blocked the good-HOLD branch (`hasRecentWarning`, 7-day window) — a self-sustaining spam loop. HOLD now skips risk evaluation and warning-memory writes (it executes nothing).
6. **Safety screening (P0)** — (a) on-chain mint authorities are now fetched per pool (`adapter.getMintAuthorities`, parsed mint account, 1h cache, fail-open on RPC errors) and the mint authority is passed to `checkPool` as the documented deployer fallback, so the deployer blacklist is actually wired; (b) pools with Data API `is_blacklisted=true`, `freeze_authority_disabled=false`, or an on-chain freeze authority set are rejected before metric evaluation with a warning.
7. **Screener `minBinUtilization`** — the param was accepted but unused. Discovery payloads carry no per-bin data, so the screener now enriches up to 10 surviving candidates with an on-chain `getBinArray` probe and applies the filter where reserves are known (fail-open otherwise; the per-pool scan loop re-applies the gate with full data).
8. **Size-cap consolidation** — risk-service had a hardcoded 30% per-position cap while config exposed `maxPerPoolAllocationPct` (0.4). The cap now follows the config value (single source of truth).
9. **Snapshot retention** — Wave 1 made per-cycle `pool_snapshots` writes permanent with no pruning. `SNAPSHOT_RETENTION_DAYS` (default 14) now prunes via the existing `db.pruneSnapshots` once per day (first cycle prunes immediately).

## Design notes

- **Freeze-authority screening is intentionally strict**: tokens with an enabled freeze authority (incl. USDC on mainnet) are screened out. This is the P0 posture from the review — flagging here for visibility since it affects which pools are LP-able.
- **Deployer = mint-authority fallback** (documented in code + AGENTS.md): Metaplex update-authority metadata is not fetched (no new deps); mint authority can only be revoked, never reassigned, so it is a conservative deployer proxy.
- **Screening order**: Data API flags → on-chain authorities → blacklist check, all before `computeMetrics`. Fail-closed on positive signals, fail-open (with warning) on transport errors.
- **RiskConfig gained `maxPerPoolAllocationPct`** (required) — `RiskLive` call sites and `bench/risk.test.ts` updated; the pre-existing "caps oversized ENTER positions" test keeps its 3000 expectation via the test-local 0.3 config, and a new test proves the cap tracks the config (0.25 → 2500).

## Failing-first evidence

Commit `423ebba` added 15 failing tests (RED against unfixed code), e.g.:

```
× rejects a pool whose token mint is blacklisted (fail-closed, recorded)
× rejects a pool whose token deployer (on-chain mint authority) is blacklisted
× rejects a pool the Meteora Data API flags as is_blacklisted
× rejects a pool whose token has freeze authority enabled per the Data API
× rejects a pool whose token has an on-chain freeze authority set
× does NOT record an EXIT for a positionless pool whose TVL dropped
× does NOT set a pool cooldown for a low-yield phantom EXIT (no position)
× computes the ENTER drawdown gate against wallet + open positions
   (Risk engine rejected: 'Portfolio drawdown 47.5% exceeds 10% — pausing new entries')
× produces no risk-rejection audit rows and no warning memories over multiple cycles
× prunes snapshots older than the retention window and keeps recent ones
× approves EXIT below the confidence threshold (capital protection beats confidence)
× derives the cap from maxPerPoolAllocationPct (config, not hardcode)
× filters out candidates whose on-chain bin utilization is below minBinUtilization
```

All 15 are green in the fix commit; the control test (held pool + TVL drop → EXIT) was green throughout.

## Manual-QA evidence

Temporary script (deleted after capture) running the real engine loop:

```
=== (b) risk gate: EXIT conf 0.3 vs ENTER conf 0.3 with threshold 0.9 ===
EXIT  conf=0.3 threshold=0.9 → approved=true (EXIT approved: capital protection)
ENTER conf=0.3 threshold=0.9 → approved=false (Confidence 0.30 below threshold 0.9)
=== (a1) TVL drop -40%, NO position → decisions ===
  HOLD (approved=true, executed=true) — No strong signal. Fee/IL: 20.00
=== (a2) TVL drop -40%, WITH position → decisions ===
  EXIT (approved=true, executed=true) — TVL dropped 40.0% — capital protection exit
```

## Verification (worktree, this branch)

- `bun run lint` (tsc --noEmit + oxlint) — exit 0
- `bun run build` (tsdown) — exit 0
- `bun run test` — 67 files, **759/759 passed**, exit 0
- `bun run format:check` — exit 0

## Test changes to existing files (justification)

- `bench/risk.test.ts`: riskConfig gained `maxPerPoolAllocationPct: 0.3` (required field); existing cap test unchanged in expectation (3000) — new behavior is config-driven, proven by the new 0.25 test.
- `bench/helpers.ts` + 9 bench files: `snapshotRetentionDays: 14` added to full AppConfig literals (required field).
- 5 adapter mocks gained `getMintAuthorities` (required AdapterApi member).
- No existing test expectations were weakened.

Docs: AGENTS.md (decision loop, env table, gotchas), README.md (risk-gate order), .env.example (`SNAPSHOT_RETENTION_DAYS`).

## Out of scope (per plan)

No Wave 4+ work (PnL accounting, atomic rebalance, strategy shapes), no cloudflare/ or mcp-server/ changes, no new dependencies.