### PR TITLE
fix(engine): settle gateway probe before close to fix Bun false-negative

### DIFF
--- a/engine/agent-detection.ts
+++ b/engine/agent-detection.ts
@@ -81,12 +81,15 @@ function isGatewayRunning(url: string): Effect.Effect<boolean, unknown> {
       ws = new WebSocket(url);
       ws.addEventListener("open", () => {
         clearTimeout(timer);
+        // Settle BEFORE closing: Bun dispatches the close listener synchronously
+        // during ws.close(), so settle(false) from the close handler would win
+        // if close() ran first.
+        settle(true);
         try {
           ws?.close();
         } catch {
           // ignore close errors during probe success cleanup
         }
-        settle(true);
       });
       ws.addEventListener("error", () => {
         clearTimeout(timer);


### PR DESCRIPTION
## Problem

`isGatewayRunning` always returns `false` on Bun, even when the OpenClaw gateway is running and healthy. This silently prevents `GatewayTransport` from ever being created (`selectTransport` gates on `detection.openclaw.gatewayRunning`), so agent check-ins and decision review are dead.

**Root cause:** Bun dispatches the WebSocket `close` listener **synchronously** during `ws.close()` — before the open handler's subsequent `settle(true)` runs. The close handler's `settle(false)` always wins the race.

Node dispatches `close` asynchronously, which masks this in Node-based tests.

**Event order on Bun (before fix):**
```
[open] → ws.close() → [close code=1000] → settle(false) wins → settle(true) no-op
```

## Fix

Move `settle(true)` **before** `ws.close()` in the `open` handler, so the probe result is captured regardless of close-event dispatch timing.

```diff
 ws.addEventListener("open", () => {
   clearTimeout(timer);
+  settle(true);
   try { ws?.close(); } catch {}
-  settle(true);
 });
```

**Verified** on the deployed Bun 1.4.0-canary linux-x64 bundle — detection flips to `gatewayRunning: true`, `recommended: "openclaw"`, `transport: "gateway"`.

## Scope

Single source module: `engine/agent-detection.ts` → `isGatewayRunning()`. This feeds both `dist/cli/index.mjs` and `dist/index.mjs` bundle entries.

## Checklist

- [x] `bun run lint` (tsc + oxlint) passes
- [x] No new dependencies
- [x] No behavioral change on Node (close was already async there)

## Summary by Sourcery

Bug Fixes:
- Fix gateway running detection returning false on Bun by settling probe success before invoking WebSocket close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway detection reliability by ensuring successful WebSocket connections are recognized before the connection closes.
  * Prevented valid running gateways from being incorrectly reported as unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->