### PR TITLE
chore(W14): limit-order fail-closed seam — BLOCKED/DEFERRED (not a working feature)

### DIFF
--- a/bench/limit-orders.test.ts
+++ b/bench/limit-orders.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { ConcreteFunctionType } from "@meteora-ag/dlmm";
+import { validateLimitOrderRequest } from "../engine/limit-orders.js";
+
+describe("limit-order request validation", () => {
+  it("accepts a valid take-profit request for a limit-order pool", () => {
+    const result = validateLimitOrderRequest(
+      { side: "ask", targetBinId: 120, amountAtomic: 10n, maxActiveBinSlippage: 3 },
+      ConcreteFunctionType.LimitOrder,
+      ConcreteFunctionType.LimitOrder,
+    );
+
+    expect(result).toEqual({
+      side: "ask",
+      targetBinId: 120,
+      amountAtomic: 10n,
+      maxActiveBinSlippage: 3,
+      isAskSide: true,
+    });
+  });
+
+  it("rejects unsupported concrete function types", () => {
+    expect(() =>
+      validateLimitOrderRequest(
+        { side: "bid", targetBinId: 120, amountAtomic: 10n },
+        ConcreteFunctionType.LiquidityMining,
+        ConcreteFunctionType.LimitOrder,
+      ),
+    ).toThrow("unsupported");
+  });
+
+  it("rejects malformed amount and target bins", () => {
+    expect(() =>
+      validateLimitOrderRequest(
+        { side: "ask", targetBinId: 120.5, amountAtomic: 10n },
+        ConcreteFunctionType.LimitOrder,
+        ConcreteFunctionType.LimitOrder,
+      ),
+    ).toThrow("integer");
+    expect(() =>
+      validateLimitOrderRequest(
+        { side: "ask", targetBinId: 120, amountAtomic: 0n },
+        ConcreteFunctionType.LimitOrder,
+        ConcreteFunctionType.LimitOrder,
+      ),
+    ).toThrow("positive");
+  });
+});

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -55,6 +55,7 @@ import { getWalletSystemLamportsRequired } from "./live-entry-budget.js";
 import { SOL_MINT, USDC_MINT, GAS_RESERVE_LAMPORTS } from "./constants.js";
 import { computeRequiredAtomic } from "./entry-prep-service.js";
 import type { ClaimedReward } from "./rewards.js";
+import { validateLimitOrderRequest, type LimitOrderRequest } from "./limit-orders.js";
 
 const DEFAULT_PUBLIC_KEY = "11111111111111111111111111111111";
 
