### PR TITLE
fix(config,doctor): normalize Helius RPC URLs and add live connectivity probes

### DIFF
--- a/bench/helius-url-normalize.test.ts
+++ b/bench/helius-url-normalize.test.ts
@@ -142,4 +142,22 @@ describe("normalizeHeliusUrl", () => {
     expect(url).toBe("not-a-url");
     expect(normalized).toBe(false);
   });
+
+  it("refuses to append credentials to http:// Helius URLs", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "http://mainnet.helius-rpc.com/",
+      "my-secret-key",
+    );
+    expect(url).toBe("http://mainnet.helius-rpc.com/");
+    expect(normalized).toBe(false);
+  });
+
+  it("still normalizes api_key= to api-key= on http:// URLs without appending the key", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "http://mainnet.helius-rpc.com/?api_key=existing",
+      "my-secret-key",
+    );
+    expect(url).toBe("http://mainnet.helius-rpc.com/?api_key=existing");
+    expect(normalized).toBe(false);
+  });
 });

--- a/bench/helius-url-normalize.test.ts
+++ b/bench/helius-url-normalize.test.ts
@@ -82,4 +82,64 @@ describe("normalizeHeliusUrl", () => {
     );
     expect(url).toBe("https://mainnet.helius-rpc.com/?api-key=abc");
   });
+
+  it("replaces empty api-key= value with the configured key", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://mainnet.helius-rpc.com/?api-key=",
+      "my-real-key",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/?api-key=my-real-key");
+    expect(normalized).toBe(true);
+  });
+
+  it("replaces empty api-key= when followed by other params", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://mainnet.helius-rpc.com/?api-key=&foo=bar",
+      "my-real-key",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/?api-key=my-real-key&foo=bar");
+    expect(normalized).toBe(true);
+  });
+
+  it("does not modify empty api-key= when no key is configured", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://mainnet.helius-rpc.com/?api-key=",
+      "",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/?api-key=");
+    expect(normalized).toBe(false);
+  });
+
+  it("rejects attacker domains containing helius-rpc.com as substring", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://helius-rpc.com.attacker.example/",
+      "my-secret-key",
+    );
+    expect(url).toBe("https://helius-rpc.com.attacker.example/");
+    expect(normalized).toBe(false);
+  });
+
+  it("rejects URLs with helius-rpc.com in the path, not the hostname", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://evil.com/helius-rpc.com/proxy",
+      "my-secret-key",
+    );
+    expect(url).toBe("https://evil.com/helius-rpc.com/proxy");
+    expect(normalized).toBe(false);
+  });
+
+  it("accepts subdomains of helius-rpc.com", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://mainnet.helius-rpc.com/",
+      "my-key",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/?api-key=my-key");
+    expect(normalized).toBe(true);
+  });
+
+  it("handles invalid URLs gracefully", () => {
+    const { url, normalized } = normalizeHeliusUrl("not-a-url", "my-key");
+    expect(url).toBe("not-a-url");
+    expect(normalized).toBe(false);
+  });
 });

