### PR TITLE
feat: add opt-in copy-trading signals (W16)

### DIFF
--- a/bench/copy-trading-signals.test.ts
+++ b/bench/copy-trading-signals.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { applyCopySignalBoost, parseCopySignalPayload } from "../engine/copy-trading-signals.js";
+import type { AgentDecision } from "../engine/types.js";
+
+const wallet = "11111111111111111111111111111111";
+const baseDecision = (action: AgentDecision["action"]): AgentDecision => ({
+  action,
+  poolAddress: "pool",
+  confidence: 0.7,
+  reasoning: "base",
+});
+
+describe("copy-trading signals", () => {
+  it("boosts an eligible decision without exceeding the cap", () => {
+    const result = applyCopySignalBoost(baseDecision("ENTER"), {
+      boost: 0.2,
+      wallets: [wallet],
+      ignored: 0,
+    });
+    expect(result.confidence).toBe(0.75);
+    expect(result.reasoning).toContain("copy-signal");
+  });
+
+  it("does not change deterministic EXIT decisions", () => {
+    const result = applyCopySignalBoost(baseDecision("EXIT"), {
+      boost: 0.05,
+      wallets: [wallet],
+      ignored: 0,
+    });
+    expect(result).toEqual(baseDecision("EXIT"));
+  });
+
+  it("ignores malformed and duplicate observations at the boundary", () => {
+    const parsed = parseCopySignalPayload([
+      { wallet, poolAddress: "pool", action: "ENTER", confidence: 0.8, observedAt: 1000 },
+      { wallet, poolAddress: "pool", action: "INVALID", confidence: 0.8, observedAt: 1000 },
+      {
+        wallet: "not-a-wallet",
+        poolAddress: "pool",
+        action: "ENTER",
+        confidence: 0.8,
+        observedAt: 1000,
+      },
+    ]);
+    expect(parsed).toHaveLength(1);
+  });
+
+  it("leaves disabled or zero-signal decisions unchanged", () => {
+    const result = applyCopySignalBoost(baseDecision("HOLD"), {
+      boost: 0,
+      wallets: [],
+      ignored: 2,
+    });
+    expect(result).toEqual(baseDecision("HOLD"));
+  });
+});