@@ -1875,6 +1876,109 @@ export const AdapterLive = Layer.effect(
             Effect.fail(
               new AdapterError({
                 message: `Failed to exit position: ${String(err)}`,
+                poolAddress,
+                cause: err,
+              }),
+            ),
+          ),
+        ),
+
+      placeLimitOrder: (poolAddress, request: LimitOrderRequest) =>
+        Effect.gen(function* () {
+          if (!wallet) {
+            return yield* Effect.fail(new AdapterError({ message: "No wallet configured" }));
+          }
+          const dlmm = yield* getDlmm(poolAddress);
+          const concreteFunctionType = Number(
+            (dlmm.lbPair as { concreteFunctionType?: number }).concreteFunctionType ?? -1,
+          );
+          const validated = validateLimitOrderRequest(
+            request,
+            concreteFunctionType,
+            ConcreteFunctionType.LimitOrder,
+          );
+          const limitOrder = new Keypair();
+          const params = {
+            isAskSide: validated.isAskSide,
+            bins: [
+              { id: validated.targetBinId, amount: new BN(validated.amountAtomic.toString()) },
+            ],
+            ...(validated.maxActiveBinSlippage === undefined
+              ? {}
+              : {
+                  relativeBin: {
+                    activeId: dlmm.lbPair.activeId,
+                    maxActiveBinSlippage: validated.maxActiveBinSlippage,
+                  },
+                }),
+          };
+          const tx = yield* Effect.tryPromise(() =>
+            dlmm.placeLimitOrder({
+              owner: wallet.publicKey,
+              payer: wallet.publicKey,
+              sender: wallet.publicKey,
+              limitOrder: limitOrder.publicKey,
+              params,
+            }),
+          );
+          const { blockhash } = yield* rpcCall((conn) => conn.getLatestBlockhash());
+          tx.feePayer = wallet.publicKey;
+          tx.recentBlockhash = blockhash;
+          tx.sign(wallet, limitOrder);
+          const txSignature = yield* rpcCall((conn) =>
+            conn.sendRawTransaction(tx.serialize(), {
+              skipPreflight: false,
+              preflightCommitment: "confirmed",
+            }),
+          );
+          yield* rpcCall((conn) => conn.confirmTransaction(txSignature, "confirmed"));
+          return { orderPubKey: limitOrder.publicKey.toBase58(), txSignature };
+        }).pipe(
+          Effect.catchAll((err: unknown) =>
+            Effect.fail(
+              new AdapterError({
+                message: `Failed to place limit order: ${underlyingErrorMessage(err)}`,
+                poolAddress,
+                cause: err,
+              }),
+            ),
+          ),
+        ),
+
+      cancelLimitOrder: (poolAddress, orderPubKey, binIds) =>
+        Effect.gen(function* () {
+          if (!wallet) {
+            return yield* Effect.fail(new AdapterError({ message: "No wallet configured" }));
+          }
+          if (binIds.length === 0 || binIds.some((binId) => !Number.isSafeInteger(binId))) {
+            return yield* Effect.fail(new AdapterError({ message: "Invalid limit-order bin IDs" }));
+          }
+          const dlmm = yield* getDlmm(poolAddress);
+          const tx = yield* Effect.tryPromise(() =>
+            dlmm.cancelLimitOrder({
+              limitOrderPubkey: new PublicKey(orderPubKey),
+              owner: wallet.publicKey,
+              rentReceiver: wallet.publicKey,
+              binIds: [...binIds],
+            }),
+          );
+          const { blockhash } = yield* rpcCall((conn) => conn.getLatestBlockhash());
+          tx.feePayer = wallet.publicKey;
+          tx.recentBlockhash = blockhash;
+          tx.sign(wallet);
+          const txSignature = yield* rpcCall((conn) =>
+            conn.sendRawTransaction(tx.serialize(), {
+              skipPreflight: false,
+              preflightCommitment: "confirmed",
+            }),
+          );
+          yield* rpcCall((conn) => conn.confirmTransaction(txSignature, "confirmed"));
+          return { txSignature };
+        }).pipe(
+          Effect.catchAll((err: unknown) =>
+            Effect.fail(
+              new AdapterError({
+                message: `Failed to cancel limit order: ${underlyingErrorMessage(err)}`,
                 poolAddress,
                 cause: err,
               }),

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -228,6 +228,10 @@ export interface AppConfig {
   /** Master switch for periodic LM farm reward claims (Wave 8). Default true;
    *  scoring stays farm-aware regardless — this only gates on-chain claims. */
   readonly farmRewardsEnabled: boolean;
+  readonly limitOrdersEnabled?: boolean;
+  readonly limitOrderMode?: "take-profit" | "dca";
+  readonly limitOrderTargetBinOffset?: number;
+  readonly limitOrderMaxActiveBinSlippage?: number;
 
   // ─── Proactive Telegram alerts (Wave 5) ───────────────────────────────────
   /** Master switch for proactive Telegram alerts. Default true; delivery only
@@ -565,6 +569,19 @@ const loadConfig = Effect.gen(function* () {
   const farmRewardsEnabled = yield* Config.boolean("FARM_REWARDS_ENABLED").pipe(
     Effect.orElseSucceed(() => true),
   );
+  const limitOrdersEnabled = yield* Config.boolean("LIMIT_ORDERS_ENABLED").pipe(
+    Config.withDefault(false),
+  );
+  const limitOrderModeRaw = yield* Config.string("LIMIT_ORDER_MODE").pipe(
+    Config.withDefault("take-profit"),
+  );
+  const limitOrderMode = limitOrderModeRaw === "dca" ? "dca" : "take-profit";
+  const limitOrderTargetBinOffset = yield* validatedNumber("LIMIT_ORDER_TARGET_BIN_OFFSET", 1, 20);
+  const limitOrderMaxActiveBinSlippage = yield* validatedNumber(
+    "LIMIT_ORDER_MAX_ACTIVE_BIN_SLIPPAGE",
+    0,
+    3,
+  );
   const alertCooldownMinutes = yield* validatedNumber("ALERT_COOLDOWN_MINUTES", 1, 120);
   const alertFeeMilestoneUsd = yield* validatedNumber("ALERT_FEE_MILESTONE_USD", 0.01, 10);
 
@@ -776,6 +793,10 @@ const loadConfig = Effect.gen(function* () {
     autoSwapEntry,
     entryStrategyType,
     farmRewardsEnabled,
+    limitOrdersEnabled,
+    limitOrderMode,
+    limitOrderTargetBinOffset,
+    limitOrderMaxActiveBinSlippage,
     alertsEnabled,
     alertCooldownMinutes,
     alertFeeMilestoneUsd,

--- a/engine/limit-orders.ts
+++ b/engine/limit-orders.ts
@@ -1,0 +1,37 @@
+import type { ConcreteFunctionType } from "@meteora-ag/dlmm";
+
+export type LimitOrderSide = "ask" | "bid";
+
+export interface LimitOrderRequest {
+  readonly side: LimitOrderSide;
+  readonly targetBinId: number;
+  readonly amountAtomic: bigint;
+  readonly maxActiveBinSlippage?: number;
+}
+
+export interface ValidatedLimitOrderRequest extends LimitOrderRequest {
+  readonly isAskSide: boolean;
+}
+
+export function validateLimitOrderRequest(
+  request: LimitOrderRequest,
+  concreteFunctionType: number,
+  limitOrderType: typeof ConcreteFunctionType.LimitOrder,
+): ValidatedLimitOrderRequest {
+  if (concreteFunctionType !== limitOrderType) {
+    throw new Error("Limit orders are unsupported for this pool function type");
+  }
+  if (!Number.isSafeInteger(request.targetBinId)) {
+    throw new Error("Limit-order target bin must be an integer");
+  }
+  if (request.amountAtomic <= 0n) {
+    throw new Error("Limit-order amount must be positive");
+  }
+  if (
+    request.maxActiveBinSlippage !== undefined &&
+    (!Number.isSafeInteger(request.maxActiveBinSlippage) || request.maxActiveBinSlippage < 0)
+  ) {
+    throw new Error("Limit-order active-bin slippage must be a non-negative integer");
+  }
+  return { ...request, isAskSide: request.side === "ask" };
+}

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -34,6 +34,7 @@ import type {
 } from "./state-service.js";
 import type { EvolvableThresholds, OutcomeRecord } from "./strategy-service.js";
 import type { ClaimedReward } from "./rewards.js";
+import type { LimitOrderRequest } from "./limit-orders.js";
 import type {
   AdapterError,
   AuditError,
@@ -131,6 +132,15 @@ export interface AdapterApi {
   readonly exitPosition: (
     poolAddress: string,
     positionPubKey: string,
+  ) => Effect.Effect<{ txSignature: string }, unknown>;
+  readonly placeLimitOrder?: (
+    poolAddress: string,
+    request: LimitOrderRequest,
+  ) => Effect.Effect<{ orderPubKey: string; txSignature: string }, unknown>;
+  readonly cancelLimitOrder?: (
+    poolAddress: string,
+    orderPubKey: string,
+    binIds: ReadonlyArray<number>,
   ) => Effect.Effect<{ txSignature: string }, unknown>;
   /**
    * Atomically rebalance a position into a new range via the Meteora SDK's


### PR DESCRIPTION
> **⚠️ STATUS: BLOCKED / DEFERRED — This PR does NOT deliver Wave 14 and must NOT be treated as a working limit-order feature.**

This is a **transparency / blocker PR**. It lands the existing **fail-closed scaffold** for DLMM limit orders and documents, in one place, exactly why W14 cannot be accepted yet. Merging it does **not** enable limit orders and does **not** count as W14 acceptance.

Plan: `.omo/plans/prism-review-remediation.md` · Engine policy: `AGENTS.md` → "Limit-order status (Wave 14)".

## What this PR contains

| File | Change | Executed by the engine? |
| --- | --- | --- |
| `engine/limit-orders.ts` | Typed `LimitOrderRequest` / `ValidatedLimitOrderRequest` + `validateLimitOrderRequest` (rejects non-`LimitOrder` pool function types, non-integer bins, non-positive amounts, negative slippage) | n/a (pure validation) |
| `engine/config-service.ts` | Typed `LIMIT_ORDERS_ENABLED` (default **false**), `LIMIT_ORDER_MODE`, `LIMIT_ORDER_TARGET_BIN_OFFSET`, `LIMIT_ORDER_MAX_ACTIVE_BIN_SLIPPAGE` | Config only |
| `engine/services.ts` | **Optional** `placeLimitOrder` / `cancelLimitOrder` on `AdapterApi` | Optional seam |
| `engine/adapter-service.ts` | Live `placeLimitOrder` / `cancelLimitOrder` implementations (wallet-required, validated, error-wrapped) | **Never called** |
| `bench/limit-orders.test.ts` | Unit tests for the fail-closed validator | Tests only |

## Why it is safe to merge (fail-closed)

- `LIMIT_ORDERS_ENABLED` defaults to **`false`**.
- The adapter methods are **optional** on `AdapterApi` and have **no caller** in `engine/program.ts`. The decision loop **never** places or cancels a limit order, in paper or live mode.
- `validateLimitOrderRequest` throws unless the pool's `concreteFunctionType === ConcreteFunctionType.LimitOrder`.
- Net behavior is identical to today: W14 is inert. Verified: `bun run lint` exit 0; `bun run build` exit 0; `bun run test` exit 0 (**83 files / 975 tests**).

## Exact SDK gaps blocking acceptance (the real blockers)

The current `@meteora-ag/dlmm` SDK path does not provide the lifecycle facts Prism needs to place, track, and unwind limit orders safely:

1. **No trusted position↔order linkage.** There is no supported way to bind a placed limit order back to the engine's `positionId`, so fills/expiry cannot be reconciled to a tracked position.
2. **No reliable fill / expiry reconciliation.** No dependable read path to detect that an order filled, partially filled, or expired, which a correct lifecycle requires.
3. **No freshness-bearing quote.** No quote with a staleness guarantee that can safely drive the order lifecycle (place/adjust/cancel decisions).
4. **No safe post-withdraw redeposit sizing contract.** After a limit order withdraws liquidity, there is no contract guaranteeing correct sizing when redepositing, risking mis-sized or stranded positions.

Until these are available via a supported SDK/API path, Prism must **not** place or cancel limit orders or claim W14 acceptance.

## Deferred acceptance criteria (must all hold before W14 can be accepted)

- [ ] Trusted linkage between a placed limit order and the engine's `positionId`.
- [ ] Reliable fill and expiry reconciliation reflected in `positions` / `position_events`.
- [ ] A freshness-bearing quote that can safely drive the order lifecycle.
- [ ] A safe post-withdraw sizing contract for redeposit.
- [ ] Paper-mode end-to-end parity for place → fill/expire → reconcile, with a passing durable QA artifact.
- [ ] Decision-loop wiring behind `LIMIT_ORDERS_ENABLED` with risk gates and audit/telemetry.

## Coordination notes

- Branch was synced to current `main` (post W10–W16) via an additive merge commit; the PR diff is the W14 seam only (`limit-orders.ts`, validator test, and additive config/services/adapter changes).
- No strategy logic is changed; `program.ts` is untouched by this seam.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for placing and canceling limit orders.
  * Added configurable limit-order settings, including order mode, target-bin offset, and slippage limits.
  * Added validation for order sides, target bins, amounts, and slippage values.
  * Limit-order transactions now return order and transaction details.
* **Tests**
  * Added coverage for valid requests and invalid limit-order inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->