### PR TITLE
feat: per-position PnL accounting (Wave 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,11 +174,19 @@ Do not import service implementations directly in program logic. `Layer.provide`
 6. Decision rules evaluate, in order: `EXIT` → `REBALANCE` → `HOLD` → `ENTER`. Deterministic `EXIT` conditions (TVL drop, low fee/IL, volume authenticity, volatility gate, trailing stop) only fire for pools with a tracked position — positionless pools take the ENTER/HOLD path only.
 7. `risk.evaluate` gates execution: `EXIT` is always approved first (capital protection beats the confidence gate), then the confidence gate and remaining structural checks. `HOLD` skips risk evaluation entirely (it executes nothing; rejections used to spam warning memory and suppress the good-HOLD branch). Portfolio value for the drawdown/allocation/size gates is `walletBalanceUsd + Σ openPositions.currentValueUsd`.
 8. `audit.recordDecision` logs every decision (errors swallowed).
-9. Execution updates the in-memory `trackedPositions` Map and persists to SQLite via `db.savePosition` / `db.deletePosition`.
+9. Execution updates the in-memory `trackedPositions` Map and persists to SQLite via `db.savePosition`. EXIT soft-closes the row via `db.closePosition` (sets `closed_at` + `realized_pnl_usd`, row kept for history); `db.deletePosition` is reserved for true cleanup (stale paper rows, externally-closed positions).
 
 ### Position persistence
 
-`trackedPositions` is only an in-memory cache. At startup `program.ts` loads all rows from `positions` into the Map, and every state change (ENTER, EXIT, REBALANCE, trailing-stop update, fee claim) is written back to SQLite.
+`trackedPositions` is only an in-memory cache. At startup `program.ts` loads all rows from `positions` into the Map, and every state change (ENTER, EXIT, REBALANCE, trailing-stop update, fee claim) is written back to SQLite. Active-position queries (`getAllPositions`) exclude rows with `paper_exited_at` or `closed_at` set; history queries (`getClosedPositions`) return them.
+
+### PnL accounting
+
+Each position row carries `entry_price_usd` (pool `currentPrice` at ENTER), `entry_amount_x_usd` / `entry_amount_y_usd` (USD value of each leg at entry — the documented 50/50 model, half the entry size per leg, since the adapter does not return actual on-chain deposit amounts), `cumulative_fees_claimed_usd`, `closed_at` and `realized_pnl_usd`. Every lifecycle transition also appends to the append-only `position_events` log (`ENTER` / `EXIT` / `REBALANCE` / `CLAIM` / `COMPOUND` with value, fees, price and metadata).
+
+`depositedUsd` is the cost basis. Auto-compounded fees become new cost basis when redeposited (they were already counted in `cumulative_fees_claimed_usd` when claimed, so total-PnL math stays continuous); `currentValueUsd` and `highestValueUsd` adjust in lockstep via `applyCompoundToCostBasis` in `engine/pnl.ts` so the trailing stop is not distorted. Pure analytics live in `engine/pnl.ts`: unrealized PnL = `currentValueUsd + cumulativeFeesClaimedUsd − depositedUsd`; HODL benchmark = `entryAmountXUsd × (currentPrice / entryPrice) + entryAmountYUsd`; fee APR = fees / cost basis annualized by position age; time-in-range is approximated as `1 − (current OOR stint / age)` (recovered past stints are not tracked and count as in-range time — a documented overestimate).
+
+Positions opened before migration v16 have NULL entry fields: analytics and the CLI degrade gracefully (no HODL benchmark / IL-vs-HODL — shown as `n/a` — and PnL falls back to the legacy `currentValueUsd − depositedUsd` model). The CLI surfaces all of this in `prism portfolio` (per-position + totals), `prism portfolio history` (realized PnL from `closed_at` rows) and `prism status`; the current price for the HODL benchmark comes from the latest `pool_snapshots` row.
 
 ### Agent runtime overlay
 

--- a/bench/db-positions.test.ts
+++ b/bench/db-positions.test.ts
@@ -41,6 +41,12 @@ function makePosition(
     paperExitedAt: overrides.paperExitedAt ?? null,
     entrySignalTimestamp: overrides.entrySignalTimestamp ?? null,
     entrySignalSnapshotId: overrides.entrySignalSnapshotId ?? null,
+    entryPriceUsd: null,
+    entryAmountXUsd: null,
+    entryAmountYUsd: null,
+    cumulativeFeesClaimedUsd: 0,
+    closedAt: null,
+    realizedPnlUsd: null,
   };
 }
 

--- a/bench/db-service.test.ts
+++ b/bench/db-service.test.ts
@@ -33,6 +33,12 @@ function makePosition(
   paperExitedAt: number | null;
   entrySignalTimestamp: number | null;
   entrySignalSnapshotId: number | null;
+  entryPriceUsd: number | null;
+  entryAmountXUsd: number | null;
+  entryAmountYUsd: number | null;
+  cumulativeFeesClaimedUsd: number;
+  closedAt: number | null;
+  realizedPnlUsd: number | null;
 } {
   return {
     poolAddress,
@@ -54,6 +60,12 @@ function makePosition(
     paperExitedAt,
     entrySignalTimestamp: null,
     entrySignalSnapshotId: null,
+    entryPriceUsd: null,
+    entryAmountXUsd: null,
+    entryAmountYUsd: null,
+    cumulativeFeesClaimedUsd: 0,
+    closedAt: null,
+    realizedPnlUsd: null,
   };
 }
 

--- a/bench/helpers.ts
+++ b/bench/helpers.ts
@@ -76,6 +76,12 @@ export function makePosition(overrides: Partial<PositionRecord> = {}): PositionR
     paperExitedAt: overrides.paperExitedAt ?? null,
     entrySignalTimestamp: overrides.entrySignalTimestamp ?? null,
     entrySignalSnapshotId: overrides.entrySignalSnapshotId ?? null,
+    entryPriceUsd: overrides.entryPriceUsd ?? null,
+    entryAmountXUsd: overrides.entryAmountXUsd ?? null,
+    entryAmountYUsd: overrides.entryAmountYUsd ?? null,
+    cumulativeFeesClaimedUsd: overrides.cumulativeFeesClaimedUsd ?? 0,
+    closedAt: overrides.closedAt ?? null,
+    realizedPnlUsd: overrides.realizedPnlUsd ?? null,
   };
 }
 

