### PR TITLE
feat: add stablecoin depeg and liquidity-drain alerts (W15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,11 @@ DISCOVERY_MIN_FEE_RATIO=1.5
 
 # Dump full pool state snapshots to DB every cycle (paper only)
 ENABLE_SNAPSHOT_CAPTURE=false
+STABLECOIN_MINTS=
+DEPEG_ABSOLUTE_USD=0.02
+DEPEG_RELATIVE_PCT=0.02
+LIQUIDITY_DRAIN_PCT=0.5
+LIQUIDITY_DRAIN_LOOKBACK_SNAPSHOTS=2
 
 # Days of pool snapshot history to keep; older rows are pruned daily (default: 14)
 SNAPSHOT_RETENTION_DAYS=14

--- a/.omo/notepads/prism-review-remediation/learnings.md
+++ b/.omo/notepads/prism-review-remediation/learnings.md
@@ -31,3 +31,16 @@
 - The original 67.76/62.96/67.96 coverage result included runtime boundaries that cannot be deterministically exercised by the engine-unit suite: child-process ACP, agent discovery, WebSocket gateway, webhook/API transports, startup bootstrap, and dotenv loading.
 - Added eight narrow exclusions for those boundaries only. Core config, strategy, risk, DB, audit, execution, state, and service logic remain in the gate; thresholds remain 75% statements, 60% branches, 75% functions, 75% lines.
 - Two consecutive coverage runs passed identically: 80.34% statements, 74.98% branches, 76.22% functions, 80.80% lines, with 959/959 tests each run.
+## 2026-07-19 W15 depeg/liquidity alerts
+
+- W15 is isolated in `feat/depeg-liquidity-alerts`, based on integrated W13 commit `7b7d818`; W14 remains separately blocked by the SDK lifecycle limitation.
+- Stablecoin detection is mint-allowlist-only (`STABLECOIN_MINTS`); missing allowlist, prices, or snapshot history produce no signal. TVL and volume must both cross the configured drain threshold.
+- Fast EXIT is inserted before ordinary per-position EXIT gates, so it remains position-scoped and reaches the existing EXIT risk override, audit, paper/live execution, and AlertService cooldown path.
+- Manual detector QA: `bun -e ...` produced both `stablecoin deviation 3.00%` and `TVL -60.0%, volume -60.0%` signals from synthetic history; see `/tmp/w15-manual-qa.txt`.
+
+## 2026-07-19 W15 full-gate verification
+
+- The branch already included corrected W13 commit `7b7d818`; no W14 ancestry or code was introduced.
+- Current TypeScript 7 types require the known W13 CLI `buildProgram()` return annotations to expose `unknown` layer errors rather than `never`; this is a type-only correction in `cli/feedback.ts` and `cli/status.ts` with no CLI behavior change.
+- Full gates passed: lint, build, 968 tests, format check, changed-file oxlint, and 14 targeted detector/AlertService tests.
+- Repository manual QA is recorded in `docs/w15-manual-qa.md`; temporary runtime/DB/port cleanup was verified.

--- a/bench/depeg-liquidity-detector.test.ts
+++ b/bench/depeg-liquidity-detector.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { detectDepegAndLiquidityDrain } from "../engine/depeg-liquidity-detector.js";
+import type { PoolSnapshot, PoolState } from "../engine/types.js";
+
+const config = {
+  stablecoinMints: new Set(["USDC"]),
+  depegAbsoluteUsd: 0.02,
+  depegRelativePct: 0.02,
+  liquidityDrainPct: 0.5,
+  liquidityDrainLookbackSnapshots: 2,
+};
+const pool: PoolState = {
+  address: "pool",
+  tokenX: "USDC",
+  tokenY: "SOL",
+  tokenXSymbol: "USDC",
+  tokenYSymbol: "SOL",
+  tvlUsd: 400,
+  volume24hUsd: 400,
+  fees24hUsd: 1,
+  apr: 1,
+  activeBinId: 1,
+  binStep: 10,
+  currentPrice: 0.97,
+  timestamp: 3,
+};
+const snapshot = (tvlUsd: number, volume24hUsd: number): PoolSnapshot => ({
+  poolAddress: "pool",
+  timestamp: 1,
+  activeBinId: 1,
+  tvlUsd,
+  volume24hUsd,
+  fees24hUsd: 1,
+  apr: 1,
+  currentPrice: 1,
+  binStep: 10,
+  tokenXSymbol: "USDC",
+  tokenYSymbol: "SOL",
+  binArray: { lowerBinId: 0, upperBinId: 1, bins: [], activeBinId: 1 },
+});
+
+describe("W15 depeg and liquidity signals", () => {
+  it("detects an allowlisted stablecoin depeg at the configured boundary", () => {
+    const result = detectDepegAndLiquidityDrain(pool, [], config);
+    expect(result.depeg?.tokenMint).toBe("USDC");
+  });
+
+  it("does not classify an unallowlisted token or missing history", () => {
+    const result = detectDepegAndLiquidityDrain({ ...pool, tokenX: "UNKNOWN" }, [], config);
+    expect(result.depeg).toBeNull();
+    expect(result.liquidityDrain).toBeNull();
+  });
+
+  it("detects a drain only with sufficient TVL and volume history", () => {
+    const result = detectDepegAndLiquidityDrain(
+      { ...pool, currentPrice: 1 },
+      [snapshot(1000, 1000), snapshot(900, 900)],
+      { ...config, liquidityDrainPct: 0.1, liquidityDrainLookbackSnapshots: 2 },
+    );
+    expect(result.liquidityDrain).toEqual({ tvlPct: -0.6, volumePct: -0.6 });
+  });
+});

--- a/bench/helpers.ts
+++ b/bench/helpers.ts
@@ -136,6 +136,11 @@ export function defaultAppConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     meteoraPoolsUrl:
       "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=tvl:desc",
     meteoraDatapiBaseUrl: "https://dlmm.datapi.meteora.ag",
+    stablecoinMints: new Set(),
+    depegAbsoluteUsd: 0.02,
+    depegRelativePct: 0.02,
+    liquidityDrainPct: 0.5,
+    liquidityDrainLookbackSnapshots: 2,
     rebalanceGasCostSol: 0.01,
     solPriceUsd: 150,
     gasAwareMinDaysOfFeesPaidAhead: 3,

--- a/cli/feedback.ts
+++ b/cli/feedback.ts
@@ -39,7 +39,7 @@ function parseSeverity(raw: string | undefined, fallback: FeedbackSeverity): Fee
   return value as FeedbackSeverity;
 }
 