--- a/bench/helius-url-normalize.test.ts
+++ b/bench/helius-url-normalize.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { normalizeHeliusUrl } from "../engine/config-service.js";
+
+describe("normalizeHeliusUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns non-Helius URLs unchanged", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://api.mainnet-beta.solana.com",
+      "my-key",
+    );
+    expect(url).toBe("https://api.mainnet-beta.solana.com");
+    expect(normalized).toBe(false);
+  });
+
+  it("returns empty strings unchanged", () => {
+    const { url, normalized } = normalizeHeliusUrl("", "my-key");
+    expect(url).toBe("");
+    expect(normalized).toBe(false);
+  });
+
+  it("replaces api_key= with api-key= in Helius URLs", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://mainnet.helius-rpc.com/?api_key=abc-123",
+      "abc-123",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/?api-key=abc-123");
+    expect(normalized).toBe(true);
+  });
+
+  it("replaces all occurrences of api_key=", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://mainnet.helius-rpc.com/?api_key=abc&api_key=def",
+      "abc",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/?api-key=abc&api-key=def");
+    expect(normalized).toBe(true);
+  });
+
+  it("leaves correct api-key= URLs unchanged", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://mainnet.helius-rpc.com/?api-key=abc-123",
+      "abc-123",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/?api-key=abc-123");
+    expect(normalized).toBe(false);
+  });
+
+  it("appends api-key when Helius URL is missing it entirely", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://mainnet.helius-rpc.com/",
+      "my-secret-key",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/?api-key=my-secret-key");
+    expect(normalized).toBe(true);
+  });
+
+  it("appends with & when URL already has query params", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://mainnet.helius-rpc.com/?foo=bar",
+      "my-key",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/?foo=bar&api-key=my-key");
+    expect(normalized).toBe(true);
+  });
+
+  it("does not append api-key when no key is configured", () => {
+    const { url, normalized } = normalizeHeliusUrl(
+      "https://mainnet.helius-rpc.com/",
+      "",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/");
+    expect(normalized).toBe(false);
+  });
+
+  it("trims whitespace from URLs", () => {
+    const { url } = normalizeHeliusUrl(
+      "  https://mainnet.helius-rpc.com/?api-key=abc  ",
+      "abc",
+    );
+    expect(url).toBe("https://mainnet.helius-rpc.com/?api-key=abc");
+  });
+});

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -156,11 +156,11 @@ async function probeRpcEndpoint(url: string): Promise<{ ok: boolean; status: num
     if (json.error) {
       return { ok: false, status: res.status, error: maskHeliusUrl(json.error.message ?? "RPC error") };
     }
-    if (json.result === undefined || json.result === null) {
+    if (json.result !== "ok") {
       return {
         ok: false,
         status: res.status,
-        error: "Response is not a valid JSON-RPC envelope (missing result field)",
+        error: `getHealth returned unexpected result: ${JSON.stringify(json.result ?? null)}`,
       };
     }
     return { ok: true, status: res.status };

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -126,6 +126,89 @@ function checkRpc(): DoctorCheck {
   );
 }
 
+async function probeRpcEndpoint(url: string): Promise<{ ok: boolean; status: number; error?: string }> {
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: "prism-doctor", method: "getHealth" }),
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, status: res.status, error: `HTTP ${res.status} — API key rejected` };
+    }
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: `HTTP ${res.status}` };
+    }
+    const json = (await res.json()) as { result?: unknown; error?: { message?: string } };
+    if (json.error) {
+      return { ok: false, status: res.status, error: json.error.message ?? "RPC error" };
+    }
+    return { ok: true, status: res.status };
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function checkRpcConnectivity(): Promise<DoctorCheck> {
+  const primary = process.env.SOLANA_RPC_URL?.trim() ?? "";
+  const helius = process.env.HELIUS_API_KEY?.trim() ?? "";
+  const fallback = process.env.SOLANA_RPC_FALLBACK_URL?.trim() ?? "";
+
+  const effectivePrimary =
+    primary || (helius ? `https://mainnet.helius-rpc.com/?api-key=${helius}` : "");
+
+  if (!effectivePrimary) {
+    return check("rpc-connectivity", "warn", "No RPC endpoint configured; skipping live probe");
+  }
+
+  const primaryResult = await probeRpcEndpoint(effectivePrimary);
+  if (!primaryResult.ok) {
+    return check(
+      "rpc-connectivity",
+      "fail",
+      `Primary RPC unreachable: ${primaryResult.error}`,
+    );
+  }
+
+  if (fallback) {
+    const fallbackResult = await probeRpcEndpoint(fallback);
+    if (!fallbackResult.ok) {
+      return check(
+        "rpc-connectivity",
+        "warn",
+        `Primary RPC reachable but fallback failed: ${fallbackResult.error}`,
+      );
+    }
+    return check("rpc-connectivity", "pass", "Primary and fallback RPC endpoints reachable");
+  }
+
+  return check("rpc-connectivity", "pass", "Primary RPC endpoint reachable");
+}
+
+async function checkHeliusApiKey(): Promise<DoctorCheck> {
+  const heliusKey = process.env.HELIUS_API_KEY?.trim() ?? "";
+  if (!heliusKey) {
+    return check("helius-api-key", "warn", "HELIUS_API_KEY not set; DAS price lookups disabled");
+  }
+
+  const url = `https://mainnet.helius-rpc.com/?api-key=${heliusKey}`;
+  const result = await probeRpcEndpoint(url);
+  if (!result.ok) {
+    return check(
+      "helius-api-key",
+      "fail",
+      `HELIUS_API_KEY rejected by Helius: ${result.error}`,
+    );
+  }
+
+  return check("helius-api-key", "pass", "Helius API key valid");
+}
+
 function checkWallet(): DoctorCheck {
   if (process.env.PAPER_TRADING !== "false") {
     return check("wallet", "pass", "Paper trading is enabled; no private key required");
@@ -168,6 +251,8 @@ export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorRepo
       : check("database", "warn", `${getPrismDbPath()} will be created on first run`),
   );
   checks.push(checkRpc());
+  checks.push(await checkRpcConnectivity());
+  checks.push(await checkHeliusApiKey());
   checks.push(checkPriceProviders());
   checks.push(checkWallet());
   checks.push(await checkRegistration());

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -10,6 +10,7 @@ import {
   getPrismLogsDir,
 } from "../engine/paths.js";
 import { isSourceInstall } from "../engine/install-method.js";
+import { normalizeHeliusUrl } from "../engine/config-service.js";
 import { getApiBaseUrl, prismApiPost, readCredentials } from "./api.js";
 
 type DoctorStatus = "pass" | "warn" | "fail";
@@ -140,7 +141,16 @@ async function probeRpcEndpoint(url: string): Promise<{ ok: boolean; status: num
     if (!res.ok) {
       return { ok: false, status: res.status, error: `HTTP ${res.status}` };
     }
-    const json = (await res.json()) as { result?: unknown; error?: { message?: string } };
+    let json: { result?: unknown; error?: { message?: string } };
+    try {
+      json = (await res.json()) as { result?: unknown; error?: { message?: string } };
+    } catch (parseErr) {
+      return {
+        ok: false,
+        status: res.status,
+        error: `Invalid JSON response: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+      };
+    }
     if (json.error) {
       return { ok: false, status: res.status, error: json.error.message ?? "RPC error" };
     }
@@ -166,7 +176,8 @@ async function checkRpcConnectivity(): Promise<DoctorCheck> {
     return check("rpc-connectivity", "warn", "No RPC endpoint configured; skipping live probe");
   }
 
-  const primaryResult = await probeRpcEndpoint(effectivePrimary);
+  const normalizedPrimary = normalizeHeliusUrl(effectivePrimary, helius).url;
+  const primaryResult = await probeRpcEndpoint(normalizedPrimary);
   if (!primaryResult.ok) {
     return check(
       "rpc-connectivity",
@@ -176,7 +187,8 @@ async function checkRpcConnectivity(): Promise<DoctorCheck> {
   }
 
   if (fallback) {
-    const fallbackResult = await probeRpcEndpoint(fallback);
+    const normalizedFallback = normalizeHeliusUrl(fallback, helius).url;
+    const fallbackResult = await probeRpcEndpoint(normalizedFallback);
     if (!fallbackResult.ok) {
       return check(
         "rpc-connectivity",

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -114,7 +114,7 @@ function checkRpc(): DoctorCheck {
       "Public Solana RPC is configured; use a paid/private provider for live trading",
     );
   }
-  if (fallback && fallback === primary) {
+  if (fallback && normalizeHeliusUrl(fallback, helius).url === normalizeHeliusUrl(primary, helius).url) {
     return check("rpc", "fail", "SOLANA_RPC_FALLBACK_URL duplicates SOLANA_RPC_URL");
   }
   if (!fallback && !paperTrading) {
@@ -156,7 +156,7 @@ async function probeRpcEndpoint(url: string): Promise<{ ok: boolean; status: num
     if (json.error) {
       return { ok: false, status: res.status, error: maskHeliusUrl(json.error.message ?? "RPC error") };
     }
-    if (json.result === undefined && json.result !== null) {
+    if (json.result === undefined || json.result === null) {
       return {
         ok: false,
         status: res.status,

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -154,6 +154,13 @@ async function probeRpcEndpoint(url: string): Promise<{ ok: boolean; status: num
     if (json.error) {
       return { ok: false, status: res.status, error: json.error.message ?? "RPC error" };
     }
+    if (json.result === undefined && json.result !== null) {
+      return {
+        ok: false,
+        status: res.status,
+        error: "Response is not a valid JSON-RPC envelope (missing result field)",
+      };
+    }
     return { ok: true, status: res.status };
   } catch (err) {
     return {

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -10,7 +10,7 @@ import {
   getPrismLogsDir,
 } from "../engine/paths.js";
 import { isSourceInstall } from "../engine/install-method.js";
-import { normalizeHeliusUrl } from "../engine/config-service.js";
+import { normalizeHeliusUrl, maskHeliusUrl } from "../engine/config-service.js";
 import { getApiBaseUrl, prismApiPost, readCredentials } from "./api.js";
 
 type DoctorStatus = "pass" | "warn" | "fail";
@@ -148,11 +148,13 @@ async function probeRpcEndpoint(url: string): Promise<{ ok: boolean; status: num
       return {
         ok: false,
         status: res.status,
-        error: `Invalid JSON response: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+        error: maskHeliusUrl(
+          `Invalid JSON response: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+        ),
       };
     }
     if (json.error) {
-      return { ok: false, status: res.status, error: json.error.message ?? "RPC error" };
+      return { ok: false, status: res.status, error: maskHeliusUrl(json.error.message ?? "RPC error") };
     }
     if (json.result === undefined && json.result !== null) {
       return {
@@ -166,7 +168,7 @@ async function probeRpcEndpoint(url: string): Promise<{ ok: boolean; status: num
     return {
       ok: false,
       status: 0,
-      error: err instanceof Error ? err.message : String(err),
+      error: maskHeliusUrl(err instanceof Error ? err.message : String(err)),
     };
   }
 }
@@ -270,8 +272,12 @@ export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorRepo
       : check("database", "warn", `${getPrismDbPath()} will be created on first run`),
   );
   checks.push(checkRpc());
-  checks.push(await checkRpcConnectivity());
-  checks.push(await checkHeliusApiKey());
+  const [rpcConnectivity, heliusApiKey] = await Promise.all([
+    checkRpcConnectivity(),
+    checkHeliusApiKey(),
+  ]);
+  checks.push(rpcConnectivity);
+  checks.push(heliusApiKey);
   checks.push(checkPriceProviders());
   checks.push(checkWallet());
   checks.push(await checkRegistration());

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -9,21 +9,39 @@ const logger = createLogger("ConfigService");
 
 export type FeeDestination = "compound" | "accumulate-quote" | "accumulate-sol";
 
+function maskHeliusUrl(u: string): string {
+  return u.replace(/(api[-_]key=)[^&\s]*/g, "$1[REDACTED]");
+}
+
+function isHeliusHost(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname;
+    return hostname === "helius-rpc.com" || hostname.endsWith(".helius-rpc.com");
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Normalize a Helius RPC URL: fix the common `api_key` → `api-key` typo and
- * warn when a Helius URL is missing the api-key query parameter entirely.
+ * Normalize a Helius RPC URL: fix the common `api_key` → `api-key` typo,
+ * replace empty `api-key=` values with the configured key, and append the
+ * key when the parameter is missing entirely.
  *
  * Helius currently accepts both spellings, but `api-key` is the documented
  * form and the one every code-generated URL uses.  User-edited `.env` files
  * often contain `api_key`, which is a latent breakage waiting for a Helius
  * API tightening.
+ *
+ * Security: hostname is validated via URL parsing (not substring match) to
+ * prevent credential leakage to attacker-controlled domains such as
+ * `helius-rpc.com.attacker.example`.  API key values are redacted in logs.
  */
 export function normalizeHeliusUrl(
   url: string,
   heliusApiKey: string,
 ): { readonly url: string; readonly normalized: boolean } {
   const trimmed = url.trim();
-  if (!trimmed || !trimmed.includes("helius-rpc.com")) {
+  if (!trimmed || !isHeliusHost(trimmed)) {
     return { url: trimmed, normalized: false };
   }
 
@@ -34,18 +52,27 @@ export function normalizeHeliusUrl(
     result = result.replace(/api_key=/g, "api-key=");
     normalized = true;
     logger.warn("Normalized Helius URL: replaced api_key= with api-key=", {
-      original: trimmed,
-      corrected: result,
+      original: maskHeliusUrl(trimmed),
+      corrected: maskHeliusUrl(result),
     });
   }
 
-  if (!result.includes("api-key=") && heliusApiKey) {
-    const separator = result.includes("?") ? "&" : "?";
-    result = `${result}${separator}api-key=${heliusApiKey}`;
-    normalized = true;
-    logger.warn("Helius URL was missing api-key parameter; appended configured key", {
-      corrected: result,
-    });
+  if (heliusApiKey) {
+    const emptyKeyMatch = result.match(/api-key=(&|$)/);
+    if (emptyKeyMatch) {
+      result = result.replace(/api-key=(&|$)/, `api-key=${heliusApiKey}$1`);
+      normalized = true;
+      logger.warn("Helius URL had empty api-key value; replaced with configured key", {
+        corrected: maskHeliusUrl(result),
+      });
+    } else if (!result.includes("api-key=")) {
+      const separator = result.includes("?") ? "&" : "?";
+      result = `${result}${separator}api-key=${heliusApiKey}`;
+      normalized = true;
+      logger.warn("Helius URL was missing api-key parameter; appended configured key", {
+        corrected: maskHeliusUrl(result),
+      });
+    }
   }
 
   return { url: result, normalized };

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -9,6 +9,48 @@ const logger = createLogger("ConfigService");
 
 export type FeeDestination = "compound" | "accumulate-quote" | "accumulate-sol";
 
+/**
+ * Normalize a Helius RPC URL: fix the common `api_key` → `api-key` typo and
+ * warn when a Helius URL is missing the api-key query parameter entirely.
+ *
+ * Helius currently accepts both spellings, but `api-key` is the documented
+ * form and the one every code-generated URL uses.  User-edited `.env` files
+ * often contain `api_key`, which is a latent breakage waiting for a Helius
+ * API tightening.
+ */
+export function normalizeHeliusUrl(
+  url: string,
+  heliusApiKey: string,
+): { readonly url: string; readonly normalized: boolean } {
+  const trimmed = url.trim();
+  if (!trimmed || !trimmed.includes("helius-rpc.com")) {
+    return { url: trimmed, normalized: false };
+  }
+
+  let result = trimmed;
+  let normalized = false;
+
+  if (result.includes("api_key=")) {
+    result = result.replace(/api_key=/g, "api-key=");
+    normalized = true;
+    logger.warn("Normalized Helius URL: replaced api_key= with api-key=", {
+      original: trimmed,
+      corrected: result,
+    });
+  }
+
+  if (!result.includes("api-key=") && heliusApiKey) {
+    const separator = result.includes("?") ? "&" : "?";
+    result = `${result}${separator}api-key=${heliusApiKey}`;
+    normalized = true;
+    logger.warn("Helius URL was missing api-key parameter; appended configured key", {
+      corrected: result,
+    });
+  }
+
+  return { url: result, normalized };
+}
+
 export interface AppConfig {
   readonly walletPrivateKey: string;
   readonly heliusApiKey: string;
@@ -290,7 +332,7 @@ const loadConfig = Effect.gen(function* () {
       isTest ? "https://example.com" : "https://api.mainnet-beta.solana.com",
     ),
   );
-  const solanaRpcFallbackUrl = yield* Config.string("SOLANA_RPC_FALLBACK_URL").pipe(
+  const solanaRpcFallbackUrlRaw = yield* Config.string("SOLANA_RPC_FALLBACK_URL").pipe(
     Effect.orElseSucceed(() => ""),
   );
 
@@ -299,6 +341,10 @@ const loadConfig = Effect.gen(function* () {
   if (!isTest && !process.env.SOLANA_RPC_URL && heliusApiKey.length > 0) {
     solanaRpcUrl = `https://mainnet.helius-rpc.com/?api-key=${heliusApiKey}`;
   }
+
+  const solanaRpcUrlNormalized = normalizeHeliusUrl(solanaRpcUrl, heliusApiKey);
+  solanaRpcUrl = solanaRpcUrlNormalized.url;
+  const solanaRpcFallbackUrl = normalizeHeliusUrl(solanaRpcFallbackUrlRaw, heliusApiKey).url;
   const paperTrading = yield* Config.boolean("PAPER_TRADING").pipe(
     Effect.orElseSucceed(() => true),
   );

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -9,7 +9,7 @@ const logger = createLogger("ConfigService");
 
 export type FeeDestination = "compound" | "accumulate-quote" | "accumulate-sol";
 
-function maskHeliusUrl(u: string): string {
+export function maskHeliusUrl(u: string): string {
   return u.replace(/(api[-_]key=)[^&\s]*/g, "$1[REDACTED]");
 }
 

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -15,7 +15,9 @@ function maskHeliusUrl(u: string): string {
 
 function isHeliusHost(url: string): boolean {
   try {
-    const hostname = new URL(url).hostname;
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    const hostname = parsed.hostname;
     return hostname === "helius-rpc.com" || hostname.endsWith(".helius-rpc.com");
   } catch {
     return false;


### PR DESCRIPTION
## Problem

User-edited `.env` files can contain Helius RPC URLs with `api_key=` (underscore) instead of the documented `api-key=` (hyphen), or Helius URLs missing the API key parameter entirely. The code passed these through unchecked, causing silent 401 errors during scan cycles that were hard to diagnose.

Additionally, `prism doctor` only checked whether env vars were *set* — never whether the RPC endpoints actually *worked*.

## Root Cause Investigation

Debugged a reported Helius API key 401 on a VPS (`381b0029-4a7f-4bdd-b136-5ba90f5d9280`):
- **API key is valid** — direct curl returns HTTP 200 on all Helius endpoints
- **VPS `.env` had `api_key=`** (underscore) in `SOLANA_RPC_FALLBACK_URL` — Helius currently accepts both spellings, but this is a latent breakage
- **No validation existed** — the code never normalized or verified user-provided Helius URLs
- **Doctor was config-only** — no live connectivity probes to catch auth failures at setup time

## Changes

### `engine/config-service.ts`
- Add `normalizeHeliusUrl()`: auto-corrects `api_key=` → `api-key=` in Helius URLs, appends the configured `HELIUS_API_KEY` when a Helius URL is missing the key parameter entirely, and emits structured warnings on every normalization
- Wired into config loading for both `SOLANA_RPC_URL` and `SOLANA_RPC_FALLBACK_URL`

### `cli/doctor.ts`
- Add `checkRpcConnectivity()`: makes a real JSON-RPC `getHealth` call to primary and fallback RPC endpoints, surfacing HTTP 401/403 auth failures before they hit the scan loop
- Add `checkHeliusApiKey()`: validates `HELIUS_API_KEY` independently against the Helius endpoint so misconfigured keys are caught at setup time, not mid-cycle

### `bench/helius-url-normalize.test.ts`
- 9 tests covering: non-Helius passthrough, empty string, underscore replacement, multi-occurrence replacement, correct URL passthrough, missing key append (with/without existing query params), empty key no-append, whitespace trimming

## Verification

- ✅ 9 new tests pass
- ✅ 12 existing config-service tests pass (no regressions)
- ✅ `tsc --noEmit` clean
- ✅ `oxlint` clean on all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added RPC connectivity checks to the diagnostic command, including primary and fallback endpoints.
  - Added direct Helius API key validation with clearer success, warning, and failure results.
  - Helius RPC URLs are now automatically normalized and completed with configured API keys when needed.

- **Bug Fixes**
  - Corrected common `api_key` URL parameter formatting.
  - Improved handling of whitespace, invalid URLs, empty keys, and non-Helius domains.
  - API keys are redacted from normalization warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->