--- a/bench/pnl-accounting.test.ts
+++ b/bench/pnl-accounting.test.ts
@@ -1,0 +1,770 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { Effect, Layer } from "effect";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Database } from "bun:sqlite";
+import { createDatabase } from "../engine/db.js";
+import { DbLive, type PositionRecord } from "../engine/db-service.js";
+import {
+  DbService,
+  type AdapterApi,
+  type StrategyApi,
+  type RevenueConfigApi,
+  type EntryPrepApi,
+} from "../engine/services.js";
+import { executePaper, executeLive } from "../engine/program.js";
+import {
+  applyCompoundToCostBasis,
+  computeFeeAprPct,
+  computeHodlValueUsd,
+  computePositionAnalytics,
+  computeRealizedPnlUsd,
+  computeTimeInRangePct,
+} from "../engine/pnl.js";
+import { makePosition } from "./helpers.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// ─── Pure analytics ──────────────────────────────────────────────────────────
+
+describe("computeHodlValueUsd", () => {
+  it("values the entry legs at the current price (price up)", () => {
+    // $500 X-leg + $500 Y-leg entered at price 100; price now 110.
+    // X leg: 5 units × 110 = $550; Y leg unchanged $500 → $1050.
+    expect(computeHodlValueUsd(500, 500, 100, 110)).toBeCloseTo(1050, 8);
+  });
+
+  it("values the entry legs at the current price (price down)", () => {
+    expect(computeHodlValueUsd(500, 500, 100, 90)).toBeCloseTo(950, 8);
+  });
+
+  it("is flat when the price has not moved", () => {
+    expect(computeHodlValueUsd(500, 500, 100, 100)).toBeCloseTo(1000, 8);
+  });
+
+  it("returns null for a non-positive entry price", () => {
+    expect(computeHodlValueUsd(500, 500, 0, 110)).toBeNull();
+    expect(computeHodlValueUsd(500, 500, -5, 110)).toBeNull();
+  });
+});
+
+describe("computeFeeAprPct", () => {
+  it("annualizes fees against cost basis by position age", () => {
+    // $10 fees on $1000 basis over exactly 1 day → 1% daily → 365% APR.
+    expect(computeFeeAprPct(10, 1000, DAY_MS)).toBeCloseTo(365, 6);
+  });
+
+  it("halves the APR when the same fees took twice as long", () => {
+    expect(computeFeeAprPct(10, 1000, 2 * DAY_MS)).toBeCloseTo(182.5, 6);
+  });
+
+  it("returns null when age or basis is zero", () => {
+    expect(computeFeeAprPct(10, 1000, 0)).toBeNull();
+    expect(computeFeeAprPct(10, 0, DAY_MS)).toBeNull();
+  });
+
+  it("returns 0 when no fees were claimed", () => {
+    expect(computeFeeAprPct(0, 1000, DAY_MS)).toBe(0);
+  });
+});
+
+describe("computeTimeInRangePct", () => {
+  const now = 1_700_000_000_000;
+
+  it("is 100% when the position never went out of range", () => {
+    expect(computeTimeInRangePct(10 * DAY_MS, null, now)).toBe(100);
+  });
+
+  it("discounts the current out-of-range stint", () => {
+    // Age 10 days, OOR for the last 5 days → 50%.
+    const oorSince = now - 5 * DAY_MS;
+    expect(computeTimeInRangePct(10 * DAY_MS, oorSince, now)).toBeCloseTo(50, 6);
+  });
+
+  it("never goes below 0", () => {
+    const oorSince = now - 20 * DAY_MS;
+    expect(computeTimeInRangePct(10 * DAY_MS, oorSince, now)).toBe(0);
+  });
+
+  it("returns null when the age is zero", () => {
+    expect(computeTimeInRangePct(0, null, now)).toBeNull();
+  });
+});
+
+describe("computePositionAnalytics", () => {
+  const now = 1_700_000_000_000;
+
+  it("computes unrealized PnL including claimed fees", () => {
+    const a = computePositionAnalytics(
+      {
+        depositedUsd: 1000,
+        currentValueUsd: 1100,
+        cumulativeFeesClaimedUsd: 25,
+        entryPriceUsd: 100,
+        entryAmountXUsd: 500,
+        entryAmountYUsd: 500,
+        openedAtMs: now - DAY_MS,
+        outOfRangeSinceMs: null,
+      },
+      110,
+      now,
+    );
+    expect(a.costBasisUsd).toBe(1000);
+    expect(a.unrealizedPnlUsd).toBeCloseTo(125, 8);
+    expect(a.unrealizedPnlPct).toBeCloseTo(12.5, 6);
+    expect(a.feesClaimedUsd).toBe(25);
+    expect(a.hodlValueUsd).toBeCloseTo(1050, 8);
+    expect(a.ilVsHodlUsd).toBeCloseTo(50, 8);
+    expect(a.timeInRangePct).toBe(100);
+    expect(a.feeAprPct).toBeCloseTo((25 / 1000) * 365 * 100, 4);
+    expect(a.ageMs).toBe(DAY_MS);
+  });
+
+  it("degrades gracefully for pre-migration rows (NULL entry fields)", () => {
+    const a = computePositionAnalytics(
+      {
+        depositedUsd: 1000,
+        currentValueUsd: 1200,
+        cumulativeFeesClaimedUsd: 0,
+        entryPriceUsd: null,
+        entryAmountXUsd: null,
+        entryAmountYUsd: null,
+        openedAtMs: now - DAY_MS,
+        outOfRangeSinceMs: null,
+      },
+      110,
+      now,
+    );
+    // PnL falls back to the legacy deposited-vs-current model.
+    expect(a.unrealizedPnlUsd).toBeCloseTo(200, 8);
+    expect(a.hodlValueUsd).toBeNull();
+    expect(a.ilVsHodlUsd).toBeNull();
+  });
+
+  it("degrades gracefully when no current price is available", () => {
+    const a = computePositionAnalytics(
+      {
+        depositedUsd: 1000,
+        currentValueUsd: 1100,
+        cumulativeFeesClaimedUsd: 0,
+        entryPriceUsd: 100,
+        entryAmountXUsd: 500,
+        entryAmountYUsd: 500,
+        openedAtMs: now - DAY_MS,
+        outOfRangeSinceMs: null,
+      },
+      null,
+      now,
+    );
+    expect(a.hodlValueUsd).toBeNull();
+    expect(a.ilVsHodlUsd).toBeNull();
+  });
+});
+
+describe("computeRealizedPnlUsd", () => {
+  it("is final value plus cumulative fees minus cost basis", () => {
+    expect(computeRealizedPnlUsd(1100, 25, 1000)).toBeCloseTo(125, 8);
+  });
+
+  it("is negative when the position loses more than fees earned", () => {
+    expect(computeRealizedPnlUsd(800, 25, 1000)).toBeCloseTo(-175, 8);
+  });
+});
+
+describe("applyCompoundToCostBasis", () => {
+  it("keeps total PnL continuous across a compound", () => {
+    const before = { depositedUsd: 1000, currentValueUsd: 1100, highestValueUsd: 1150 };
+    const feesAlreadyClaimed = 25;
+    const pnlBefore = before.currentValueUsd + feesAlreadyClaimed - before.depositedUsd;
+
+    const after = applyCompoundToCostBasis({ ...before, compoundedFeesUsd: 25 });
+    const pnlAfter = after.currentValueUsd + feesAlreadyClaimed - after.depositedUsd;
+
+    expect(pnlAfter).toBeCloseTo(pnlBefore, 8);
+    expect(after.depositedUsd).toBeCloseTo(1025, 8);
+    expect(after.currentValueUsd).toBeCloseTo(1125, 8);
+  });
+
+  it("raises highestValueUsd when the compounded value exceeds it", () => {
+    const after = applyCompoundToCostBasis({
+      depositedUsd: 1000,
+      currentValueUsd: 1140,
+      highestValueUsd: 1150,
+      compoundedFeesUsd: 25,
+    });
+    expect(after.highestValueUsd).toBeCloseTo(1165, 8);
+  });
+
+  it("keeps highestValueUsd when the compounded value stays below it", () => {
+    const after = applyCompoundToCostBasis({
+      depositedUsd: 1000,
+      currentValueUsd: 1000,
+      highestValueUsd: 1200,
+      compoundedFeesUsd: 25,
+    });
+    expect(after.highestValueUsd).toBeCloseTo(1200, 8);
+  });
+
+  it("seeds highestValueUsd from the new value when none was tracked", () => {
+    const after = applyCompoundToCostBasis({
+      depositedUsd: 1000,
+      currentValueUsd: 1100,
+      highestValueUsd: null,
+      compoundedFeesUsd: 25,
+    });
+    expect(after.highestValueUsd).toBeCloseTo(1125, 8);
+  });
+});
+
+// ─── Migration ───────────────────────────────────────────────────────────────
+
+describe("migration v16 — pnl_accounting", () => {
+  const tmpDirs: string[] = [];
+
+  afterAll(() => {
+    for (const dir of tmpDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("adds PnL columns and position_events to an old-schema DB, preserving rows", () => {
+    const dir = mkdtempSync(join(tmpdir(), "prism-pnl-migration-"));
+    tmpDirs.push(dir);
+    const dbPath = join(dir, "old.db");
+
+    // Build a pre-v16 database by hand: positions as of v15, _migrations 1..15 applied.
+    const old = new Database(dbPath);
+    old.exec(`
+      CREATE TABLE positions (
+        pool_address TEXT PRIMARY KEY,
+        position_pubkey TEXT,
+        deposited_usd REAL,
+        current_value_usd REAL,
+        token_x_symbol TEXT,
+        token_y_symbol TEXT,
+        active_bin_id INTEGER,
+        lower_bin_id INTEGER,
+        upper_bin_id INTEGER,
+        timestamp INTEGER,
+        out_of_range_since INTEGER,
+        oor_cycle_count INTEGER DEFAULT 0,
+        last_fee_claim_at INTEGER DEFAULT 0,
+        last_rebalance_at INTEGER DEFAULT 0,
+        trailing_stop_threshold REAL,
+        highest_value_usd REAL,
+        paper_exited_at INTEGER,
+        entry_signal_timestamp INTEGER,
+        entry_signal_snapshot_id INTEGER
+      );
+    `);
+    old.exec(`
+      CREATE TABLE _migrations (
+        version INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        applied_at INTEGER NOT NULL
+      );
+    `);
+    for (let v = 1; v <= 15; v++) {
+      old.run("INSERT INTO _migrations (version, name, applied_at) VALUES (?, ?, ?)", [
+        v,
+        `legacy_v${v}`,
+        Date.now(),
+      ]);
+    }
+    old.run(
+      `INSERT INTO positions (
+        pool_address, position_pubkey, deposited_usd, current_value_usd,
+        token_x_symbol, token_y_symbol, active_bin_id, lower_bin_id, upper_bin_id,
+        timestamp, out_of_range_since, oor_cycle_count, last_fee_claim_at,
+        last_rebalance_at, trailing_stop_threshold, highest_value_usd,
+        paper_exited_at, entry_signal_timestamp, entry_signal_snapshot_id
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "LegacyPool111",
+        null,
+        1000,
+        1200,
+        "SOL",
+        "USDC",
+        5000,
+        4980,
+        5020,
+        1700000000000,
+        null,
+        0,
+        0,
+        0,
+        null,
+        1200,
+        null,
+        null,
+        null,
+      ],
+    );
+    old.close();
+
+    // Opening via createDatabase must run migration v16.
+    const db = createDatabase(dbPath);
+    const columns = (db.query("PRAGMA table_info(positions)").all() as Array<{ name: string }>).map(
+      (r) => r.name,
+    );
+    for (const col of [
+      "entry_price_usd",
+      "entry_amount_x_usd",
+      "entry_amount_y_usd",
+      "cumulative_fees_claimed_usd",
+      "closed_at",
+      "realized_pnl_usd",
+    ]) {
+      expect(columns).toContain(col);
+    }
+
+    const eventsTable = db
+      .query("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'position_events'")
+      .get();
+    expect(eventsTable).not.toBeNull();
+
+    const row = db
+      .query("SELECT * FROM positions WHERE pool_address = ?")
+      .get("LegacyPool111") as Record<string, unknown> | null;
+    expect(row).not.toBeNull();
+    expect(Number(row!.deposited_usd)).toBe(1000);
+    expect(Number(row!.current_value_usd)).toBe(1200);
+    expect(Number(row!.cumulative_fees_claimed_usd)).toBe(0);
+    expect(row!.entry_price_usd).toBeNull();
+    expect(row!.entry_amount_x_usd).toBeNull();
+    expect(row!.entry_amount_y_usd).toBeNull();
+    expect(row!.closed_at).toBeNull();
+    expect(row!.realized_pnl_usd).toBeNull();
+    db.close();
+  });
+});
+
+// ─── DB record keeping ───────────────────────────────────────────────────────
+
+async function runDb<T>(
+  effect: Effect.Effect<T, unknown, DbService>,
+  layer: Layer.Layer<DbService, never, never>,
+): Promise<T> {
+  return Effect.runPromise(Effect.provide(effect, layer));
+}
+
+describe("DbService — position events + soft close", () => {
+  it("records and reads position_events in creation order", async () => {
+    const layer = DbLive(":memory:");
+    const events = await runDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        yield* db.savePosition(makePosition({ poolAddress: "pool1" }));
+        yield* db.savePositionEvent({
+          id: "evt-1",
+          poolAddress: "pool1",
+          positionPubKey: null,
+          event: "ENTER",
+          valueUsd: 1000,
+          feesUsd: null,
+          price: 100,
+          metadata: { lowerBinId: 4980, upperBinId: 5020 },
+          createdAt: 1000,
+        });
+        yield* db.savePositionEvent({
+          id: "evt-2",
+          poolAddress: "pool1",
+          positionPubKey: null,
+          event: "CLAIM",
+          valueUsd: null,
+          feesUsd: 25,
+          price: 100,
+          createdAt: 2000,
+        });
+        return yield* db.getPositionEvents("pool1");
+      }),
+      layer,
+    );
+    expect(events).toHaveLength(2);
+    expect(events[0]!.event).toBe("ENTER");
+    expect(events[0]!.valueUsd).toBe(1000);
+    expect(events[0]!.price).toBe(100);
+    expect(events[0]!.metadata).toContain("lowerBinId");
+    expect(events[1]!.event).toBe("CLAIM");
+    expect(events[1]!.feesUsd).toBe(25);
+  });
+
+  it("closePosition soft-closes: excluded from active, present in closed, realized PnL stored", async () => {
+    const layer = DbLive(":memory:");
+    const result = await runDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        yield* db.savePosition(makePosition({ poolAddress: "pool1", currentValueUsd: 1100 }));
+        yield* db.closePosition("pool1", 125);
+        const active = yield* db.getAllPositions();
+        const closed = yield* db.getClosedPositions();
+        const raw = yield* db.getPosition("pool1");
+        return { active, closed, raw };
+      }),
+      layer,
+    );
+    expect(result.active).toHaveLength(0);
+    expect(result.closed).toHaveLength(1);
+    expect(result.closed[0]!.poolAddress).toBe("pool1");
+    expect(result.closed[0]!.realizedPnlUsd).toBeCloseTo(125, 8);
+    expect(result.closed[0]!.closedAt).not.toBeNull();
+    expect(result.raw).not.toBeNull();
+  });
+
+  it("getLatestSnapshotPrice returns the newest snapshot price or null", async () => {
+    const layer = DbLive(":memory:");
+    const prices = await runDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const missing = yield* db.getLatestSnapshotPrice("pool1");
+        yield* db.saveSnapshot({
+          poolAddress: "pool1",
+          timestamp: 1000,
+          activeBinId: 5000,
+          tvlUsd: 100_000,
+          volume24hUsd: 1000,
+          fees24hUsd: 10,
+          apr: 5,
+          currentPrice: 100,
+          binStep: 10,
+          tokenXSymbol: "SOL",
+          tokenYSymbol: "USDC",
+          binArray: { lowerBinId: 4980, upperBinId: 5020, bins: [], activeBinId: 5000 },
+        });
+        yield* db.saveSnapshot({
+          poolAddress: "pool1",
+          timestamp: 2000,
+          activeBinId: 5001,
+          tvlUsd: 100_000,
+          volume24hUsd: 1000,
+          fees24hUsd: 10,
+          apr: 5,
+          currentPrice: 110,
+          binStep: 10,
+          tokenXSymbol: "SOL",
+          tokenYSymbol: "USDC",
+          binArray: { lowerBinId: 4980, upperBinId: 5020, bins: [], activeBinId: 5001 },
+        });
+        const latest = yield* db.getLatestSnapshotPrice("pool1");
+        return { missing, latest };
+      }),
+      layer,
+    );
+    expect(prices.missing).toBeNull();
+    expect(prices.latest).toBe(110);
+  });
+});
+
+// ─── Lifecycle: ENTER → CLAIM → price move → EXIT (paper path) ───────────────
+
+describe("paper lifecycle PnL accounting", () => {
+  it("ENTER snapshots entry price/legs and writes an ENTER event", async () => {
+    const layer = DbLive(":memory:");
+    const trackedPositions = new Map<string, PositionRecord>();
+    const pool = {
+      activeBinId: 5000,
+      binStep: 10,
+      tokenXSymbol: "SOL",
+      tokenYSymbol: "USDC",
+      currentPrice: 100,
+    };
+
+    const outcome = await runDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const result = yield* executePaper(
+          { db, trackedPositions },
+          {
+            action: "ENTER",
+            poolAddress: "pool1",
+            confidence: 0.8,
+            reasoning: "test entry",
+            positionSizeUsd: 1000,
+          },
+          pool,
+        );
+        const pos = yield* db.getPosition("pool1");
+        const events = yield* db.getPositionEvents("pool1");
+        return { result, pos, events };
+      }),
+      layer,
+    );
+
+    expect(outcome.result.executed).toBe(true);
+    expect(outcome.pos).not.toBeNull();
+    expect(outcome.pos!.entryPriceUsd).toBe(100);
+    expect(outcome.pos!.entryAmountXUsd).toBeCloseTo(500, 8);
+    expect(outcome.pos!.entryAmountYUsd).toBeCloseTo(500, 8);
+    expect(outcome.pos!.cumulativeFeesClaimedUsd).toBe(0);
+    expect(outcome.pos!.closedAt).toBeNull();
+    expect(outcome.pos!.realizedPnlUsd).toBeNull();
+    expect(outcome.events.map((e) => e.event)).toEqual(["ENTER"]);
+    expect(outcome.events[0]!.valueUsd).toBe(1000);
+    expect(outcome.events[0]!.price).toBe(100);
+  });
+
+  it("EXIT computes realized PnL (value + fees − basis), writes EXIT event, soft-closes", async () => {
+    const layer = DbLive(":memory:");
+    const trackedPositions = new Map<string, PositionRecord>();
+    const pool = {
+      activeBinId: 5000,
+      binStep: 10,
+      tokenXSymbol: "SOL",
+      tokenYSymbol: "USDC",
+      currentPrice: 100,
+    };
+
+    const outcome = await runDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        yield* executePaper(
+          { db, trackedPositions },
+          {
+            action: "ENTER",
+            poolAddress: "pool1",
+            confidence: 0.8,
+            reasoning: "test entry",
+            positionSizeUsd: 1000,
+          },
+          pool,
+        );
+
+        // CLAIM $25 of fees (mirrors the engine's claim accounting).
+        const pos = trackedPositions.get("pool1")!;
+        pos.cumulativeFeesClaimedUsd += 25;
+        yield* db.savePosition(pos);
+        yield* db.savePositionEvent({
+          id: "evt-claim",
+          poolAddress: "pool1",
+          positionPubKey: null,
+          event: "CLAIM",
+          valueUsd: null,
+          feesUsd: 25,
+          price: 100,
+          createdAt: Date.now(),
+        });
+
+        // Price moves 100 → 110; the per-cycle value tracker marks the position to $1100.
+        pos.currentValueUsd = 1100;
+        yield* db.savePosition(pos);
+
+        const exitResult = yield* executePaper(
+          { db, trackedPositions },
+          { action: "EXIT", poolAddress: "pool1", confidence: 0.9, reasoning: "test exit" },
+          { ...pool, currentPrice: 110 },
+        );
+
+        const closed = yield* db.getClosedPositions();
+        const active = yield* db.getAllPositions();
+        const events = yield* db.getPositionEvents("pool1");
+        return { exitResult, closed, active, events };
+      }),
+      layer,
+    );
+
+    expect(outcome.exitResult.executed).toBe(true);
+    expect(outcome.active).toHaveLength(0);
+    expect(outcome.closed).toHaveLength(1);
+
+    const closed = outcome.closed[0]!;
+    // realized = final value 1100 + fees 25 − basis 1000 = 125
+    expect(closed.realizedPnlUsd).toBeCloseTo(125, 8);
+    expect(closed.closedAt).not.toBeNull();
+
+    expect(outcome.events.map((e) => e.event)).toEqual(["ENTER", "CLAIM", "EXIT"]);
+    const exitEvent = outcome.events[2]!;
+    expect(exitEvent.valueUsd).toBeCloseTo(1100, 8);
+    expect(exitEvent.feesUsd).toBeCloseTo(25, 8);
+    expect(exitEvent.price).toBe(110);
+
+    // HODL benchmark: 500 × (110/100) + 500 = 1050 → IL-vs-HODL = 1100 − 1050 = 50.
+    const analytics = computePositionAnalytics(
+      {
+        depositedUsd: closed.depositedUsd,
+        currentValueUsd: closed.currentValueUsd,
+        cumulativeFeesClaimedUsd: closed.cumulativeFeesClaimedUsd,
+        entryPriceUsd: closed.entryPriceUsd,
+        entryAmountXUsd: closed.entryAmountXUsd,
+        entryAmountYUsd: closed.entryAmountYUsd,
+        openedAtMs: closed.timestamp,
+        outOfRangeSinceMs: closed.outOfRangeSince,
+      },
+      110,
+      Date.now(),
+    );
+    expect(analytics.hodlValueUsd).toBeCloseTo(1050, 6);
+    expect(analytics.ilVsHodlUsd).toBeCloseTo(50, 6);
+  });
+});
+
+// ─── Live REBALANCE inline-claim accounting ──────────────────────────────────
+
+function makeLiveAdapter(overrides: Partial<AdapterApi> = {}): AdapterApi {
+  return {
+    hasWallet: () => true,
+    getWalletAddress: () => "Wallet111",
+    getWalletBalanceUsd: () => Effect.succeed(10_000),
+    getNativeSolBalance: () => Effect.succeed(10_000_000_000n),
+    getPoolState: () => Effect.fail(new Error("not used")),
+    getBinArray: () => Effect.fail(new Error("not used")),
+    getPositions: () => Effect.succeed([]),
+    getAllWalletPositions: () => Effect.succeed([]),
+    simulateRebalance: () =>
+      Effect.succeed({ estimatedIlUsd: 0, estimatedFeesUsd: 0, netBenefitUsd: 0 }),
+    enterPosition: () => Effect.succeed({ positionPubKey: "pos-1", txSignature: "tx-enter" }),
+    exitPosition: () => Effect.succeed({ txSignature: "tx-exit" }),
+    rebalancePosition: () =>
+      Effect.succeed({ newPositionPubKey: "pos-2", txSignatures: ["tx-rebalance"] }),
+    claimFees: () =>
+      Effect.succeed({
+        txSignature: "tx-claim",
+        feeX: 0,
+        feeY: 25_000_000, // 25 USDC raw (6 decimals)
+        platformFeeX: 0,
+        platformFeeY: 0,
+        netFeeX: 0,
+        netFeeY: 25_000_000,
+      }),
+    discoverPools: () => Effect.succeed([]),
+    reportFeeCollection: () => Effect.void,
+    swapUSDCForSOL: () => Effect.void,
+    getTokenBalance: () => Effect.succeed(0n),
+    getTokenPrices: () => Effect.succeed({}),
+    getTokenDecimals: () => Effect.succeed(9),
+    quoteSwapUSDCForToken: () => Effect.succeed({}),
+    swapUSDCForToken: () => Effect.succeed("mock-swap-tx"),
+    getMintAuthorities: () => Effect.succeed({ mintAuthority: null, freezeAuthority: null }),
+    ...overrides,
+  } as AdapterApi;
+}
+
+const liveStrategy: StrategyApi = {
+  computeMetrics: () => {
+    throw new Error("not used");
+  },
+  checkVolumeAuthenticity: () => ({ score: 1, flags: [] }),
+  computeBinUtilization: () => 1,
+  computeFeeIlRatio: () => 1,
+  recommendBinRange: (activeBinId: number) => ({
+    lowerBinId: activeBinId - 20,
+    upperBinId: activeBinId + 20,
+  }),
+  passesPreFilter: () => true,
+};
+
+const liveRevenueConfig: RevenueConfigApi = {
+  getConfig: () =>
+    Effect.succeed({
+      tier: "free",
+      platformFeeRate: 0,
+      revenueShareEnabled: false,
+      revenueShareOperatorPct: 0,
+      feeWalletAddress: "",
+    }),
+  refreshConfig: () =>
+    Effect.succeed({
+      tier: "free",
+      platformFeeRate: 0,
+      revenueShareEnabled: false,
+      revenueShareOperatorPct: 0,
+      feeWalletAddress: "",
+    }),
+};
+
+const liveEntryPrep: EntryPrepApi = { prepareEntryTokens: () => Effect.void };
+
+describe("live lifecycle PnL accounting", () => {
+  it("ENTER stores entry basis; REBALANCE inline claim accumulates fees + events; EXIT realizes PnL", async () => {
+    const layer = DbLive(":memory:");
+    const trackedPositions = new Map<string, PositionRecord>();
+    const pool = {
+      activeBinId: 5000,
+      binStep: 10,
+      tokenXSymbol: "SOL",
+      tokenYSymbol: "USDC",
+      currentPrice: 100,
+    };
+
+    const outcome = await runDb(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const deps = {
+          adapter: makeLiveAdapter(),
+          strategy: liveStrategy,
+          db,
+          revenueConfigSvc: liveRevenueConfig,
+          trackedPositions,
+          entryPrep: liveEntryPrep,
+          solPriceUsd: 150,
+        };
+
+        // 1. ENTER $1000 at price 100.
+        const enter = yield* executeLive(
+          deps,
+          {
+            action: "ENTER",
+            poolAddress: "pool1",
+            confidence: 0.8,
+            reasoning: "entry",
+            positionSizeUsd: 1000,
+          },
+          pool,
+        );
+        expect(enter.executed).toBe(true);
+
+        // 2. REBALANCE claims $25 USDC of fees inline, then re-ranges.
+        const rebalance = yield* executeLive(
+          deps,
+          {
+            action: "REBALANCE",
+            poolAddress: "pool1",
+            confidence: 0.8,
+            reasoning: "re-range",
+            rebalanceParams: { newLowerBinId: 4990, newUpperBinId: 5030, slippageBps: 50 },
+          },
+          pool,
+        );
+        expect(rebalance.executed).toBe(true);
+
+        // 3. Price moves 100 → 110; position marked to $1100.
+        const pos = trackedPositions.get("pool1")!;
+        pos.currentValueUsd = 1100;
+        yield* db.savePosition(pos);
+
+        // 4. EXIT realizes the PnL on-chain.
+        const exit = yield* executeLive(
+          deps,
+          { action: "EXIT", poolAddress: "pool1", confidence: 0.9, reasoning: "exit" },
+          { ...pool, currentPrice: 110 },
+        );
+        expect(exit.executed).toBe(true);
+
+        const closed = yield* db.getClosedPositions();
+        const active = yield* db.getAllPositions();
+        const events = yield* db.getPositionEvents("pool1");
+        return { closed, active, events, tracked: trackedPositions.get("pool1") };
+      }),
+      layer,
+    );
+
+    expect(outcome.active).toHaveLength(0);
+    expect(outcome.tracked).toBeUndefined();
+    expect(outcome.closed).toHaveLength(1);
+
+    const closed = outcome.closed[0]!;
+    expect(closed.entryPriceUsd).toBe(100);
+    expect(closed.entryAmountXUsd).toBeCloseTo(500, 8);
+    expect(closed.entryAmountYUsd).toBeCloseTo(500, 8);
+    expect(closed.cumulativeFeesClaimedUsd).toBeCloseTo(25, 8);
+    expect(closed.realizedPnlUsd).toBeCloseTo(125, 8);
+    expect(closed.closedAt).not.toBeNull();
+
+    expect(outcome.events.map((e) => e.event)).toEqual(["ENTER", "CLAIM", "REBALANCE", "EXIT"]);
+    const claimEvent = outcome.events[1]!;
+    expect(claimEvent.feesUsd).toBeCloseTo(25, 8);
+    const rebalanceEvent = outcome.events[2]!;
+    expect(rebalanceEvent.metadata).toContain("4990");
+  });
+});

--- a/bench/portfolio-cli.test.ts
+++ b/bench/portfolio-cli.test.ts
@@ -13,6 +13,7 @@ import {
   computeSummary,
   computePnl,
   formatAge,
+  formatPosition,
   toJsonOutput,
   toHistoryJsonOutput,
 } from "../cli/portfolio.js";
@@ -39,6 +40,12 @@ function makePosition(overrides: Partial<PositionRecord> = {}): PositionRecord {
     paperExitedAt: overrides.paperExitedAt ?? null,
     entrySignalTimestamp: overrides.entrySignalTimestamp ?? null,
     entrySignalSnapshotId: overrides.entrySignalSnapshotId ?? null,
+    entryPriceUsd: overrides.entryPriceUsd ?? null,
+    entryAmountXUsd: overrides.entryAmountXUsd ?? null,
+    entryAmountYUsd: overrides.entryAmountYUsd ?? null,
+    cumulativeFeesClaimedUsd: overrides.cumulativeFeesClaimedUsd ?? 0,
+    closedAt: overrides.closedAt ?? null,
+    realizedPnlUsd: overrides.realizedPnlUsd ?? null,
   };
 }
 
@@ -233,6 +240,99 @@ describe("toHistoryJsonOutput", () => {
     expect(json.positions).toHaveLength(0);
     expect(json.summary.positionCount).toBe(0);
     expect(json.summary.totalDepositedUsd).toBe(0);
+  });
+
+  it("prefers the stored realizedPnlUsd over the legacy fallback", () => {
+    const positions = [
+      makePosition({
+        poolAddress: "pool1",
+        depositedUsd: 1000,
+        currentValueUsd: 1100,
+        cumulativeFeesClaimedUsd: 25,
+        closedAt: 1700000000000,
+        realizedPnlUsd: 125,
+      }),
+    ];
+    const json = toHistoryJsonOutput(positions);
+    expect(json.positions[0]).toBeDefined();
+    if (json.positions[0]) {
+      expect(json.positions[0].realizedPnlUsd).toBe(125);
+      expect(json.positions[0].realizedPnlPct).toBeCloseTo(12.5, 5);
+      expect(json.positions[0].feesClaimedUsd).toBe(25);
+      expect(json.positions[0].closedAt).toBe(1700000000000);
+    }
+  });
+});
+
+describe("Wave 4 — PnL accounting fields", () => {
+  it("toJsonOutput surfaces entry price, fees, HODL benchmark, IL and time-in-range", () => {
+    const positions = [
+      makePosition({
+        poolAddress: "pool1",
+        depositedUsd: 1000,
+        currentValueUsd: 1100,
+        cumulativeFeesClaimedUsd: 25,
+        entryPriceUsd: 100,
+        entryAmountXUsd: 500,
+        entryAmountYUsd: 500,
+        timestamp: Date.now() - 24 * 60 * 60 * 1000,
+      }),
+    ];
+    const prices = new Map([["pool1", 110]]);
+    const json = toJsonOutput(positions, prices);
+
+    expect(json.positions[0]).toBeDefined();
+    const p = json.positions[0]!;
+    expect(p.entryPriceUsd).toBe(100);
+    expect(p.feesClaimedUsd).toBe(25);
+    // unrealized = 1100 + 25 − 1000 = 125
+    expect(p.unrealizedPnlUsd).toBeCloseTo(125, 6);
+    expect(p.unrealizedPnlPct).toBeCloseTo(12.5, 4);
+    // HODL = 500 × (110/100) + 500 = 1050 → IL vs HODL = 1100 − 1050 = 50
+    expect(p.hodlValueUsd).toBeCloseTo(1050, 6);
+    expect(p.ilVsHodlUsd).toBeCloseTo(50, 6);
+    expect(p.timeInRangePct).toBe(100);
+    expect(p.feeAprPct).toBeCloseTo(912.5, 1);
+    expect(json.summary.totalFeesClaimedUsd).toBe(25);
+    expect(json.summary.totalUnrealizedPnlUsd).toBeCloseTo(125, 6);
+  });
+
+  it("toJsonOutput degrades to null benchmarks for pre-migration rows", () => {
+    const positions = [
+      makePosition({ poolAddress: "pool1", depositedUsd: 1000, currentValueUsd: 1200 }),
+    ];
+    const json = toJsonOutput(positions, new Map([["pool1", 110]]));
+    const p = json.positions[0]!;
+    expect(p.entryPriceUsd).toBeNull();
+    expect(p.hodlValueUsd).toBeNull();
+    expect(p.ilVsHodlUsd).toBeNull();
+    // Legacy PnL model still works.
+    expect(p.unrealizedPnlUsd).toBeCloseTo(200, 6);
+  });
+
+  it("formatPosition renders fees, IL-vs-HODL and time-in-range lines", () => {
+    const pos = makePosition({
+      poolAddress: "pool1",
+      depositedUsd: 1000,
+      currentValueUsd: 1100,
+      cumulativeFeesClaimedUsd: 25,
+      entryPriceUsd: 100,
+      entryAmountXUsd: 500,
+      entryAmountYUsd: 500,
+      timestamp: Date.now() - 3_600_000,
+    });
+    const text = formatPosition(pos, 110);
+    expect(text).toContain("Fees:");
+    expect(text).toContain("$25.00");
+    expect(text).toContain("IL vs HODL:");
+    expect(text).toContain("In range:");
+    expect(text).toContain("100.0%");
+  });
+
+  it("formatPosition shows n/a for IL-vs-HODL when entry data is missing", () => {
+    const pos = makePosition({ poolAddress: "pool1" });
+    const text = formatPosition(pos, 110);
+    expect(text).toContain("IL vs HODL: n/a");
   });
 });
 

--- a/bench/program.test.ts
+++ b/bench/program.test.ts
@@ -175,6 +175,11 @@ describe("executeLive", () => {
       getPaperExitedPositions: () => Effect.succeed([]),
       deletePosition: () => Effect.void,
       markPaperExited: () => Effect.void,
+      closePosition: () => Effect.void,
+      getClosedPositions: () => Effect.succeed([]),
+      savePositionEvent: () => Effect.void,
+      getPositionEvents: () => Effect.succeed([]),
+      getLatestSnapshotPrice: () => Effect.succeed(null),
       updatePositionValue: () => Effect.void,
       saveAudit: () => Effect.void,
       getRecentAudit: () => Effect.succeed([]),
@@ -243,6 +248,7 @@ describe("executeLive", () => {
           revenueConfigSvc: makeRevenueConfigSvc(),
           trackedPositions: new Map(),
           entryPrep: { prepareEntryTokens: prepareSpy },
+          solPriceUsd: 150,
         },
         {
           action: "ENTER",
@@ -251,7 +257,13 @@ describe("executeLive", () => {
           reasoning: "test",
           positionSizeUsd,
         } as AgentDecision,
-        { activeBinId: 5000, binStep: 10, tokenXSymbol: "SOL", tokenYSymbol: "USDC" },
+        {
+          activeBinId: 5000,
+          binStep: 10,
+          tokenXSymbol: "SOL",
+          tokenYSymbol: "USDC",
+          currentPrice: 150,
+        },
       ),
     );
 
@@ -291,6 +303,7 @@ describe("executeLive", () => {
                 }),
               ),
           },
+          solPriceUsd: 150,
         },
         {
           action: "ENTER",
@@ -299,7 +312,13 @@ describe("executeLive", () => {
           reasoning: "test",
           positionSizeUsd,
         } as AgentDecision,
-        { activeBinId: 5000, binStep: 10, tokenXSymbol: "SOL", tokenYSymbol: "USDC" },
+        {
+          activeBinId: 5000,
+          binStep: 10,
+          tokenXSymbol: "SOL",
+          tokenYSymbol: "USDC",
+          currentPrice: 150,
+        },
       ),
     );
 
@@ -331,6 +350,12 @@ describe("estimatePositionValue", () => {
       paperExitedAt: null,
       entrySignalTimestamp: null,
       entrySignalSnapshotId: null,
+      entryPriceUsd: null,
+      entryAmountXUsd: null,
+      entryAmountYUsd: null,
+      cumulativeFeesClaimedUsd: 0,
+      closedAt: null,
+      realizedPnlUsd: null,
     };
   }
 
@@ -881,6 +906,12 @@ describe("buildPositionSnapshots", () => {
         paperExitedAt: null,
         entrySignalTimestamp: null,
         entrySignalSnapshotId: null,
+        entryPriceUsd: null,
+        entryAmountXUsd: null,
+        entryAmountYUsd: null,
+        cumulativeFeesClaimedUsd: 0,
+        closedAt: null,
+        realizedPnlUsd: null,
       },
       {
         poolAddress: "pool-b",
@@ -902,6 +933,12 @@ describe("buildPositionSnapshots", () => {
         paperExitedAt: null,
         entrySignalTimestamp: null,
         entrySignalSnapshotId: null,
+        entryPriceUsd: null,
+        entryAmountXUsd: null,
+        entryAmountYUsd: null,
+        cumulativeFeesClaimedUsd: 0,
+        closedAt: null,
+        realizedPnlUsd: null,
       },
     ];
 

--- a/bench/reconcile-positions.test.ts
+++ b/bench/reconcile-positions.test.ts
@@ -69,6 +69,12 @@ function makePosition(poolAddress: string, positionPubKey: string | null): Posit
     paperExitedAt: null,
     entrySignalTimestamp: null,
     entrySignalSnapshotId: null,
+    entryPriceUsd: null,
+    entryAmountXUsd: null,
+    entryAmountYUsd: null,
+    cumulativeFeesClaimedUsd: 0,
+    closedAt: null,
+    realizedPnlUsd: null,
   };
 }
 

--- a/cli/portfolio.ts
+++ b/cli/portfolio.ts
@@ -1,8 +1,9 @@
 import { Command } from "commander";
 import { Effect, Layer } from "effect";
 import { DbLive } from "../engine/db-service.js";
-import { DbService } from "../engine/services.js";
+import { DbService, type DbApi } from "../engine/services.js";
 import type { PositionRecord } from "../engine/db-service.js";
+import { computePositionAnalytics } from "../engine/pnl.js";
 import { createLogger } from "../engine/logger.js";
 import { getPrismDbPath } from "../engine/paths.js";
 
@@ -17,13 +18,15 @@ export interface PortfolioSummary {
   totalCurrentValueUsd: number;
   totalUnrealizedPnlUsd: number;
   totalUnrealizedPnlPct: number;
+  totalFeesClaimedUsd: number;
   positionCount: number;
 }
 
 export function computeSummary(positions: ReadonlyArray<PositionRecord>): PortfolioSummary {
   const totalDepositedUsd = positions.reduce((sum, p) => sum + p.depositedUsd, 0);
   const totalCurrentValueUsd = positions.reduce((sum, p) => sum + p.currentValueUsd, 0);
-  const totalUnrealizedPnlUsd = totalCurrentValueUsd - totalDepositedUsd;
+  const totalFeesClaimedUsd = positions.reduce((sum, p) => sum + p.cumulativeFeesClaimedUsd, 0);
+  const totalUnrealizedPnlUsd = totalCurrentValueUsd + totalFeesClaimedUsd - totalDepositedUsd;
   const totalUnrealizedPnlPct =
     totalDepositedUsd > 0 ? (totalUnrealizedPnlUsd / totalDepositedUsd) * 100 : 0;
 
@@ -32,6 +35,7 @@ export function computeSummary(positions: ReadonlyArray<PositionRecord>): Portfo
     totalCurrentValueUsd,
     totalUnrealizedPnlUsd,
     totalUnrealizedPnlPct,
+    totalFeesClaimedUsd,
     positionCount: positions.length,
   };
 }
@@ -64,21 +68,46 @@ function colorize(text: string, colorCode: string): string {
   return `${colorCode}${text}\x1b[0m`;
 }
 
-function formatPosition(pos: PositionRecord): string {
-  const { pnlUsd, pnlPct } = computePnl(pos.depositedUsd, pos.currentValueUsd);
-  const pnlText = `${formatCurrency(pnlUsd)} (${formatPct(pnlPct)})`;
-  const coloredPnl = colorize(pnlText, pnlUsd >= 0 ? "\x1b[32m" : "\x1b[31m");
+export function formatPosition(pos: PositionRecord, currentPriceUsd: number | null): string {
+  const analytics = computePositionAnalytics(
+    {
+      depositedUsd: pos.depositedUsd,
+      currentValueUsd: pos.currentValueUsd,
+      cumulativeFeesClaimedUsd: pos.cumulativeFeesClaimedUsd,
+      entryPriceUsd: pos.entryPriceUsd,
+      entryAmountXUsd: pos.entryAmountXUsd,
+      entryAmountYUsd: pos.entryAmountYUsd,
+      openedAtMs: pos.timestamp,
+      outOfRangeSinceMs: pos.outOfRangeSince,
+    },
+    currentPriceUsd,
+    Date.now(),
+  );
+  const pnlText = `${formatCurrency(analytics.unrealizedPnlUsd)} (${formatPct(analytics.unrealizedPnlPct)})`;
+  const coloredPnl = colorize(pnlText, analytics.unrealizedPnlUsd >= 0 ? "\x1b[32m" : "\x1b[31m");
 
   const poolName = `${pos.tokenXSymbol}/${pos.tokenYSymbol}`;
   const range = `[${pos.lowerBinId}–${pos.upperBinId}]`;
   const age = formatAge(pos.timestamp);
+  const ilText =
+    analytics.ilVsHodlUsd != null
+      ? colorize(
+          `${analytics.ilVsHodlUsd >= 0 ? "+" : ""}${formatCurrency(analytics.ilVsHodlUsd)}`,
+          analytics.ilVsHodlUsd >= 0 ? "\x1b[32m" : "\x1b[31m",
+        )
+      : "n/a";
+  const inRangeText =
+    analytics.timeInRangePct != null ? `${analytics.timeInRangePct.toFixed(1)}%` : "n/a";
 
   return [
     `  ${poolName} ${range}`,
-    `    Pool:     ${pos.poolAddress}`,
+    `    Pool:       ${pos.poolAddress}`,
     `    Deposited:  ${formatCurrency(pos.depositedUsd)}`,
     `    Current:    ${formatCurrency(pos.currentValueUsd)}`,
     `    P&L:        ${coloredPnl}`,
+    `    Fees:       ${formatCurrency(analytics.feesClaimedUsd)}`,
+    `    IL vs HODL: ${ilText}`,
+    `    In range:   ${inRangeText}`,
     `    Active bin: ${pos.activeBinId}`,
     `    Age:        ${age}`,
     pos.outOfRangeSince != null ? `    ⚠ Out of range since ${formatAge(pos.outOfRangeSince)}` : "",
@@ -112,14 +141,18 @@ function formatSummary(summary: PortfolioSummary): string {
   return [
     "Portfolio Summary",
     "=================",
-    `  Positions:     ${summary.positionCount}`,
+    `  Positions:        ${summary.positionCount}`,
     `  Total Deposited:  ${formatCurrency(summary.totalDepositedUsd)}`,
     `  Total Current:    ${formatCurrency(summary.totalCurrentValueUsd)}`,
+    `  Fees Claimed:     ${formatCurrency(summary.totalFeesClaimedUsd)}`,
     `  Unrealized P&L:   ${coloredPnl}`,
   ].join("\n");
 }
 
-function formatPositionsList(positions: ReadonlyArray<PositionRecord>): string {
+function formatPositionsList(
+  positions: ReadonlyArray<PositionRecord>,
+  prices: ReadonlyMap<string, number>,
+): string {
   if (positions.length === 0) {
     return "No active positions.\n";
   }
@@ -129,11 +162,18 @@ function formatPositionsList(positions: ReadonlyArray<PositionRecord>): string {
   lines.push("=".repeat(40));
 
   for (const pos of positions) {
-    lines.push(formatPosition(pos));
+    lines.push(formatPosition(pos, prices.get(pos.poolAddress) ?? null));
     lines.push("");
   }
 
   return lines.join("\n");
+}
+
+function realizedPnlFor(pos: PositionRecord): { pnlUsd: number; pnlPct: number } {
+  const pnlUsd =
+    pos.realizedPnlUsd ?? pos.currentValueUsd + pos.cumulativeFeesClaimedUsd - pos.depositedUsd;
+  const pnlPct = pos.depositedUsd > 0 ? (pnlUsd / pos.depositedUsd) * 100 : 0;
+  return { pnlUsd, pnlPct };
 }
 
 function formatHistoryList(positions: ReadonlyArray<PositionRecord>): string {
@@ -146,18 +186,18 @@ function formatHistoryList(positions: ReadonlyArray<PositionRecord>): string {
   lines.push("=".repeat(40));
 
   for (const pos of positions) {
-    const { pnlUsd, pnlPct } = computePnl(pos.depositedUsd, pos.currentValueUsd);
+    const { pnlUsd, pnlPct } = realizedPnlFor(pos);
     const pnlText = `${formatCurrency(pnlUsd)} (${formatPct(pnlPct)})`;
     const coloredPnl = colorize(pnlText, pnlUsd >= 0 ? "\x1b[32m" : "\x1b[31m");
+    const exitedAt = pos.closedAt ?? pos.paperExitedAt;
 
     lines.push(`  ${pos.tokenXSymbol}/${pos.tokenYSymbol}`);
-    lines.push(`    Pool:      ${pos.poolAddress}`);
+    lines.push(`    Pool:       ${pos.poolAddress}`);
     lines.push(`    Deposited:  ${formatCurrency(pos.depositedUsd)}`);
     lines.push(`    Exit Value: ${formatCurrency(pos.currentValueUsd)}`);
+    lines.push(`    Fees:       ${formatCurrency(pos.cumulativeFeesClaimedUsd)}`);
     lines.push(`    Realized P&L: ${coloredPnl}`);
-    lines.push(
-      `    Exited:     ${pos.paperExitedAt != null ? new Date(pos.paperExitedAt).toISOString() : "N/A"}`,
-    );
+    lines.push(`    Exited:     ${exitedAt != null ? new Date(exitedAt).toISOString() : "N/A"}`);
     lines.push("");
   }
 
@@ -173,6 +213,12 @@ export interface PortfolioJsonOutput {
     currentValueUsd: number;
     unrealizedPnlUsd: number;
     unrealizedPnlPct: number;
+    entryPriceUsd: number | null;
+    feesClaimedUsd: number;
+    hodlValueUsd: number | null;
+    ilVsHodlUsd: number | null;
+    timeInRangePct: number | null;
+    feeAprPct: number | null;
     activeBinId: number;
     lowerBinId: number;
     upperBinId: number;
@@ -183,18 +229,40 @@ export interface PortfolioJsonOutput {
   summary: PortfolioSummary;
 }
 
-export function toJsonOutput(positions: ReadonlyArray<PositionRecord>): PortfolioJsonOutput {
+export function toJsonOutput(
+  positions: ReadonlyArray<PositionRecord>,
+  prices: ReadonlyMap<string, number> = new Map(),
+): PortfolioJsonOutput {
   return {
     positions: positions.map((pos) => {
-      const { pnlUsd, pnlPct } = computePnl(pos.depositedUsd, pos.currentValueUsd);
+      const analytics = computePositionAnalytics(
+        {
+          depositedUsd: pos.depositedUsd,
+          currentValueUsd: pos.currentValueUsd,
+          cumulativeFeesClaimedUsd: pos.cumulativeFeesClaimedUsd,
+          entryPriceUsd: pos.entryPriceUsd,
+          entryAmountXUsd: pos.entryAmountXUsd,
+          entryAmountYUsd: pos.entryAmountYUsd,
+          openedAtMs: pos.timestamp,
+          outOfRangeSinceMs: pos.outOfRangeSince,
+        },
+        prices.get(pos.poolAddress) ?? null,
+        Date.now(),
+      );
       return {
         poolAddress: pos.poolAddress,
         poolName: `${pos.tokenXSymbol}/${pos.tokenYSymbol}`,
         positionPubKey: pos.positionPubKey,
         depositedUsd: pos.depositedUsd,
         currentValueUsd: pos.currentValueUsd,
-        unrealizedPnlUsd: pnlUsd,
-        unrealizedPnlPct: pnlPct,
+        unrealizedPnlUsd: analytics.unrealizedPnlUsd,
+        unrealizedPnlPct: analytics.unrealizedPnlPct,
+        entryPriceUsd: pos.entryPriceUsd,
+        feesClaimedUsd: analytics.feesClaimedUsd,
+        hodlValueUsd: analytics.hodlValueUsd,
+        ilVsHodlUsd: analytics.ilVsHodlUsd,
+        timeInRangePct: analytics.timeInRangePct,
+        feeAprPct: analytics.feeAprPct,
         activeBinId: pos.activeBinId,
         lowerBinId: pos.lowerBinId,
         upperBinId: pos.upperBinId,
@@ -213,8 +281,10 @@ export interface HistoryJsonOutput {
     poolName: string;
     depositedUsd: number;
     exitValueUsd: number;
+    feesClaimedUsd: number;
     realizedPnlUsd: number;
     realizedPnlPct: number;
+    closedAt: number | null;
     paperExitedAt: number | null;
   }>;
   summary: PortfolioSummary;
@@ -223,14 +293,16 @@ export interface HistoryJsonOutput {
 export function toHistoryJsonOutput(positions: ReadonlyArray<PositionRecord>): HistoryJsonOutput {
   return {
     positions: positions.map((pos) => {
-      const { pnlUsd, pnlPct } = computePnl(pos.depositedUsd, pos.currentValueUsd);
+      const { pnlUsd, pnlPct } = realizedPnlFor(pos);
       return {
         poolAddress: pos.poolAddress,
         poolName: `${pos.tokenXSymbol}/${pos.tokenYSymbol}`,
         depositedUsd: pos.depositedUsd,
         exitValueUsd: pos.currentValueUsd,
+        feesClaimedUsd: pos.cumulativeFeesClaimedUsd,
         realizedPnlUsd: pnlUsd,
         realizedPnlPct: pnlPct,
+        closedAt: pos.closedAt,
         paperExitedAt: pos.paperExitedAt,
       };
     }),
@@ -275,13 +347,14 @@ portfolioCommand.action(async function (this: Command, opts: { json?: boolean })
       Effect.gen(function* () {
         const db = yield* DbService;
         const positions = yield* db.getAllPositions();
+        const prices = yield* latestPrices(db, positions);
 
         if (isJson) {
-          console.log(JSON.stringify(toJsonOutput(positions), null, 2));
+          console.log(JSON.stringify(toJsonOutput(positions, prices), null, 2));
           return;
         }
 
-        console.log(formatPositionsList(positions));
+        console.log(formatPositionsList(positions, prices));
         console.log(formatSummary(computeSummary(positions)));
       }).pipe(Effect.provide(program)),
     );
@@ -330,7 +403,7 @@ portfolioCommand
       await Effect.runPromise(
         Effect.gen(function* () {
           const db = yield* DbService;
-          const positions = yield* db.getPaperExitedPositions();
+          const positions = yield* db.getClosedPositions();
 
           if (isJson) {
             console.log(JSON.stringify(toHistoryJsonOutput(positions), null, 2));
@@ -342,3 +415,19 @@ portfolioCommand
       );
     });
   });
+
+function latestPrices(
+  db: DbApi,
+  positions: ReadonlyArray<PositionRecord>,
+): Effect.Effect<ReadonlyMap<string, number>, never, never> {
+  return Effect.gen(function* () {
+    const prices = new Map<string, number>();
+    for (const pos of positions) {
+      const price = yield* db
+        .getLatestSnapshotPrice(pos.poolAddress)
+        .pipe(Effect.catchAll(() => Effect.succeed(null)));
+      if (price != null) prices.set(pos.poolAddress, price);
+    }
+    return prices;
+  });
+}

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -74,6 +74,13 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
           const summary = computeSummary(positions);
 
           const activePositions = positions.filter((p) => p.paperExitedAt === null);
+          const prices = new Map<string, number>();
+          for (const pos of activePositions) {
+            const price = yield* db
+              .getLatestSnapshotPrice(pos.poolAddress)
+              .pipe(Effect.catchAll(() => Effect.succeed(null)));
+            if (price != null) prices.set(pos.poolAddress, price);
+          }
           const hasDb = positions.length > 0 || recentAudit.length > 0;
           const lastActivityAt = recentAudit[0]?.timestamp ?? 0;
           const lock = readLockfile();
@@ -97,7 +104,7 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
                 checkinOnEvents: config.agentCheckinOnEvents,
               },
               portfolio: summary,
-              positions: toJsonOutput(activePositions).positions,
+              positions: toJsonOutput(activePositions, prices).positions,
               recentDecisions: recentAudit.slice(0, 10).map((d) => ({
                 timestamp: new Date(d.timestamp).toISOString(),
                 action: d.action,
@@ -135,6 +142,7 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
               `Positions: ${activePositions.length} active`,
               `Deposited: $${summary.totalDepositedUsd.toFixed(2)}`,
               `Current:   $${summary.totalCurrentValueUsd.toFixed(2)}`,
+              `Fees:      $${summary.totalFeesClaimedUsd.toFixed(2)}`,
               `Unrealized: ${pnlEmoji} $${summary.totalUnrealizedPnlUsd.toFixed(2)} (${summary.totalUnrealizedPnlPct.toFixed(2)}%)`,
               "",
               "*Open positions*",
@@ -163,6 +171,7 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
               `  Positions:   ${activePositions.length} active`,
               `  Deposited:   $${summary.totalDepositedUsd.toFixed(2)}`,
               `  Current:     $${summary.totalCurrentValueUsd.toFixed(2)}`,
+              `  Fees:        $${summary.totalFeesClaimedUsd.toFixed(2)}`,
               `  Unrealized:  ${pnlText}`,
               `  ${agentStatus}`,
               "",

--- a/engine/db-service.ts
+++ b/engine/db-service.ts
@@ -37,6 +37,26 @@ export interface PositionRecord {
   paperExitedAt: number | null;
   entrySignalTimestamp: number | null;
   entrySignalSnapshotId: number | null;
+  entryPriceUsd: number | null;
+  entryAmountXUsd: number | null;
+  entryAmountYUsd: number | null;
+  cumulativeFeesClaimedUsd: number;
+  closedAt: number | null;
+  realizedPnlUsd: number | null;
+}
+
+export type PositionEventType = "ENTER" | "EXIT" | "REBALANCE" | "CLAIM" | "COMPOUND";
+
+export interface PositionEventRecord {
+  id: string;
+  poolAddress: string;
+  positionPubKey: string | null;
+  event: PositionEventType;
+  valueUsd: number | null;
+  feesUsd: number | null;
+  price: number | null;
+  metadata: string | null;
+  createdAt: number;
 }
 
 export interface AuditRecord {
@@ -116,8 +136,10 @@ export const DbLive = (dbPath?: string) =>
               timestamp, out_of_range_since, oor_cycle_count, last_fee_claim_at,
               trailing_stop_threshold, highest_value_usd, last_rebalance_at, paper_exited_at,
               entry_signal_timestamp,
-              entry_signal_snapshot_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              entry_signal_snapshot_id,
+              entry_price_usd, entry_amount_x_usd, entry_amount_y_usd,
+              cumulative_fees_claimed_usd, closed_at, realized_pnl_usd
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(pool_address) DO UPDATE SET
               position_pubkey = COALESCE(excluded.position_pubkey, positions.position_pubkey),
               deposited_usd = excluded.deposited_usd,
@@ -136,7 +158,13 @@ export const DbLive = (dbPath?: string) =>
               last_rebalance_at = excluded.last_rebalance_at,
               paper_exited_at = excluded.paper_exited_at,
               entry_signal_timestamp = excluded.entry_signal_timestamp,
-              entry_signal_snapshot_id = excluded.entry_signal_snapshot_id`,
+              entry_signal_snapshot_id = excluded.entry_signal_snapshot_id,
+              entry_price_usd = COALESCE(excluded.entry_price_usd, positions.entry_price_usd),
+              entry_amount_x_usd = COALESCE(excluded.entry_amount_x_usd, positions.entry_amount_x_usd),
+              entry_amount_y_usd = COALESCE(excluded.entry_amount_y_usd, positions.entry_amount_y_usd),
+              cumulative_fees_claimed_usd = excluded.cumulative_fees_claimed_usd,
+              closed_at = excluded.closed_at,
+              realized_pnl_usd = excluded.realized_pnl_usd`,
               pos.poolAddress,
               pos.positionPubKey,
               pos.depositedUsd,
@@ -156,6 +184,12 @@ export const DbLive = (dbPath?: string) =>
               pos.paperExitedAt,
               pos.entrySignalTimestamp,
               pos.entrySignalSnapshotId,
+              pos.entryPriceUsd,
+              pos.entryAmountXUsd,
+              pos.entryAmountYUsd,
+              pos.cumulativeFeesClaimedUsd,
+              pos.closedAt,
+              pos.realizedPnlUsd,
             );
           }),
 
@@ -173,7 +207,7 @@ export const DbLive = (dbPath?: string) =>
           Effect.sync(() => {
             const rows = queryAll<Record<string, unknown>>(
               db,
-              "SELECT * FROM positions WHERE paper_exited_at IS NULL",
+              "SELECT * FROM positions WHERE paper_exited_at IS NULL AND closed_at IS NULL",
             );
             return rows.map(rowToPosition);
           }),
@@ -183,6 +217,17 @@ export const DbLive = (dbPath?: string) =>
             const rows = queryAll<Record<string, unknown>>(
               db,
               "SELECT * FROM positions WHERE paper_exited_at IS NOT NULL ORDER BY paper_exited_at DESC",
+            );
+            return rows.map(rowToPosition);
+          }),
+
+        getClosedPositions: () =>
+          Effect.sync(() => {
+            const rows = queryAll<Record<string, unknown>>(
+              db,
+              `SELECT * FROM positions
+               WHERE closed_at IS NOT NULL OR paper_exited_at IS NOT NULL
+               ORDER BY COALESCE(closed_at, paper_exited_at) DESC`,
             );
             return rows.map(rowToPosition);
           }),
@@ -200,6 +245,62 @@ export const DbLive = (dbPath?: string) =>
               Date.now(),
               poolAddress,
             );
+          }),
+
+        closePosition: (poolAddress, realizedPnlUsd) =>
+          Effect.sync(() => {
+            runOne(
+              db,
+              "UPDATE positions SET closed_at = ?, realized_pnl_usd = ? WHERE pool_address = ?",
+              Date.now(),
+              realizedPnlUsd,
+              poolAddress,
+            );
+          }),
+
+        savePositionEvent: (event) =>
+          Effect.sync(() => {
+            runOne(
+              db,
+              `INSERT INTO position_events (
+                id, pool_address, position_pubkey, event,
+                value_usd, fees_usd, price, metadata, created_at
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+              event.id,
+              event.poolAddress,
+              event.positionPubKey,
+              event.event,
+              event.valueUsd,
+              event.feesUsd,
+              event.price,
+              event.metadata != null ? serializeJson(event.metadata) : null,
+              event.createdAt,
+            );
+          }),
+
+        getPositionEvents: (poolAddress, limit) =>
+          Effect.sync(() => {
+            const rows = queryAll<Record<string, unknown>>(
+              db,
+              `SELECT * FROM position_events
+               WHERE pool_address = ?
+               ORDER BY created_at ASC, rowid ASC
+               ${limit != null ? "LIMIT ?" : ""}`,
+              ...(limit != null ? [poolAddress, limit] : [poolAddress]),
+            );
+            return rows.map(rowToPositionEvent);
+          }),
+
+        getLatestSnapshotPrice: (poolAddress) =>
+          Effect.sync(() => {
+            const row = queryOne<{ current_price: number }>(
+              db,
+              `SELECT current_price FROM pool_snapshots
+               WHERE pool_address = ?
+               ORDER BY timestamp DESC LIMIT 1`,
+              poolAddress,
+            );
+            return row ? Number(row.current_price) : null;
           }),
 
         updatePositionValue: (poolAddress, currentValueUsd, highestValueUsd) =>
@@ -907,6 +1008,26 @@ function rowToPosition(row: Record<string, unknown>): PositionRecord {
       row.entry_signal_timestamp != null ? Number(row.entry_signal_timestamp) : null,
     entrySignalSnapshotId:
       row.entry_signal_snapshot_id != null ? Number(row.entry_signal_snapshot_id) : null,
+    entryPriceUsd: row.entry_price_usd != null ? Number(row.entry_price_usd) : null,
+    entryAmountXUsd: row.entry_amount_x_usd != null ? Number(row.entry_amount_x_usd) : null,
+    entryAmountYUsd: row.entry_amount_y_usd != null ? Number(row.entry_amount_y_usd) : null,
+    cumulativeFeesClaimedUsd: Number(row.cumulative_fees_claimed_usd ?? 0),
+    closedAt: row.closed_at != null ? Number(row.closed_at) : null,
+    realizedPnlUsd: row.realized_pnl_usd != null ? Number(row.realized_pnl_usd) : null,
+  };
+}
+
+function rowToPositionEvent(row: Record<string, unknown>): PositionEventRecord {
+  return {
+    id: String(row.id),
+    poolAddress: String(row.pool_address),
+    positionPubKey: row.position_pubkey ? String(row.position_pubkey) : null,
+    event: String(row.event) as PositionEventType,
+    valueUsd: row.value_usd != null ? Number(row.value_usd) : null,
+    feesUsd: row.fees_usd != null ? Number(row.fees_usd) : null,
+    price: row.price != null ? Number(row.price) : null,
+    metadata: row.metadata != null ? String(row.metadata) : null,
+    createdAt: Number(row.created_at ?? 0),
   };
 }
 

--- a/engine/db.ts
+++ b/engine/db.ts
@@ -494,6 +494,53 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
       }
     },
   },
+  {
+    version: 16,
+    name: "pnl_accounting",
+    up(db) {
+      // Per-position PnL accounting. Entry columns stay NULL for positions
+      // opened before this migration — analytics degrade gracefully on them.
+      if (!hasColumn(db, "positions", "entry_price_usd")) {
+        db.exec("ALTER TABLE positions ADD COLUMN entry_price_usd REAL");
+      }
+      if (!hasColumn(db, "positions", "entry_amount_x_usd")) {
+        db.exec("ALTER TABLE positions ADD COLUMN entry_amount_x_usd REAL");
+      }
+      if (!hasColumn(db, "positions", "entry_amount_y_usd")) {
+        db.exec("ALTER TABLE positions ADD COLUMN entry_amount_y_usd REAL");
+      }
+      if (!hasColumn(db, "positions", "cumulative_fees_claimed_usd")) {
+        db.exec(
+          "ALTER TABLE positions ADD COLUMN cumulative_fees_claimed_usd REAL NOT NULL DEFAULT 0",
+        );
+      }
+      if (!hasColumn(db, "positions", "closed_at")) {
+        db.exec("ALTER TABLE positions ADD COLUMN closed_at INTEGER");
+      }
+      if (!hasColumn(db, "positions", "realized_pnl_usd")) {
+        db.exec("ALTER TABLE positions ADD COLUMN realized_pnl_usd REAL");
+      }
+
+      // Append-only lifecycle event log (ENTER/EXIT/REBALANCE/CLAIM/COMPOUND).
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS position_events (
+          id TEXT PRIMARY KEY,
+          pool_address TEXT NOT NULL,
+          position_pubkey TEXT,
+          event TEXT NOT NULL,
+          value_usd REAL,
+          fees_usd REAL,
+          price REAL,
+          metadata TEXT,
+          created_at INTEGER NOT NULL
+        );
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_position_events_pool_time
+          ON position_events(pool_address, created_at);
+      `);
+    },
+  },
 ];
 
 function runMigrations(db: Database) {

--- a/engine/pnl.ts
+++ b/engine/pnl.ts
@@ -1,0 +1,169 @@
+// ─── Per-position PnL accounting (pure functions) ────────────────────────────
+//
+// Data model (Wave 4):
+// - `depositedUsd` is the position cost basis. Auto-compounded fees become new
+//   cost basis when they are redeposited (see applyCompoundToCostBasis), which
+//   keeps total-PnL and trailing-stop math continuous across a compound.
+// - `entryPriceUsd` is the pool's `currentPrice` at ENTER (price of token X
+//   denominated in token Y, as served by the DLMM SDK / Meteora Data API).
+// - `entryAmountXUsd` / `entryAmountYUsd` are the USD values of each leg at
+//   entry. The adapter does not return actual on-chain deposit amounts, so the
+//   engine records the documented 50/50 model: each leg is half of the entry
+//   size in USD. This matches a symmetric range centered on the active bin.
+// - Positions opened before this accounting existed have NULL entry fields;
+//   analytics degrade gracefully (no HODL benchmark, PnL from cost basis).
+
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+export interface PositionAnalyticsInput {
+  /** Cost basis: initial deposit plus any compounded fees. */
+  readonly depositedUsd: number;
+  /** Latest estimated position value (per-cycle mark). */
+  readonly currentValueUsd: number;
+  /** Total fees claimed over the position lifecycle, in USD. */
+  readonly cumulativeFeesClaimedUsd: number;
+  /** Pool price at entry; null for pre-migration rows. */
+  readonly entryPriceUsd: number | null;
+  /** USD value of the token-X leg at entry; null for pre-migration rows. */
+  readonly entryAmountXUsd: number | null;
+  /** USD value of the token-Y leg at entry; null for pre-migration rows. */
+  readonly entryAmountYUsd: number | null;
+  /** Position open timestamp (ms). */
+  readonly openedAtMs: number;
+  /** Start of the current out-of-range stint (ms); null when in range. */
+  readonly outOfRangeSinceMs: number | null;
+}
+
+export interface PositionAnalytics {
+  readonly costBasisUsd: number;
+  /** currentValue + cumulativeFees − costBasis. */
+  readonly unrealizedPnlUsd: number;
+  /** unrealizedPnlUsd / costBasis × 100 (0 when basis is 0). */
+  readonly unrealizedPnlPct: number;
+  readonly feesClaimedUsd: number;
+  /** HODL benchmark value; null when entry data or current price is missing. */
+  readonly hodlValueUsd: number | null;
+  /** currentValue − hodlValue (negative = worse than holding); null as above. */
+  readonly ilVsHodlUsd: number | null;
+  /**
+   * Approximation: 1 − (current OOR stint / age). Only the current stint is
+   * tracked, so recovered past stints count as in-range time (documented
+   * overestimate for positions that went out of range and came back).
+   */
+  readonly timeInRangePct: number | null;
+  /** Fees / cost basis annualized by position age; null when age or basis is 0. */
+  readonly feeAprPct: number | null;
+  readonly ageMs: number;
+}
+
+/**
+ * HODL benchmark: what the entry capital would be worth if it had never been
+ * deposited. The X leg moves with the price ratio, the Y leg (numeraire) is
+ * constant. Returns null when the entry price is not positive.
+ */
+export function computeHodlValueUsd(
+  entryAmountXUsd: number,
+  entryAmountYUsd: number,
+  entryPriceUsd: number,
+  currentPriceUsd: number,
+): number | null {
+  if (!(entryPriceUsd > 0)) return null;
+  return entryAmountXUsd * (currentPriceUsd / entryPriceUsd) + entryAmountYUsd;
+}
+
+/** Fees earned annualized against cost basis. Null when age or basis is 0. */
+export function computeFeeAprPct(
+  feesClaimedUsd: number,
+  costBasisUsd: number,
+  ageMs: number,
+): number | null {
+  if (costBasisUsd <= 0 || ageMs <= 0) return null;
+  return (feesClaimedUsd / costBasisUsd) * (YEAR_MS / ageMs) * 100;
+}
+
+/**
+ * Time-in-range approximation (see PositionAnalytics.timeInRangePct).
+ * Null when the position age is zero.
+ */
+export function computeTimeInRangePct(
+  ageMs: number,
+  outOfRangeSinceMs: number | null,
+  nowMs: number,
+): number | null {
+  if (ageMs <= 0) return null;
+  const oorMs = outOfRangeSinceMs != null ? Math.max(0, nowMs - outOfRangeSinceMs) : 0;
+  const ratio = Math.max(0, 1 - oorMs / ageMs);
+  return ratio * 100;
+}
+
+export function computePositionAnalytics(
+  input: PositionAnalyticsInput,
+  currentPriceUsd: number | null,
+  nowMs: number,
+): PositionAnalytics {
+  const ageMs = Math.max(0, nowMs - input.openedAtMs);
+  const unrealizedPnlUsd =
+    input.currentValueUsd + input.cumulativeFeesClaimedUsd - input.depositedUsd;
+  const unrealizedPnlPct =
+    input.depositedUsd > 0 ? (unrealizedPnlUsd / input.depositedUsd) * 100 : 0;
+
+  const hasEntryLegs =
+    input.entryPriceUsd != null && input.entryAmountXUsd != null && input.entryAmountYUsd != null;
+  const hodlValueUsd =
+    hasEntryLegs && currentPriceUsd != null
+      ? computeHodlValueUsd(
+          input.entryAmountXUsd!,
+          input.entryAmountYUsd!,
+          input.entryPriceUsd!,
+          currentPriceUsd,
+        )
+      : null;
+
+  return {
+    costBasisUsd: input.depositedUsd,
+    unrealizedPnlUsd,
+    unrealizedPnlPct,
+    feesClaimedUsd: input.cumulativeFeesClaimedUsd,
+    hodlValueUsd,
+    ilVsHodlUsd: hodlValueUsd != null ? input.currentValueUsd - hodlValueUsd : null,
+    timeInRangePct: computeTimeInRangePct(ageMs, input.outOfRangeSinceMs, nowMs),
+    feeAprPct: computeFeeAprPct(input.cumulativeFeesClaimedUsd, input.depositedUsd, ageMs),
+    ageMs,
+  };
+}
+
+/** Realized PnL at close: final value + cumulative fees − cost basis. */
+export function computeRealizedPnlUsd(
+  finalValueUsd: number,
+  cumulativeFeesClaimedUsd: number,
+  costBasisUsd: number,
+): number {
+  return finalValueUsd + cumulativeFeesClaimedUsd - costBasisUsd;
+}
+
+/**
+ * Cost-basis bookkeeping for an auto-compound of already-claimed fees.
+ *
+ * The fees were counted once in `cumulativeFeesClaimedUsd` when claimed.
+ * Redepositing them injects new capital into the position, so the cost basis
+ * rises by the same amount — the two cancel in total-PnL math, keeping it
+ * continuous. `currentValueUsd` rises by the compounded amount and
+ * `highestValueUsd` tracks the new peak, fixing the W2 reviewer finding where
+ * `depositedUsd` was inflated without adjusting the value columns (which
+ * distorted PnL and the trailing stop).
+ */
+export function applyCompoundToCostBasis(input: {
+  readonly depositedUsd: number;
+  readonly currentValueUsd: number;
+  readonly highestValueUsd: number | null;
+  readonly compoundedFeesUsd: number;
+}): {
+  readonly depositedUsd: number;
+  readonly currentValueUsd: number;
+  readonly highestValueUsd: number;
+} {
+  const depositedUsd = input.depositedUsd + input.compoundedFeesUsd;
+  const currentValueUsd = input.currentValueUsd + input.compoundedFeesUsd;
+  const highest = Math.max(input.highestValueUsd ?? input.depositedUsd, currentValueUsd);
+  return { depositedUsd, currentValueUsd, highestValueUsd: highest };
+}

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -39,6 +39,7 @@ import { shouldDiscoverPools } from "./pool-policy.js";
 
 import { checkForAutoUpdate } from "./update-check.js";
 import type { PositionRecord } from "./db-service.js";
+import { applyCompoundToCostBasis, computeRealizedPnlUsd } from "./pnl.js";
 import { BlacklistError, DiscoverPoolsError } from "./errors.js";
 import {
   GAS_TOP_UP_USDC,
@@ -418,6 +419,12 @@ export function reconcilePositions(
             paperExitedAt: null,
             entrySignalTimestamp: null,
             entrySignalSnapshotId: null,
+            entryPriceUsd: null,
+            entryAmountXUsd: null,
+            entryAmountYUsd: null,
+            cumulativeFeesClaimedUsd: 0,
+            closedAt: null,
+            realizedPnlUsd: null,
           };
           trackedPositions.set(onChainPos.poolAddress, pos);
           yield* db.savePosition(pos).pipe(Effect.catchAll(() => Effect.void));
@@ -548,7 +555,13 @@ export function executePaper(
     trackedPositions: Map<string, PositionRecord>;
   },
   decision: AgentDecision,
-  pool: { activeBinId: number; binStep: number; tokenXSymbol: string; tokenYSymbol: string },
+  pool: {
+    activeBinId: number;
+    binStep: number;
+    tokenXSymbol: string;
+    tokenYSymbol: string;
+    currentPrice: number;
+  },
   signalTimestamp?: number,
   signalSnapshotId?: number,
 ): Effect.Effect<{ executed: boolean; error: string | undefined }, never> {
@@ -578,9 +591,28 @@ export function executePaper(
         paperExitedAt: liveExited ? existing!.paperExitedAt : null,
         entrySignalTimestamp: signalTimestamp ?? null,
         entrySignalSnapshotId: signalSnapshotId ?? null,
+        entryPriceUsd: pool.currentPrice,
+        entryAmountXUsd: decision.positionSizeUsd / 2,
+        entryAmountYUsd: decision.positionSizeUsd / 2,
+        cumulativeFeesClaimedUsd: 0,
+        closedAt: null,
+        realizedPnlUsd: null,
       };
       trackedPositions.set(decision.poolAddress, pos);
       yield* db.savePosition(pos).pipe(Effect.catchAll(() => Effect.void));
+      yield* db
+        .savePositionEvent({
+          id: randomUUID(),
+          poolAddress: decision.poolAddress,
+          positionPubKey: pos.positionPubKey,
+          event: "ENTER",
+          valueUsd: decision.positionSizeUsd,
+          feesUsd: null,
+          price: pool.currentPrice,
+          metadata: { lowerBinId: pos.lowerBinId, upperBinId: pos.upperBinId },
+          createdAt: Date.now(),
+        })
+        .pipe(Effect.catchAll(() => Effect.void));
     } else if (decision.action === "EXIT") {
       const pos = trackedPositions.get(decision.poolAddress);
       if (pos?.positionPubKey) {
@@ -601,6 +633,29 @@ export function executePaper(
           .recordSignalOutcome(pos.entrySignalSnapshotId, pnlUsd)
           .pipe(Effect.catchAll(() => Effect.void));
       }
+      if (pos) {
+        const realizedPnlUsd = computeRealizedPnlUsd(
+          pos.currentValueUsd,
+          pos.cumulativeFeesClaimedUsd,
+          pos.depositedUsd,
+        );
+        yield* db
+          .savePositionEvent({
+            id: randomUUID(),
+            poolAddress: decision.poolAddress,
+            positionPubKey: pos.positionPubKey,
+            event: "EXIT",
+            valueUsd: pos.currentValueUsd,
+            feesUsd: pos.cumulativeFeesClaimedUsd,
+            price: pool.currentPrice,
+            metadata: { realizedPnlUsd },
+            createdAt: Date.now(),
+          })
+          .pipe(Effect.catchAll(() => Effect.void));
+        yield* db
+          .closePosition(decision.poolAddress, realizedPnlUsd)
+          .pipe(Effect.catchAll(() => Effect.void));
+      }
       yield* db.markPaperExited(decision.poolAddress).pipe(Effect.catchAll(() => Effect.void));
       trackedPositions.delete(decision.poolAddress);
     } else if (
@@ -617,6 +672,22 @@ export function executePaper(
       };
       trackedPositions.set(decision.poolAddress, updated);
       yield* db.savePosition(updated).pipe(Effect.catchAll(() => Effect.void));
+      yield* db
+        .savePositionEvent({
+          id: randomUUID(),
+          poolAddress: decision.poolAddress,
+          positionPubKey: updated.positionPubKey,
+          event: "REBALANCE",
+          valueUsd: updated.currentValueUsd,
+          feesUsd: null,
+          price: pool.currentPrice,
+          metadata: {
+            newLowerBinId: decision.rebalanceParams.newLowerBinId,
+            newUpperBinId: decision.rebalanceParams.newUpperBinId,
+          },
+          createdAt: Date.now(),
+        })
+        .pipe(Effect.catchAll(() => Effect.void));
     }
     return { executed: true, error: undefined };
   });
@@ -637,14 +708,22 @@ export function executeLive(
     revenueConfigSvc: RevenueConfigApi;
     trackedPositions: Map<string, PositionRecord>;
     entryPrep: EntryPrepApi;
+    solPriceUsd: number;
   },
   decision: AgentDecision,
-  pool: { activeBinId: number; binStep: number; tokenXSymbol: string; tokenYSymbol: string },
+  pool: {
+    activeBinId: number;
+    binStep: number;
+    tokenXSymbol: string;
+    tokenYSymbol: string;
+    currentPrice: number;
+  },
   signalTimestamp?: number,
   signalSnapshotId?: number,
 ): Effect.Effect<{ executed: boolean; error: string | undefined }, never, never> {
   return Effect.gen(function* () {
-    const { adapter, strategy, db, revenueConfigSvc, trackedPositions, entryPrep } = deps;
+    const { adapter, strategy, db, revenueConfigSvc, trackedPositions, entryPrep, solPriceUsd } =
+      deps;
 
     if (!adapter.hasWallet()) {
       console.error("Live trading enabled but no wallet configured");
@@ -747,9 +826,32 @@ export function executeLive(
           paperExitedAt: null,
           entrySignalTimestamp: signalTimestamp ?? null,
           entrySignalSnapshotId: signalSnapshotId ?? null,
+          entryPriceUsd: pool.currentPrice,
+          entryAmountXUsd: decision.positionSizeUsd / 2,
+          entryAmountYUsd: decision.positionSizeUsd / 2,
+          cumulativeFeesClaimedUsd: 0,
+          closedAt: null,
+          realizedPnlUsd: null,
         };
         trackedPositions.set(decision.poolAddress, pos);
         yield* db.savePosition(pos).pipe(Effect.catchAll(() => Effect.void));
+        yield* db
+          .savePositionEvent({
+            id: randomUUID(),
+            poolAddress: decision.poolAddress,
+            positionPubKey: pos.positionPubKey,
+            event: "ENTER",
+            valueUsd: decision.positionSizeUsd,
+            feesUsd: null,
+            price: pool.currentPrice,
+            metadata: {
+              lowerBinId: pos.lowerBinId,
+              upperBinId: pos.upperBinId,
+              txSignature: enterResult.result.txSignature,
+            },
+            createdAt: Date.now(),
+          })
+          .pipe(Effect.catchAll(() => Effect.void));
         return { executed: true, error: undefined };
       }
       return { executed: false, error: enterResult.error };
@@ -790,8 +892,30 @@ export function executeLive(
             .recordSignalOutcome(pos.entrySignalSnapshotId, pnlUsd)
             .pipe(Effect.catchAll(() => Effect.void));
         }
+        if (pos) {
+          const realizedPnlUsd = computeRealizedPnlUsd(
+            pos.currentValueUsd,
+            pos.cumulativeFeesClaimedUsd,
+            pos.depositedUsd,
+          );
+          yield* db
+            .savePositionEvent({
+              id: randomUUID(),
+              poolAddress: decision.poolAddress,
+              positionPubKey: pos.positionPubKey,
+              event: "EXIT",
+              valueUsd: pos.currentValueUsd,
+              feesUsd: pos.cumulativeFeesClaimedUsd,
+              price: pool.currentPrice,
+              metadata: { realizedPnlUsd },
+              createdAt: Date.now(),
+            })
+            .pipe(Effect.catchAll(() => Effect.void));
+          yield* db
+            .closePosition(decision.poolAddress, realizedPnlUsd)
+            .pipe(Effect.catchAll(() => Effect.void));
+        }
         trackedPositions.delete(decision.poolAddress);
-        yield* db.deletePosition(decision.poolAddress).pipe(Effect.catchAll(() => Effect.void));
         return { executed: true, error: undefined };
       }
       return { executed: false, error: exitError };
@@ -833,6 +957,28 @@ export function executeLive(
               txSignature: claimResult.txSignature,
               feeTransferTxSignature: claimResult.feeTransferTxSignature ?? null,
               reportedToApi: false,
+              createdAt: Date.now(),
+            })
+            .pipe(Effect.catchAll(() => Effect.void));
+
+          const claimedFeesUsd = convertClaimFeesToUsd({
+            netFeeXRaw: claimResult.netFeeX,
+            netFeeYRaw: claimResult.netFeeY,
+            tokenXSymbol: pos.tokenXSymbol,
+            tokenYSymbol: pos.tokenYSymbol,
+            solPriceUsd,
+          });
+          pos.cumulativeFeesClaimedUsd += claimedFeesUsd;
+          yield* db
+            .savePositionEvent({
+              id: randomUUID(),
+              poolAddress: decision.poolAddress,
+              positionPubKey: pos.positionPubKey,
+              event: "CLAIM",
+              valueUsd: null,
+              feesUsd: claimedFeesUsd,
+              price: pool.currentPrice,
+              metadata: { txSignature: claimResult.txSignature },
               createdAt: Date.now(),
             })
             .pipe(Effect.catchAll(() => Effect.void));
@@ -911,6 +1057,22 @@ export function executeLive(
           };
           trackedPositions.set(decision.poolAddress, updated);
           yield* db.savePosition(updated).pipe(Effect.catchAll(() => Effect.void));
+          yield* db
+            .savePositionEvent({
+              id: randomUUID(),
+              poolAddress: decision.poolAddress,
+              positionPubKey: updated.positionPubKey,
+              event: "REBALANCE",
+              valueUsd: updated.currentValueUsd,
+              feesUsd: null,
+              price: pool.currentPrice,
+              metadata: {
+                newLowerBinId: decision.rebalanceParams.newLowerBinId,
+                newUpperBinId: decision.rebalanceParams.newUpperBinId,
+              },
+              createdAt: Date.now(),
+            })
+            .pipe(Effect.catchAll(() => Effect.void));
           return { executed: true, error: undefined };
         }
         return { executed: false, error: rebalanceResult.error };
@@ -2939,7 +3101,15 @@ export const program = Effect.gen(function* () {
           `[PAPER] PAPER_MODE_EXIT_LIVE is enabled — executing live EXIT for ${poolAddress}`,
         );
         const liveResult = yield* executeLive(
-          { adapter, strategy, db, revenueConfigSvc, trackedPositions, entryPrep },
+          {
+            adapter,
+            strategy,
+            db,
+            revenueConfigSvc,
+            trackedPositions,
+            entryPrep,
+            solPriceUsd: config.solPriceUsd,
+          },
           decision,
           pool,
           signalTimestamp,
@@ -2963,7 +3133,15 @@ export const program = Effect.gen(function* () {
         executionError = paperResult.error;
       } else {
         const liveResult = yield* executeLive(
-          { adapter, strategy, db, revenueConfigSvc, trackedPositions, entryPrep },
+          {
+            adapter,
+            strategy,
+            db,
+            revenueConfigSvc,
+            trackedPositions,
+            entryPrep,
+            solPriceUsd: config.solPriceUsd,
+          },
           decision,
           pool,
           signalTimestamp,
@@ -3087,6 +3265,14 @@ export const program = Effect.gen(function* () {
             continue;
           }
 
+          const netFeesUsd = convertClaimFeesToUsd({
+            netFeeXRaw: result.netFeeX,
+            netFeeYRaw: result.netFeeY,
+            tokenXSymbol: pos.tokenXSymbol,
+            tokenYSymbol: pos.tokenYSymbol,
+            solPriceUsd: config.solPriceUsd,
+          });
+
           yield* db
             .saveFeeClaim({
               id: randomUUID(),
@@ -3145,31 +3331,30 @@ export const program = Effect.gen(function* () {
           }
 
           pos.lastFeeClaimAt = Date.now();
+          pos.cumulativeFeesClaimedUsd += netFeesUsd;
           yield* db.savePosition(pos).pipe(Effect.catchAll(() => Effect.void));
 
-          yield* alertSvc.recordFeeClaim(
-            poolAddress,
-            convertClaimFeesToUsd({
-              netFeeXRaw: result.netFeeX,
-              netFeeYRaw: result.netFeeY,
-              tokenXSymbol: pos.tokenXSymbol,
-              tokenYSymbol: pos.tokenYSymbol,
-              solPriceUsd: config.solPriceUsd,
-            }),
-          );
+          yield* db
+            .savePositionEvent({
+              id: randomUUID(),
+              poolAddress,
+              positionPubKey: pos.positionPubKey,
+              event: "CLAIM",
+              valueUsd: null,
+              feesUsd: netFeesUsd,
+              price: null,
+              metadata: { txSignature: result.txSignature },
+              createdAt: Date.now(),
+            })
+            .pipe(Effect.catchAll(() => Effect.void));
+
+          yield* alertSvc.recordFeeClaim(poolAddress, netFeesUsd);
 
           // F3: fee compounding — if AUTO_COMPOUND_FEES is on and the net fees
           // cleared the cost threshold, redeposit them into the same range.
           // This closes + reopens the position around the same bins so the
           // claimed fees become new liquidity instead of sitting in the wallet.
           if (config.autoCompoundFees && config.paperTrading === false) {
-            const netFeesUsd = convertClaimFeesToUsd({
-              netFeeXRaw: result.netFeeX,
-              netFeeYRaw: result.netFeeY,
-              tokenXSymbol: pos.tokenXSymbol,
-              tokenYSymbol: pos.tokenYSymbol,
-              solPriceUsd: config.solPriceUsd,
-            });
             const rebalanceGasCostUsd = config.rebalanceGasCostSol * config.solPriceUsd;
             const compoundGate = evaluateCompoundGate({
               netFeesUsd,
@@ -3201,8 +3386,32 @@ export const program = Effect.gen(function* () {
               if (compoundResult) {
                 pos.positionPubKey = compoundResult.newPositionPubKey;
                 pos.lastRebalanceAt = Date.now();
-                pos.depositedUsd += netFeesUsd;
+                // Compounded fees become new cost basis; currentValue/highest
+                // adjust in lockstep so PnL and the trailing stop stay honest
+                // (see applyCompoundToCostBasis in engine/pnl.ts).
+                const compounded = applyCompoundToCostBasis({
+                  depositedUsd: pos.depositedUsd,
+                  currentValueUsd: pos.currentValueUsd,
+                  highestValueUsd: pos.highestValueUsd,
+                  compoundedFeesUsd: netFeesUsd,
+                });
+                pos.depositedUsd = compounded.depositedUsd;
+                pos.currentValueUsd = compounded.currentValueUsd;
+                pos.highestValueUsd = compounded.highestValueUsd;
                 yield* db.savePosition(pos).pipe(Effect.catchAll(() => Effect.void));
+                yield* db
+                  .savePositionEvent({
+                    id: randomUUID(),
+                    poolAddress,
+                    positionPubKey: pos.positionPubKey,
+                    event: "COMPOUND",
+                    valueUsd: netFeesUsd,
+                    feesUsd: null,
+                    price: null,
+                    metadata: { savingsUsd: compoundGate.savingsUsd },
+                    createdAt: Date.now(),
+                  })
+                  .pipe(Effect.catchAll(() => Effect.void));
                 yield* memory
                   .upsert({
                     category: "pattern",

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -408,6 +408,12 @@ export interface DbApi {
     paperExitedAt: number | null;
     entrySignalTimestamp: number | null;
     entrySignalSnapshotId: number | null;
+    entryPriceUsd: number | null;
+    entryAmountXUsd: number | null;
+    entryAmountYUsd: number | null;
+    cumulativeFeesClaimedUsd: number;
+    closedAt: number | null;
+    realizedPnlUsd: number | null;
   }) => Effect.Effect<void, unknown>;
   readonly getPosition: (poolAddress: string) => Effect.Effect<
     {
@@ -430,6 +436,12 @@ export interface DbApi {
       paperExitedAt: number | null;
       entrySignalTimestamp: number | null;
       entrySignalSnapshotId: number | null;
+      entryPriceUsd: number | null;
+      entryAmountXUsd: number | null;
+      entryAmountYUsd: number | null;
+      cumulativeFeesClaimedUsd: number;
+      closedAt: number | null;
+      realizedPnlUsd: number | null;
     } | null,
     unknown
   >;
@@ -454,6 +466,12 @@ export interface DbApi {
       paperExitedAt: number | null;
       entrySignalTimestamp: number | null;
       entrySignalSnapshotId: number | null;
+      entryPriceUsd: number | null;
+      entryAmountXUsd: number | null;
+      entryAmountYUsd: number | null;
+      cumulativeFeesClaimedUsd: number;
+      closedAt: number | null;
+      realizedPnlUsd: number | null;
     }>,
     unknown
   >;
@@ -478,11 +496,80 @@ export interface DbApi {
       paperExitedAt: number | null;
       entrySignalTimestamp: number | null;
       entrySignalSnapshotId: number | null;
+      entryPriceUsd: number | null;
+      entryAmountXUsd: number | null;
+      entryAmountYUsd: number | null;
+      cumulativeFeesClaimedUsd: number;
+      closedAt: number | null;
+      realizedPnlUsd: number | null;
     }>,
     unknown
   >;
   readonly deletePosition: (poolAddress: string) => Effect.Effect<void, unknown>;
   readonly markPaperExited: (poolAddress: string) => Effect.Effect<void, unknown>;
+  readonly closePosition: (
+    poolAddress: string,
+    realizedPnlUsd: number | null,
+  ) => Effect.Effect<void, unknown>;
+  readonly getClosedPositions: () => Effect.Effect<
+    ReadonlyArray<{
+      poolAddress: string;
+      positionPubKey: string | null;
+      depositedUsd: number;
+      currentValueUsd: number;
+      tokenXSymbol: string;
+      tokenYSymbol: string;
+      activeBinId: number;
+      lowerBinId: number;
+      upperBinId: number;
+      timestamp: number;
+      outOfRangeSince: number | null;
+      oorCycleCount: number;
+      lastFeeClaimAt: number;
+      trailingStopThreshold: number | null;
+      highestValueUsd: number | null;
+      lastRebalanceAt: number;
+      paperExitedAt: number | null;
+      entrySignalTimestamp: number | null;
+      entrySignalSnapshotId: number | null;
+      entryPriceUsd: number | null;
+      entryAmountXUsd: number | null;
+      entryAmountYUsd: number | null;
+      cumulativeFeesClaimedUsd: number;
+      closedAt: number | null;
+      realizedPnlUsd: number | null;
+    }>,
+    unknown
+  >;
+  readonly savePositionEvent: (event: {
+    id: string;
+    poolAddress: string;
+    positionPubKey: string | null;
+    event: "ENTER" | "EXIT" | "REBALANCE" | "CLAIM" | "COMPOUND";
+    valueUsd: number | null;
+    feesUsd: number | null;
+    price: number | null;
+    metadata?: Record<string, unknown> | null;
+    createdAt: number;
+  }) => Effect.Effect<void, unknown>;
+  readonly getPositionEvents: (
+    poolAddress: string,
+    limit?: number,
+  ) => Effect.Effect<
+    ReadonlyArray<{
+      id: string;
+      poolAddress: string;
+      positionPubKey: string | null;
+      event: "ENTER" | "EXIT" | "REBALANCE" | "CLAIM" | "COMPOUND";
+      valueUsd: number | null;
+      feesUsd: number | null;
+      price: number | null;
+      metadata: string | null;
+      createdAt: number;
+    }>,
+    unknown
+  >;
+  readonly getLatestSnapshotPrice: (poolAddress: string) => Effect.Effect<number | null, unknown>;
   readonly updatePositionValue: (
     poolAddress: string,
     currentValueUsd: number,

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -26,6 +26,17 @@ function openDb(): InstanceType<typeof Database> | null {
   return new Database(dbPath, { readonly: true, fileMustExist: true });
 }
 
+// The engine soft-closes positions via closed_at (Wave 4); DBs written by
+// older engines lack the column, so detect it per connection instead of
+// failing the query with "no such column".
+function activePositionsWhere(db: InstanceType<typeof Database>): string {
+  const cols = db.prepare("PRAGMA table_info(positions)").all() as Array<{ name: string }>;
+  const hasClosedAt = cols.some((c) => c.name === "closed_at");
+  return hasClosedAt
+    ? "paper_exited_at IS NULL AND closed_at IS NULL"
+    : "paper_exited_at IS NULL";
+}
+
 function registerPrismStatus(server: McpServer): void {
   server.tool(
     "prism_status",
@@ -50,14 +61,15 @@ function registerPrismStatus(server: McpServer): void {
         };
       }
       try {
+        const activeWhere = activePositionsWhere(db);
         const positionCount = (
-          db.prepare("SELECT COUNT(*) as n FROM positions WHERE paper_exited_at IS NULL").get() as { n: number }
+          db.prepare("SELECT COUNT(*) as n FROM positions WHERE " + activeWhere).get() as { n: number }
         ).n;
         const totals = db
           .prepare(
             "SELECT COALESCE(SUM(deposited_usd), 0) as total_deposited, " +
               "COALESCE(SUM(current_value_usd), 0) as total_current " +
-              "FROM positions WHERE paper_exited_at IS NULL",
+              "FROM positions WHERE " + activeWhere,
           )
           .get() as { total_deposited: number; total_current: number };
         const lastAudit = db
@@ -121,7 +133,8 @@ function registerPrismStatus(server: McpServer): void {
 function registerPrismPositions(server: McpServer): void {
   server.tool(
     "prism_positions",
-    "List all active positions tracked by the Prism agent. Excludes paper-exited positions. " +
+    "List all active positions tracked by the Prism agent. Excludes exited (soft-closed " +
+      "or paper-exited) positions. " +
       "Returns an empty array if the SQLite database does not exist.",
     {},
     async () => {
@@ -142,7 +155,7 @@ function registerPrismPositions(server: McpServer): void {
             "SELECT pool_address, token_x_symbol, token_y_symbol, " +
               "deposited_usd, current_value_usd, lower_bin_id, upper_bin_id, " +
               "active_bin_id, oor_cycle_count, last_rebalance_at " +
-              "FROM positions WHERE paper_exited_at IS NULL " +
+              "FROM positions WHERE " + activePositionsWhere(db) + " " +
               "ORDER BY deposited_usd DESC",
           )
           .all() as Array<Record<string, unknown>>;

--- a/mcp-server/test/tools.test.ts
+++ b/mcp-server/test/tools.test.ts
@@ -151,7 +151,8 @@ const SCHEMA_SQL = `
     trailing_stop_threshold REAL,
     highest_value_usd REAL,
     last_rebalance_at INTEGER DEFAULT 0,
-    paper_exited_at INTEGER
+    paper_exited_at INTEGER,
+    closed_at INTEGER
   );
   CREATE TABLE audit (
     id TEXT PRIMARY KEY,
@@ -198,6 +199,18 @@ function seedPositions(dbPath: string): void {
   ).run(
     "PoolExited", 500, 500, "SOL", "USDC", 5000, 4980, 5020,
     Date.now(), null, 0, Date.now(), null, 500, 0, Date.now() - 3600_000,
+  );
+  // Soft-closed (Wave 4 live EXIT): closed_at set, paper_exited_at NULL.
+  db.prepare(
+    `INSERT INTO positions (pool_address, deposited_usd, current_value_usd,
+      token_x_symbol, token_y_symbol, active_bin_id, lower_bin_id, upper_bin_id,
+      timestamp, out_of_range_since, oor_cycle_count, last_fee_claim_at,
+      trailing_stop_threshold, highest_value_usd, last_rebalance_at, paper_exited_at,
+      closed_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "PoolClosed", 800, 900, "RAY", "USDC", 7000, 6980, 7020,
+    Date.now(), null, 0, Date.now(), null, 950, 0, null, Date.now() - 1800_000,
   );
   db.close();
 }
@@ -275,6 +288,60 @@ describe("DB-backed tools", () => {
     const parsed = JSON.parse(result.text);
     assert.equal(parsed.length, 1);
     assert.equal(parsed[0].pool, "PoolActive1");
+  });
+
+  it("prism_status and prism_positions exclude soft-closed (closed_at) positions", async () => {
+    const dbPath = setupTestDb(workDir);
+    seedPositions(dbPath);
+    seedAudit(dbPath);
+    process.env.SQLITE_DB_PATH = dbPath;
+
+    const status = JSON.parse((await runTool("prism_status", {})).text);
+    assert.equal(status.positionCount, 1);
+    assert.equal(status.totalDepositedUsd, 1000);
+
+    const positions = JSON.parse((await runTool("prism_positions", {})).text);
+    assert.equal(positions.length, 1);
+    assert.ok(!positions.some((p: { pool: string }) => p.pool === "PoolClosed"));
+  });
+
+  it("prism_status still works against a pre-v16 schema without closed_at", async () => {
+    const dbPath = join(workDir, "old.db");
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE positions (
+        pool_address TEXT PRIMARY KEY,
+        deposited_usd REAL,
+        current_value_usd REAL,
+        paper_exited_at INTEGER
+      );
+      CREATE TABLE audit (
+        id TEXT PRIMARY KEY,
+        timestamp INTEGER,
+        cycle_id TEXT,
+        pool_address TEXT,
+        action TEXT,
+        confidence REAL,
+        reasoning TEXT,
+        metrics_json TEXT,
+        risk_result_json TEXT,
+        executed INTEGER,
+        paper_trading INTEGER,
+        tx_signature TEXT,
+        error TEXT
+      );
+    `);
+    db.prepare(
+      "INSERT INTO positions (pool_address, deposited_usd, current_value_usd, paper_exited_at) VALUES (?, ?, ?, ?)",
+    ).run("PoolOld", 250, 260, null);
+    db.close();
+    process.env.SQLITE_DB_PATH = dbPath;
+
+    const result = await runTool("prism_status", {});
+    const parsed = JSON.parse(result.text);
+    assert.equal(result.ok, true);
+    assert.equal(parsed.positionCount, 1);
+    assert.equal(parsed.totalDepositedUsd, 250);
   });
 
   it("prism_positions includes range and out-of-range count", async () => {


### PR DESCRIPTION
Wave 4 of `.omo/plans/prism-review-remediation.md` — per-position PnL accounting.

## Gap fixed

The #1 ecosystem gap from the review: the agent claims fees on-chain every cycle but stored **no entry price, no realized PnL, no fees-earned** — PnL was an ad-hoc `currentValueUsd − depositedUsd`. DefiTuna / LP Agent / Step Finance all show realized vs unrealized PnL, fees earned, and IL-vs-HODL; Prism now records the data to do the same.

## Data model (migration v16, `pnl_accounting`)

`positions` gains:
| column | meaning |
| --- | --- |
| `entry_price_usd` | pool `currentPrice` at ENTER (price of X in Y terms) |
| `entry_amount_x_usd` / `entry_amount_y_usd` | USD value of each leg at entry |
| `cumulative_fees_claimed_usd` | running total of claimed fees (default 0) |
| `closed_at` | soft-close timestamp (nullable) |
| `realized_pnl_usd` | set at close (nullable until then) |

New append-only `position_events` log: `id, pool_address, position_pubkey?, event (ENTER|EXIT|REBALANCE|CLAIM|COMPOUND), value_usd?, fees_usd?, price?, metadata JSON?, created_at` (+ index on pool/time).

**Entry legs model:** the adapter's `enterPosition` returns only the pubkey/tx, not on-chain deposit amounts, so entry legs use the documented **50/50 USD model** (half the entry size per leg — matches a symmetric range around the active bin). `entryPriceUsd` is the pool's `currentPrice` at entry.

## Record keeping

- **ENTER** (paper + live): snapshots entry price + leg amounts, writes `ENTER` event.
- **CLAIM** — both claim points (`claimAllFees` periodic **and** the REBALANCE inline claim): accumulates `cumulativeFeesClaimedUsd` (net fees → USD via the existing `convertClaimFeesToUsd`) and writes a `CLAIM` event.
- **COMPOUND**: writes a `COMPOUND` event and applies the cost-basis fix below.
- **EXIT** (paper + live): `realizedPnlUsd = finalValue + cumulativeFees − costBasis`, `closed_at` set, `EXIT` event — the row is **soft-closed and kept** (history preserved). `deletePosition` remains for true cleanup (stale paper rows at startup, externally-closed positions in reconcile). `getAllPositions` now excludes closed rows; new `getClosedPositions` feeds `portfolio history`.
- **REBALANCE** (paper + live): writes a `REBALANCE` event with the new range.

## Cost-basis decision (W2 reviewer finding)

The reviewer flagged that auto-compound inflated `depositedUsd` **without** adjusting `currentValueUsd`/`highestValueUsd`, distorting PnL and the trailing stop. Chosen model: **compounded fees become new cost basis** (`depositedUsd += F`) — they were already counted as earnings in `cumulativeFeesClaimedUsd` when claimed, so the two cancel and total-PnL math stays continuous — **and** `currentValueUsd += F`, `highestValueUsd = max(highest, currentValue)` move in lockstep (`applyCompoundToCostBasis` in `engine/pnl.ts`, continuity proven by test). The alternative (basis untouched, deduct from fees) was rejected: it erases the earnings record and complicates the claim trail.

## Analytics (`engine/pnl.ts`, pure)

- `unrealizedPnl = currentValueUsd + cumulativeFeesClaimedUsd − costBasis`
- HODL benchmark = `entryAmountXUsd × (currentPrice / entryPrice) + entryAmountYUsd`; IL-vs-HODL = `currentValue − hodl` (current price from latest `pool_snapshots` row)
- fee APR = fees / cost basis, annualized by position age
- `timeInRangePct ≈ 1 − (current OOR stint / age)` — documented approximation: recovered past stints aren't tracked and count as in-range time (overestimates for positions that recovered)

## Backfill behavior

Positions opened before v16 have NULL entry fields: analytics and CLI degrade gracefully — `IL vs HODL: n/a`, no HODL benchmark, PnL from the legacy `currentValueUsd − depositedUsd` model. Migration test proves an old-schema row survives with defaults.

## CLI surfacing (no redesign)

`prism portfolio` gains per-position Fees / IL vs HODL / In-range lines (P&L now includes claimed fees) and a Fees Claimed totals row; `prism portfolio history` reads closed rows with realized PnL + fees; `prism status` (human, `--message`, `--json`) reports fees claimed; `portfolio --json` gains `entryPriceUsd, feesClaimedUsd, hodlValueUsd, ilVsHodlUsd, timeInRangePct, feeAprPct` (additive).

## Failing-first evidence

Tests committed first (`04f357b`); red before implementation:

```
FAIL bench/pnl-accounting.test.ts
Error: Cannot find module '../engine/pnl.js'
Test Files  1 failed (1)
```

## Verification (all in worktree)

- `bun run lint` → exit 0 (tsc + oxlint)
- `bun run build` → exit 0
- `bun run test` → **803/803 pass (69 files)**, incl. new `bench/pnl-accounting.test.ts` (24 tests: lifecycle, migration, analytics units, compound continuity, live inline-claim) and extended `portfolio-cli` tests
- `bun run format:check` → exit 0

## Manual QA (temp DB, seeded via script; user DB untouched; temp files removed)

```
Active Positions (2)
========================================
  SOL/USDC [4980–5020]
    Pool:       SoLdcPool111111111111111111111111111111111
    Deposited:  $1,025.00
    Current:    $1,125.00
    P&L:        $125.00 (+12.20%)
    Fees:       $25.00
    IL vs HODL: +$75.00
    In range:   100.0%
    Active bin: 5001
    Age:        3d 0h

  BONK/SOL [280–320]
    Pool:       BonkPool2222222222222222222222222222222222
    Deposited:  $500.00
    Current:    $450.00
    P&L:        -$50.00 (-10.00%)
    Fees:       $0.00
    IL vs HODL: n/a
    In range:   80.0%
    Active bin: 300
    Age:        10d 0h
    ⚠ Out of range since 2d 0h

Portfolio Summary
=================
  Positions:        2
  Total Deposited:  $1,525.00
  Total Current:    $1,575.00
  Fees Claimed:     $25.00
  Unrealized P&L:   $75.00 (+4.92%)
```

```
Exited Positions (1)
========================================
  RAY/USDC
    Pool:       RayPool333333333333333333333333333333333333
    Deposited:  $800.00
    Exit Value: $900.00
    Fees:       $40.00
    Realized P&L: $140.00 (+17.50%)
    Exited:     2026-07-13T04:13:30.502Z
```

```
Prism Status
============
  Positions:   2 active
  Deposited:   $1525.00
  Current:     $1575.00
  Fees:        $25.00
  Unrealized:  +$75.00 (4.92%)
```

Event log verified in DB: `ENTER → CLAIM → COMPOUND` (active pool), `ENTER → CLAIM → EXIT` (closed pool).

## Notes / deliberate exclusions

- `recordSignalOutcome` (threshold evolution) keeps the W2 value-minus-deposited semantics — intentionally not changed here.
- Reconcile paths for externally-closed positions still hard-delete (true cleanup; final value unknowable).
- No new env vars, no new dependencies, no `as any`/`@ts-ignore`. `cloudflare/` and `mcp-server/` untouched.
- Optional Meteora Data API `/positions/{pool}/pnl` enrichment not wired — stored model is self-sufficient; can be a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed position PnL analytics, including realized PnL, claimed fees, HODL comparison, fee APR, and time-in-range metrics.
  * Portfolio and status views now display expanded per-position and total fee information.
  * Position history now preserves closed positions and reports exit timestamps and realized PnL.
  * Added lifecycle event tracking for entries, exits, rebalances, claims, and compounding.

* **Bug Fixes**
  * Improved handling of legacy positions so unavailable analytics degrade gracefully.
  * Soft-closed positions are consistently excluded from active portfolio views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->