-function buildProgram(): Layer.Layer<FeedbackService | ConfigService, never, never> {
+function buildProgram(): Layer.Layer<FeedbackService | ConfigService, unknown, never> {
   return Layer.merge(
     Layer.provide(
       FeedbackLive,

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -38,7 +38,7 @@ export interface StatusJsonOutput {
   }>;
 }
 
-function buildProgram(): Layer.Layer<DbService | AuditService | ConfigService, never, never> {
+function buildProgram(): Layer.Layer<DbService | AuditService | ConfigService, unknown, never> {
   const dbPath = process.env.SQLITE_DB_PATH ?? getPrismDbPath();
   const dbLayer = DbLive(dbPath);
   const auditLayer = Layer.provide(AuditLive, dbLayer);

--- a/docs/w15-manual-qa.md
+++ b/docs/w15-manual-qa.md
@@ -1,0 +1,30 @@
+# W15 Manual QA
+
+Date: 2026-07-19
+Branch: `feat/depeg-liquidity-alerts`
+Base: W13/W12 corrected base, commit `7b7d818`
+
+## Synthetic detector run
+
+The detector was exercised through its real TypeScript module boundary with an allowlisted `USDC` mint, a 3% stablecoin deviation, and two historical snapshots. The output was:
+
+```json
+{"depeg":{"tokenMint":"USDC","deviationUsd":0.030000000000000027},"liquidityDrain":{"tvlPct":-0.6,"volumePct":-0.6}}
+```
+
+This proves both W15 signals are emitted from snapshot history. The run left no process, port, database, or generated repository artifact running; raw output was also captured at `/tmp/w15-manual-qa.txt`.
+
+## Safety checks
+
+- Only configured mint allowlist entries can produce depeg signals; arbitrary symbols are ignored.
+- Missing or insufficient snapshot history produces no liquidity-drain signal.
+- Fast EXIT decisions are created only inside the tracked-position loop, preserving W10 position identity isolation.
+- Alerts use the existing persisted cooldown key and fail-open `AlertService`; POST failures are swallowed and cannot block a cycle.
+
+## Verification
+
+- `bun run lint`: passed
+- `bun run build`: passed
+- `bun run test`: 81 files, 968 tests passed
+- `bun run format:check`: passed
+- `bun run test -- bench/depeg-liquidity-detector.test.ts bench/alert-service.test.ts`: 14 tests passed

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -62,6 +62,11 @@ export interface AppConfig {
   // if the env var is unset or empty.
   readonly meteoraPoolsUrl: string;
   readonly meteoraDatapiBaseUrl: string;
+  readonly stablecoinMints?: ReadonlySet<string>;
+  readonly depegAbsoluteUsd?: number;
+  readonly depegRelativePct?: number;
+  readonly liquidityDrainPct?: number;
+  readonly liquidityDrainLookbackSnapshots?: number;
 
   // ─── F1: Gas-aware rebalancing ──────────────────────────────────────────────
   /** Estimated SOL cost of a single rebalance tx (entry + close). */
@@ -305,6 +310,23 @@ const loadConfig = Effect.gen(function* () {
   const maxRebalanceRangeBins = yield* validatedNumber("MAX_REBALANCE_RANGE_BINS", 1, 50);
   const watchlistPoolsRaw = yield* Config.string("WATCHLIST_POOLS").pipe(
     Effect.orElseSucceed(() => ""),
+  );
+  const stablecoinMintsRaw = yield* Config.string("STABLECOIN_MINTS").pipe(
+    Effect.orElseSucceed(() => ""),
+  );
+  const stablecoinMints = new Set(
+    stablecoinMintsRaw
+      .split(",")
+      .map((mint) => mint.trim())
+      .filter(Boolean),
+  );
+  const depegAbsoluteUsd = yield* validatedNumber("DEPEG_ABSOLUTE_USD", 0.001, 0.02);
+  const depegRelativePct = yield* validatedNumber("DEPEG_RELATIVE_PCT", 0.001, 0.02);
+  const liquidityDrainPct = yield* validatedNumber("LIQUIDITY_DRAIN_PCT", 0.01, 0.9);
+  const liquidityDrainLookbackSnapshots = yield* validatedNumber(
+    "LIQUIDITY_DRAIN_LOOKBACK_SNAPSHOTS",
+    1,
+    12,
   );
 
   // ─── F1: Gas-aware rebalancing ──────────────────────────────────────────────
@@ -712,6 +734,11 @@ const loadConfig = Effect.gen(function* () {
     paperModeExitLive,
     meteoraPoolsUrl,
     meteoraDatapiBaseUrl,
+    stablecoinMints,
+    depegAbsoluteUsd,
+    depegRelativePct,
+    liquidityDrainPct,
+    liquidityDrainLookbackSnapshots,
 
     rebalanceGasCostSol,
     solPriceUsd,

--- a/engine/depeg-liquidity-detector.ts
+++ b/engine/depeg-liquidity-detector.ts
@@ -1,0 +1,61 @@
+import type { PoolSnapshot, PoolState } from "./types.js";
+
+export interface DepegLiquidityConfig {
+  readonly stablecoinMints?: ReadonlySet<string>;
+  readonly depegAbsoluteUsd?: number;
+  readonly depegRelativePct?: number;
+  readonly liquidityDrainPct?: number;
+  readonly liquidityDrainLookbackSnapshots?: number;
+}
+
+export interface DepegLiquiditySignals {
+  readonly depeg: { readonly tokenMint: string; readonly deviationUsd: number } | null;
+  readonly liquidityDrain: { readonly tvlPct: number; readonly volumePct: number } | null;
+}
+
+const finitePositive = (value: number): boolean => Number.isFinite(value) && value > 0;
+
+export function detectDepegAndLiquidityDrain(
+  pool: PoolState,
+  history: ReadonlyArray<PoolSnapshot>,
+  config: DepegLiquidityConfig,
+): DepegLiquiditySignals {
+  const stablecoinMints = [pool.tokenX, pool.tokenY].filter(
+    (mint) => config.stablecoinMints?.has(mint) === true,
+  );
+  const depegThreshold = config.depegAbsoluteUsd ?? 0.02;
+  const relativeThreshold = config.depegRelativePct ?? 0.02;
+  const drainThreshold = config.liquidityDrainPct ?? 0.5;
+  const depeg =
+    stablecoinMints
+      .map((tokenMint) => {
+        const stablecoinPrice =
+          tokenMint === pool.tokenX ? pool.currentPrice : 1 / pool.currentPrice;
+        return { tokenMint, deviationUsd: Math.abs(stablecoinPrice - 1) };
+      })
+      .find(
+        (signal) =>
+          finitePositive(pool.currentPrice) &&
+          (signal.deviationUsd >= depegThreshold || signal.deviationUsd >= relativeThreshold),
+      ) ?? null;
+
+  const lookback = Math.max(1, Math.floor(config.liquidityDrainLookbackSnapshots ?? 2));
+  const reference = history.length >= lookback ? history[history.length - lookback] : undefined;
+  const tvlPct =
+    reference && finitePositive(reference.tvlUsd)
+      ? (pool.tvlUsd - reference.tvlUsd) / reference.tvlUsd
+      : null;
+  const volumePct =
+    reference && finitePositive(reference.volume24hUsd)
+      ? (pool.volume24hUsd - reference.volume24hUsd) / reference.volume24hUsd
+      : null;
+  const liquidityDrain =
+    tvlPct !== null &&
+    volumePct !== null &&
+    tvlPct <= -drainThreshold &&
+    volumePct <= -drainThreshold
+      ? { tvlPct, volumePct }
+      : null;
+
+  return { depeg, liquidityDrain };
+}

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -78,6 +78,7 @@ import {
 } from "./services.js";
 import { MeteoraDatapiLive, enrichPoolWithDatapi } from "./meteora-datapi-service.js";
 import { AlertLive } from "./alert-service.js";
+import { detectDepegAndLiquidityDrain } from "./depeg-liquidity-detector.js";
 import type {
   AgentDecision,
   AgentProposal,
@@ -1911,6 +1912,7 @@ export const program = Effect.gen(function* () {
         .pipe(Effect.catchAll(() => Effect.succeed([] as ReadonlyArray<PoolSnapshot>)));
       const previousSnapshot =
         previousSnapshots.length > 0 ? previousSnapshots[previousSnapshots.length - 1] : undefined;
+      const w15Signals = detectDepegAndLiquidityDrain(pool, previousSnapshots, config);
 
       // Persist a snapshot every cycle (both paper and live): TVL velocity and
       // the TVL-drop EXIT are dead code without per-cycle history. The full
@@ -2234,10 +2236,38 @@ export const program = Effect.gen(function* () {
       const rawDecisions: AgentDecision[] = [];
       let poolExitFired = false;
 
+      if (w15Signals.depeg || w15Signals.liquidityDrain) {
+        const reasons = [
+          ...(w15Signals.depeg
+            ? [`stablecoin deviation ${(w15Signals.depeg.deviationUsd * 100).toFixed(2)}%`]
+            : []),
+          ...(w15Signals.liquidityDrain
+            ? [
+                `TVL ${(w15Signals.liquidityDrain.tvlPct * 100).toFixed(1)}%, volume ${(w15Signals.liquidityDrain.volumePct * 100).toFixed(1)}%`,
+              ]
+            : []),
+        ];
+        yield* alertSvc.sendAlert({
+          type: w15Signals.depeg ? "stablecoin_depeg" : "liquidity_drain",
+          severity: "critical",
+          message: `Fast EXIT signal on ${pool.tokenXSymbol}/${pool.tokenYSymbol}: ${reasons.join("; ")}`,
+          poolAddress,
+          data: { ...w15Signals },
+        });
+      }
+
       for (const pos of poolPositions) {
         let decision: AgentDecision | null = null;
 
-        if (tvlVelocity < -config.tvlDropExitPct) {
+        if (w15Signals.depeg || w15Signals.liquidityDrain) {
+          decision = {
+            action: "EXIT",
+            poolAddress,
+            positionId: pos.positionId,
+            confidence: 1,
+            reasoning: `W15 fast EXIT: ${w15Signals.depeg ? "stablecoin depeg" : "liquidity drain"}`,
+          };
+        } else if (tvlVelocity < -config.tvlDropExitPct) {
           decision = {
             action: "EXIT",
             poolAddress,

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -1104,7 +1104,9 @@ export type AlertType =
   | "range_warning"
   | "exit_executed"
   | "risk_rejection"
-  | "fee_milestone";
+  | "fee_milestone"
+  | "stablecoin_depeg"
+  | "liquidity_drain";
 
 export type AlertSeverity = "info" | "warning" | "critical";
 


### PR DESCRIPTION
## W15

Adds trusted stablecoin depeg and snapshot-based liquidity-drain detection as position-scoped fast `EXIT` signals. Signals preserve W10 position-pubkey targeting, existing EXIT risk override/audit/execution semantics, paper safety, and W5 persisted cooldown/fail-open alert delivery.

### Verification

- `bun run lint` passed
- `bun run build` passed
- `bun run test` passed: 81 files, 968 tests
- `bun run format:check` passed
- Targeted W15 + alert tests passed: 14 tests
- Changed-file `oxlint` passed
- Manual artifact: `docs/w15-manual-qa.md`
- Raw manual output: `/tmp/w15-manual-qa.txt`

The CLI layer return-type correction is the known W13 `buildProgram()` typing fix required by current TypeScript 7; it changes no CLI behavior. W14 remains separately blocked by the SDK lifecycle limitation and is not modified by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supports multiple independently managed positions within the same pool.
  * Adds configurable fee destinations, including compounding and accumulation options.
  * Adds stablecoin depeg and liquidity-drain detection with position-specific alerts.
  * Portfolio output now identifies each active and exited position.
  * Backtesting now applies the same key risk checks used during replay evaluation.
* **Bug Fixes**
  * Improved configuration validation, numeric clamping, and invalid pool-key detection.
  * Prevented invalid token prices and swap results from producing incorrect fee calculations.
* **Documentation**
  * Added manual QA records and clarified multi-position and backtesting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## F3 coordination correction (2026-07-19)
- Plan mapping: W15 in `.omo/plans/prism-review-remediation.md`; W14 is independently blocked/deferred and is not a dependency implementation.
- Fixed findings: position-scoped depeg and liquidity-drain signals route through existing fast EXIT, cooldown, alert, and fail-open semantics.
- Verification evidence at head: `bun run lint`, `bun run build`, `bun run test` (968 passed, 81 files), `bun run format:check`, and targeted W15/alert tests (14 passed).
- Manual QA artifact: `docs/w15-manual-qa.md`.
- Base/dependency correction: this PR currently targets `main` but its head includes W10-W13 ancestry; it is not a clean W15-only diff. Retargeting/merge must preserve the dependency order after W10-W13.
- Merge status: required Kilo Code Review is failed; no merge bypass performed.

## F1/F3 coordination update (2026-07-20)
- Wave link: W15 in `.omo/plans/prism-review-remediation.md`; W14 remains independently blocked/deferred and is not implemented by this PR.
- Base correction: retargeted from `main` to W13 branch `feat/auto-accumulate` (PR #107), so the dependency chain is represented as W10 -> W11 -> W12 -> W13 -> W15 rather than a misleading direct-main base.
- Findings/evidence: allowlisted stablecoin depeg and snapshot liquidity-drain signals use position-scoped fast EXIT, persisted cooldowns, and fail-open alert delivery.
- Verification recorded at this head: `bun run lint`, `bun run build`, `bun run test` (968/968, 81 files), `bun run format:check`, and 14 targeted W15/alert tests.
- Manual QA artifact: `docs/w15-manual-qa.md` is present in the PR head; no raw output is reclassified as durable evidence.
- Current merge gate: CI build/security checks are green, but required Kilo Code Review is failed and no approval is recorded; PR remains open and unmerged.