--- a/docs/w16-copy-signal-qa.md
+++ b/docs/w16-copy-signal-qa.md
@@ -15,3 +15,10 @@ Observed output:
 ```
 
 This exercises boundary ingestion and the capped decision effect. The production path applies the same transform before the existing risk evaluation; paper mode still uses the existing paper executor and wallet signals never authorize transactions.
+
+Additional checks:
+
+- A disabled configuration or empty signal set returns zero boost and leaves the decision unchanged.
+- The pure transform preserves `EXIT` exactly and clamps boosts to `0.05`.
+- Malformed, stale, unauthorized, and duplicate observations are filtered before scoring; fetch timeout/HTTP/parse failures return zero boost.
+- The temporary QA script was removed after execution; no listener, database, or network mock remains.

--- a/docs/w16-copy-signal-qa.md
+++ b/docs/w16-copy-signal-qa.md
@@ -1,0 +1,17 @@
+# W16 Copy-Signal Manual QA
+
+Date: 2026-07-19
+
+Command:
+
+```bash
+bun -e 'import { parseCopySignalPayload, applyCopySignalBoost } from "./engine/copy-trading-signals.ts"; const wallet = "11111111111111111111111111111111"; const signals = parseCopySignalPayload([{ wallet, poolAddress: "pool", action: "ENTER", confidence: 0.9, observedAt: Date.now() }]); const decision = applyCopySignalBoost({ action: "ENTER", poolAddress: "pool", confidence: 0.7, reasoning: "base" }, { boost: signals.length > 0 ? 0.05 : 0, wallets: [wallet], ignored: 0 }); console.log(JSON.stringify({ observations: signals.length, action: decision.action, confidence: decision.confidence, bounded: decision.confidence <= 0.75 }));'
+```
+
+Observed output:
+
+```text
+{"observations":1,"action":"ENTER","confidence":0.75,"bounded":true}
+```
+
+This exercises boundary ingestion and the capped decision effect. The production path applies the same transform before the existing risk evaluation; paper mode still uses the existing paper executor and wallet signals never authorize transactions.

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -242,6 +242,11 @@ export interface AppConfig {
   readonly alertCooldownMinutes: number;
   /** USD step between cumulative-fee milestone alerts. Default 10. */
   readonly alertFeeMilestoneUsd: number;
+  readonly copySignalsEnabled?: boolean;
+  readonly copySignalsEndpoint?: string;
+  readonly copySignalWallets?: ReadonlyArray<string>;
+  readonly copySignalsStaleMs?: number;
+  readonly copySignalsMaxBoost?: number;
 }
 
 export class ConfigService extends Context.Tag("ConfigService")<ConfigService, AppConfig>() {}
@@ -587,6 +592,26 @@ const loadConfig = Effect.gen(function* () {
   const farmRewardsEnabled = yield* Config.boolean("FARM_REWARDS_ENABLED").pipe(
     Effect.orElseSucceed(() => true),
   );
+  const copySignalsEnabled = yield* Config.boolean("COPY_SIGNALS_ENABLED").pipe(
+    Effect.orElseSucceed(() => false),
+  );
+  const copySignalsEndpoint = yield* Config.string("COPY_SIGNALS_ENDPOINT").pipe(
+    Effect.orElseSucceed(() => ""),
+  );
+  const copySignalWalletsRaw = yield* Config.string("COPY_SIGNAL_WALLETS").pipe(
+    Effect.orElseSucceed(() => ""),
+  );
+  const copySignalWallets = copySignalWalletsRaw
+    .split(",")
+    .map((wallet) => wallet.trim())
+    .filter(Boolean);
+  const copySignalsStaleMs = yield* validatedNumber(
+    "COPY_SIGNALS_STALE_MS",
+    60_000,
+    900_000,
+    86_400_000,
+  );
+  const copySignalsMaxBoost = yield* validatedNumber("COPY_SIGNALS_MAX_BOOST", 0, 0.05, 0.05);
   const alertCooldownMinutes = yield* validatedNumber("ALERT_COOLDOWN_MINUTES", 1, 120);
   const alertFeeMilestoneUsd = yield* validatedNumber("ALERT_FEE_MILESTONE_USD", 0.01, 10);
 
@@ -806,6 +831,11 @@ const loadConfig = Effect.gen(function* () {
     alertsEnabled,
     alertCooldownMinutes,
     alertFeeMilestoneUsd,
+    copySignalsEnabled,
+    copySignalsEndpoint,
+    copySignalWallets,
+    copySignalsStaleMs,
+    copySignalsMaxBoost,
   };
 
   return cfg;

--- a/engine/copy-trading-signals.ts
+++ b/engine/copy-trading-signals.ts
@@ -1,0 +1,161 @@
+import { Effect, Layer } from "effect";
+import { ConfigService } from "./config-service.js";
+import { CopySignalService } from "./services.js";
+import type { ActionType, AgentDecision } from "./types.js";
+import { createLogger } from "./logger.js";
+import { retryEffectWithBackoff } from "./adapter-retry.js";
+
+const logger = createLogger("copy-signals");
+const MAX_BOOST = 0.05;
+const WALLET_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+export type CopySignalObservation = {
+  readonly wallet: string;
+  readonly poolAddress: string;
+  readonly action: "ENTER" | "HOLD" | "REBALANCE";
+  readonly confidence: number;
+  readonly observedAt: number;
+  readonly signature?: string;
+};
+
+export type CopySignalApi = {
+  readonly getBoost: (poolAddress: string, now: number) => Effect.Effect<CopySignalResult, never>;
+};
+
+export type CopySignalResult = {
+  readonly boost: number;
+  readonly wallets: ReadonlyArray<string>;
+  readonly ignored: number;
+};
+
+type CopySignalConfig = {
+  readonly enabled: boolean;
+  readonly endpoint: string;
+  readonly wallets: ReadonlyArray<string>;
+  readonly staleMs: number;
+  readonly maxBoost: number;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function parseCopySignalPayload(raw: unknown): ReadonlyArray<CopySignalObservation> {
+  const values = Array.isArray(raw)
+    ? raw
+    : isObject(raw) && Array.isArray(raw["signals"])
+      ? raw["signals"]
+      : [];
+  const observations: CopySignalObservation[] = [];
+  for (const value of values) {
+    if (!isObject(value)) continue;
+    const wallet = value["wallet"];
+    const poolAddress = value["poolAddress"];
+    const action = value["action"];
+    const confidence = value["confidence"];
+    const observedAt = value["observedAt"];
+    if (
+      typeof wallet !== "string" ||
+      !WALLET_PATTERN.test(wallet) ||
+      typeof poolAddress !== "string" ||
+      poolAddress.length === 0 ||
+      (action !== "ENTER" && action !== "HOLD" && action !== "REBALANCE") ||
+      typeof confidence !== "number" ||
+      !Number.isFinite(confidence) ||
+      confidence < 0 ||
+      confidence > 1 ||
+      typeof observedAt !== "number" ||
+      !Number.isFinite(observedAt)
+    )
+      continue;
+    observations.push({
+      wallet,
+      poolAddress,
+      action,
+      confidence,
+      observedAt,
+      ...(typeof value["signature"] === "string" ? { signature: value["signature"] } : {}),
+    });
+  }
+  return observations;
+}
+
+export function applyCopySignalBoost(
+  decision: AgentDecision,
+  result: CopySignalResult,
+  maxBoost = MAX_BOOST,
+): AgentDecision {
+  if (decision.action === "EXIT" || result.boost <= 0) return decision;
+  const boost = Math.min(Math.max(result.boost, 0), maxBoost);
+  return {
+    ...decision,
+    confidence: Math.min(1, decision.confidence + boost),
+    reasoning: `${decision.reasoning} [copy-signal +${boost.toFixed(3)} from ${result.wallets.length} wallet(s)]`,
+  };
+}
+
+const fetchSignals = (config: CopySignalConfig) =>
+  retryEffectWithBackoff(
+    Effect.tryPromise({
+      try: () =>
+        fetch(config.endpoint, { signal: AbortSignal.timeout(10_000) }).then((response) => {
+          if (!response.ok) throw new Error(`copy-signal HTTP ${response.status}`);
+          return response.json() as Promise<unknown>;
+        }),
+      catch: (cause) => cause,
+    }),
+    { maxRetries: 2 },
+  );
+
+export const CopySignalLive = Layer.effect(
+  CopySignalService,
+  Effect.gen(function* () {
+    const config = yield* ConfigService;
+    const settings: CopySignalConfig = {
+      enabled: config.copySignalsEnabled ?? false,
+      endpoint: config.copySignalsEndpoint ?? "",
+      wallets: config.copySignalWallets ?? [],
+      staleMs: config.copySignalsStaleMs ?? 900_000,
+      maxBoost: config.copySignalsMaxBoost ?? MAX_BOOST,
+    };
+    const getBoost = (poolAddress: string, now: number): Effect.Effect<CopySignalResult, never> => {
+      if (!settings.enabled || settings.endpoint.length === 0 || settings.wallets.length === 0) {
+        return Effect.succeed({ boost: 0, wallets: [], ignored: 0 });
+      }
+      return fetchSignals(settings).pipe(
+        Effect.map((raw) => {
+          const allowed = new Set(settings.wallets);
+          const seen = new Set<string>();
+          const valid = parseCopySignalPayload(raw).filter((signal) => {
+            const key = `${signal.wallet}:${signal.poolAddress}:${signal.action}:${signal.signature ?? signal.observedAt}`;
+            const accepted =
+              signal.poolAddress === poolAddress &&
+              allowed.has(signal.wallet) &&
+              now - signal.observedAt >= 0 &&
+              now - signal.observedAt <= settings.staleMs &&
+              !seen.has(key);
+            seen.add(key);
+            return accepted;
+          });
+          const wallets = [...new Set(valid.map((signal) => signal.wallet))];
+          return {
+            boost: Math.min(settings.maxBoost, wallets.length > 0 ? MAX_BOOST : 0),
+            wallets,
+            ignored: parseCopySignalPayload(raw).length - valid.length,
+          };
+        }),
+        Effect.catchAll((error) =>
+          Effect.sync(() => {
+            logger.warn("Copy-signal fetch failed; continuing without boost", {
+              error: String(error),
+            });
+            return { boost: 0, wallets: [], ignored: 0 };
+          }),
+        ),
+      );
+    };
+    return { getBoost } satisfies CopySignalApi;
+  }),
+);
+
+export const copySignalActionTypes: ReadonlyArray<ActionType> = ["ENTER", "HOLD", "REBALANCE"];

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -3253,6 +3253,25 @@ export const program = Effect.gen(function* () {
           };
         }
 
+        const copySignalResult =
+          copySignalsOption._tag === "Some"
+            ? yield* copySignalsOption.value.getBoost(poolAddress, Date.now())
+            : { boost: 0, wallets: [], ignored: 0 };
+        if (copySignalResult.boost > 0 && decision.action !== "EXIT") {
+          decision = applyCopySignalBoost(
+            decision,
+            copySignalResult,
+            config.copySignalsMaxBoost ?? 0.05,
+          );
+          logger.info("Applied bounded copy-trading signal boost", {
+            pool: poolAddress,
+            boost: copySignalResult.boost,
+            wallets: copySignalResult.wallets.length,
+            ignored: copySignalResult.ignored,
+            paperTrading: config.paperTrading,
+          });
+        }
+
         // Risk evaluation. HOLD executes nothing, so risk gates are skipped for
         // it — every rejection used to write a 60-day warning memory, and those
         // warnings then suppressed the good-HOLD branch (hasRecentWarning),

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -66,6 +66,7 @@ import {
   EntryPrepService,
   MeteoraDatapiService,
   AlertService,
+  CopySignalService,
   type AdapterApi,
   type DbApi,
   type MemoryApi,
@@ -79,6 +80,7 @@ import {
 import { MeteoraDatapiLive, enrichPoolWithDatapi } from "./meteora-datapi-service.js";
 import { AlertLive } from "./alert-service.js";
 import { detectDepegAndLiquidityDrain } from "./depeg-liquidity-detector.js";
+import { CopySignalLive, applyCopySignalBoost } from "./copy-trading-signals.js";
 import type {
   AgentDecision,
   AgentProposal,
@@ -555,7 +557,8 @@ type AllServices =
   | HttpStatusServerService
   | EntryPrepService
   | MeteoraDatapiService
-  | AlertService;
+  | AlertService
+  | CopySignalService;
 
 export function buildLayer(cfg?: AppConfig): Layer.Layer<AllServices, never, never> {
   const dbLayer = DbLive(cfg?.sqliteDbPath);
@@ -633,8 +636,10 @@ export function buildLayer(cfg?: AppConfig): Layer.Layer<AllServices, never, nev
   const alertDeps = Layer.merge(dbLayer, configLayer);
   const alertLayer = Layer.provide(AlertLive, alertDeps);
   const merged16 = Layer.merge(merged15, alertLayer);
+  const copySignalLayer = Layer.provide(CopySignalLive, configLayer);
+  const merged17 = Layer.merge(merged16, copySignalLayer);
 
-  return merged16 as Layer.Layer<AllServices, never, never>;
+  return merged17 as Layer.Layer<AllServices, never, never>;
 }
 
 // ─── Paper execution ─────────────────────────────────────────────────────────
@@ -1287,6 +1292,7 @@ export const program = Effect.gen(function* () {
   const httpStatusServer = yield* HttpStatusServerService;
   const meteoraDatapi = yield* MeteoraDatapiService;
   const alertSvc = yield* AlertService;
+  const copySignalsOption = yield* Effect.serviceOption(CopySignalService);
 
   // Load persisted positions at startup (keyed by position identity — a pool
   // may hold several positions).

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -44,6 +44,7 @@ import type {
   RiskError,
   ScreenerError,
 } from "./errors.js";
+import type { CopySignalApi } from "./copy-trading-signals.js";
 
 // ─── Adapter Service ─────────────────────────────────────────────────────────
 
@@ -1139,6 +1140,11 @@ export interface AlertApi {
 }
 
 export class AlertService extends Context.Tag("AlertService")<AlertService, AlertApi>() {}
+
+export class CopySignalService extends Context.Tag("CopySignalService")<
+  CopySignalService,
+  CopySignalApi
+>() {}
 
 // ─── MCP Server Service ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- add an opt-in typed smart-wallet signal service with configured wallet allowlisting
- validate remote observations, reject stale/malformed/duplicate/unauthorized data, and fail open on delivery errors
- apply a bounded confidence boost before the existing risk gates without changing deterministic EXIT behavior
- include paper-first manual QA evidence

## Verification
- `bun run lint`
- `bun run build`
- `bun run test` (82 files, 972 tests passed)
- `bun run format:check`
- manual QA: confidence 0.70 -> 0.75, cap/disabled/EXIT behavior documented in `docs/w16-copy-signal-qa.md`

## Stack
This PR is intentionally based on W15 branch `feat/depeg-liquidity-alerts` and therefore includes W13 fee routing, W12 coverage, W11 replay, and W10 position identity. Retarget to `main` after W15 merges.

W14 remains separate and blocked by SDK 1.9.13 lifecycle limitations.

## F3 coordination addendum (2026-07-19)
- Plan mapping: W16 in `.omo/plans/prism-review-remediation.md`; stacked on W15 PR #108.
- Fixed findings: copy signals validate allowlists/freshness/deduplication, fail open on retries, cap confidence boost at 0.05, and cannot downgrade EXIT.
- Verification evidence at head: `bun run lint`, `bun run build`, `bun run test` (972 passed, 82 files), and `bun run format:check` passed.
- Manual QA artifact: `docs/w16-copy-signal-qa.md`.
- Merge status: required Kilo Code Review is failed; no merge bypass performed.

## F1/F3 coordination update (2026-07-20)
- Wave link: W16 in `.omo/plans/prism-review-remediation.md`; stacked on W15 PR #108.
- Findings/evidence: copy signals are opt-in, allowlist/freshness/deduplication validated, retries fail open, confidence boost is capped at 0.05, and deterministic EXIT cannot be downgraded.
- Verification recorded at this head: `bun run lint`, `bun run build`, `bun run test` (972/972, 82 files), and `bun run format:check`.
- Manual QA artifact: `docs/w16-copy-signal-qa.md` is present in the PR head. W14 remains separately blocked by the SDK lifecycle limitations stated in the body.
- Current merge gate: CI build/security checks are green, but required Kilo Code Review is failed and no approval is recorded; PR remains open and unmerged.