### PR TITLE
feat: add canary release channel — prism update --canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,306 @@ jobs:
 
       - name: Run tests
         run: bun run test
+
+  # Canary release channel: build + publish a per-merge canary bundle to R2
+  # whenever CI passes on main. Mirrors release.yml's bundle/manifest patterns
+  # but publishes to a canary-only R2 prefix and flips a single manifest
+  # pointer (releases/channel/canary.json) last. No GitHub Release, no GPG.
+  canary-prepare:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: canary-publish
+      cancel-in-progress: true
+    outputs:
+      canary_version: ${{ steps.meta.outputs.canary_version }}
+      build_dir: ${{ steps.meta.outputs.build_dir }}
+      full_sha: ${{ steps.meta.outputs.full_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: canary
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Compute canary version and build dir
+        id: meta
+        run: |
+          NEXT=$(node -e "console.log(require('semver').inc(require('./package.json').version, 'patch'))")
+          TS=$(date -u +%Y%m%dT%H%M%S)
+          SHA8=$(git rev-parse --short=8 HEAD)
+          FULL_SHA=$(git rev-parse HEAD)
+          echo "canary_version=${NEXT}-canary.${TS}" >> "$GITHUB_OUTPUT"
+          echo "build_dir=releases/canary/${TS}-${SHA8}" >> "$GITHUB_OUTPUT"
+          echo "full_sha=${FULL_SHA}" >> "$GITHUB_OUTPUT"
+
+  canary-build:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build, canary-prepare]
+    concurrency:
+      group: canary-publish
+      cancel-in-progress: true
+    env:
+      VERSION: ${{ needs.canary-prepare.outputs.canary_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform-key: linux-x64
+          - os: ubuntu-24.04-arm
+            platform-key: linux-arm64
+          - os: macos-15-intel
+            platform-key: darwin-x64
+          - os: macos-latest
+            platform-key: darwin-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: canary
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Stamp package.json canary version
+        run: |
+          node -e "const fs=require('fs');const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));pkg.version=process.env.VERSION;fs.writeFileSync('package.json',JSON.stringify(pkg,null,2)+'\n');"
+
+      - name: Generate embedded sqlite-vec extension
+        run: |
+          PLATFORM_KEY="${{ matrix.platform-key }}"
+          bun run scripts/generate-vec-embed.ts "${PLATFORM_KEY%%-*}" "${PLATFORM_KEY##*-}"
+
+      - name: Build bundle
+        run: bun run scripts/build-bundle.ts
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: canary-bundle-${{ matrix.platform-key }}
+          path: |
+            prism-v*.tar.gz
+            prism-v*.tar.gz.sha256
+          if-no-files-found: error
+
+  canary-publish:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build, canary-prepare, canary-build]
+    runs-on: ubuntu-latest
+    concurrency:
+      group: canary-publish
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: canary
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Download canary bundle artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: canary-bundle-*
+          path: canary-assets
+
+      - name: Flatten bundle artifacts
+        run: |
+          mkdir -p canary-assets
+          for dir in canary-assets/canary-bundle-*/; do
+            if [ -d "$dir" ]; then
+              mv "$dir"prism-v* canary-assets/ 2>/dev/null || true
+              rmdir "$dir" 2>/dev/null || true
+            fi
+          done
+          ls -lh canary-assets/
+
+      - name: Stamp package.json canary version
+        env:
+          VERSION: ${{ needs.canary-prepare.outputs.canary_version }}
+        run: |
+          node -e "const fs=require('fs');const pkg=JSON.parse(fs.readFileSync('package.json','utf8'));pkg.version=process.env.VERSION;fs.writeFileSync('package.json',JSON.stringify(pkg,null,2)+'\n');"
+
+      - name: Build source tarball
+        env:
+          VERSION: ${{ needs.canary-prepare.outputs.canary_version }}
+        run: |
+          TARBALL_NAME="prism-v${VERSION}.tar.gz"
+          echo "Building ${TARBALL_NAME}"
+          mkdir -p /tmp/prism-release
+          tar -czf "/tmp/prism-release/${TARBALL_NAME}" \
+            --warning=no-file-changed \
+            --exclude=node_modules \
+            --exclude=dist \
+            --exclude=engine/sqlite-vec-embedded.ts \
+            --exclude=.git \
+            --exclude=*.db \
+            --exclude=*.db-journal \
+            --exclude=*.db-wal \
+            --exclude=*.db-shm \
+            --exclude=logs \
+            --exclude=.env \
+            --exclude=.env.* \
+            --exclude=bench/tmp-audit \
+            --exclude=.wrangler \
+            --exclude=cloudflare/.wrangler \
+            --exclude=.omo \
+            --exclude=.rtk \
+            --exclude=.opencode \
+            .
+          cp "/tmp/prism-release/${TARBALL_NAME}" "./${TARBALL_NAME}"
+          sha256sum "${TARBALL_NAME}" > "${TARBALL_NAME}.sha256"
+          mv "${TARBALL_NAME}" "${TARBALL_NAME}.sha256" canary-assets/
+          ls -lh canary-assets/
+
+      - name: Generate canary manifest
+        env:
+          VERSION: ${{ needs.canary-prepare.outputs.canary_version }}
+          BUILD_DIR: ${{ needs.canary-prepare.outputs.build_dir }}
+          FULL_SHA: ${{ needs.canary-prepare.outputs.full_sha }}
+        run: |
+          cd canary-assets
+          VERSION="${VERSION}" CHANNEL=canary COMMIT="${FULL_SHA}" R2_BASE_URL="https://pub-2f55c98709e74d1d900b89ec20f8f1fc.r2.dev" R2_KEY_PREFIX="${BUILD_DIR}" REQUIRE_ALL_BUNDLES=true bun run ../scripts/generate-release-manifest.ts
+          cd ..
+          BUNDLE_COUNT=$(jq '.bundles | length' canary-assets/manifest.json)
+          if [ "$BUNDLE_COUNT" -lt 4 ]; then
+            echo "::error::Manifest has only ${BUNDLE_COUNT} platform bundles; expected 4"
+            jq '.bundles | keys' canary-assets/manifest.json
+            exit 1
+          fi
+          echo "→ Manifest has ${BUNDLE_COUNT} platform bundles"
+          cat canary-assets/manifest.json
+
+      - name: Upload canary assets to R2 (before manifest)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BUILD_DIR: ${{ needs.canary-prepare.outputs.build_dir }}
+        run: |
+          for f in canary-assets/*; do
+            [ -f "$f" ] || continue
+            [ "$(basename "$f")" = "manifest.json" ] && continue
+            npx wrangler r2 object put "prism-backups/${BUILD_DIR}/$(basename "$f")" --file "$f" --remote
+          done
+
+      - name: Upload canary manifest pointer to R2 (atomic flip)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler r2 object put "prism-backups/releases/channel/canary.json" --file canary-assets/manifest.json --remote
+
+      - name: Garbage-collect old canary builds
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BUILD_DIR: ${{ needs.canary-prepare.outputs.build_dir }}
+        run: |
+          set +e
+          FAILED=0
+          # wrangler v4 has no `r2 object list`, so list via the Cloudflare R2
+          # admin API and delete each key with `wrangler r2 object delete`.
+          # Keep the 5 newest canary build dirs; never delete the just-published
+          # ${BUILD_DIR}. Emit the keys-to-delete on stdout and the dir names on
+          # stderr, then delete them below.
+          node -e '
+            const token = process.env.CLOUDFLARE_API_TOKEN;
+            const account = process.env.CLOUDFLARE_ACCOUNT_ID;
+            const bucket = "prism-backups";
+            const keep = process.env.BUILD_DIR;
+            const re = /^[0-9]{8}T[0-9]{6}-[0-9a-f]{8}$/;
+            (async () => {
+              const keys = [];
+              let cursor = "";
+              do {
+                const q = new URLSearchParams();
+                q.set("prefix", "releases/canary/");
+                if (cursor) q.set("cursor", cursor);
+                const res = await fetch(`https://api.cloudflare.com/client/v4/accounts/${account}/r2/buckets/${bucket}/objects?${q.toString()}`, {
+                  headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+                });
+                const body = await res.json();
+                if (!body || body.success !== true) {
+                  console.error("R2 object list failed: " + JSON.stringify(body && body.errors));
+                  process.exit(1);
+                }
+                const result = body.result || {};
+                for (const o of result.objects || []) keys.push(o.key);
+                cursor = result.truncated ? (result.cursor || "") : "";
+              } while (cursor);
+
+              const byDir = new Map();
+              for (const key of keys) {
+                const parts = key.split("/");
+                if (parts.length < 4 || parts[0] !== "releases" || parts[1] !== "canary") continue;
+                const dir = parts[2];
+                if (!re.test(dir)) continue;
+                if (!byDir.has(dir)) byDir.set(dir, []);
+                byDir.get(dir).push(key);
+              }
+
+              const dirs = [...byDir.keys()].sort();
+              const keepDirs = new Set(dirs.slice(Math.max(0, dirs.length - 5)));
+              keepDirs.add(keep);
+
+              for (const dir of dirs) {
+                if (keepDirs.has(dir)) continue;
+                console.error("Deleting canary build dir: " + dir);
+                for (const key of byDir.get(dir)) console.log(key);
+              }
+            })().catch((err) => { console.error("R2 GC error: " + err); process.exit(1); });
+          ' > /tmp/canary-gc-keys.txt
+          if [ $? -ne 0 ]; then
+            echo "WARNING: failed to list canary R2 objects; skipping garbage collection."
+            FAILED=1
+          fi
+
+          while IFS= read -r key; do
+            [ -n "$key" ] || continue
+            npx wrangler r2 object delete "prism-backups/${key}" --remote || FAILED=1
+          done < /tmp/canary-gc-keys.txt
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "WARNING: canary garbage collection hit errors; the published canary is unaffected."
+          fi
+          exit "$FAILED"
+
+      - name: Canary summary
+        env:
+          CANARY_VERSION: ${{ needs.canary-prepare.outputs.canary_version }}
+          FULL_SHA: ${{ needs.canary-prepare.outputs.full_sha }}
+        run: |
+          echo "Canary published: ${CANARY_VERSION} (commit ${FULL_SHA})"
+          echo "Users can install with: prism update --canary"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,10 @@ jobs:
   canary-build:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [build, canary-prepare]
+    # Per-platform group: a shared group with cancel-in-progress would make
+    # matrix siblings cancel each other, so no run would produce all 4 bundles.
     concurrency:
-      group: canary-publish
+      group: canary-publish-${{ matrix.platform-key }}
       cancel-in-progress: true
     env:
       VERSION: ${{ needs.canary-prepare.outputs.canary_version }}
@@ -209,6 +211,7 @@ jobs:
             --warning=no-file-changed \
             --exclude=node_modules \
             --exclude=dist \
+            --exclude=canary-assets \
             --exclude=engine/sqlite-vec-embedded.ts \
             --exclude=.git \
             --exclude=*.db \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,11 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    # Role-scoped group: prepare and publish must not share a group, or an
+    # older run's publish can cancel a newer run's prepare mid-flight and
+    # publish the older commit. Same-role jobs still supersede each other.
     concurrency:
-      group: canary-publish
+      group: canary-prepare
       cancel-in-progress: true
     outputs:
       canary_version: ${{ steps.meta.outputs.canary_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
             --warning=no-file-changed \
             --exclude=node_modules \
             --exclude=dist \
+            --exclude=bundles \
             --exclude=engine/sqlite-vec-embedded.ts \
             --exclude=.git \
             --exclude=*.db \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,7 +310,7 @@ Required secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`.
 4. Builds a source tarball.
 5. Generates SHA-256 checksums and optional GPG signatures.
 6. Uploads assets to Cloudflare R2 (`prism-backups/releases/v{VERSION}/`).
-7. Updates `prism-backups/releases/latest.json` and per-channel manifests (`beta`, `dev`).
+7. Updates `prism-backups/releases/latest.json` and per-channel manifests (`beta`, `dev`; the `canary` pointer is written by `ci.yml` on `main`, NOT by this workflow).
 8. Creates or updates a GitHub Release.
 
 `prism update` downloads from R2 and verifies SHA-256; it falls back to GitHub Releases if R2 is unreachable.
@@ -373,7 +373,7 @@ The `Dockerfile` builds the engine bundle with `oven/bun:canary-slim`, then copi
 | `AGENT_APPROVAL_TOKEN`        | `""`                                                               | Bearer token for `/approve` / MCP approve. Required for supervised; no fallback to proposal token.                 |
 | `AGENT_PROPOSAL_MAX_QUEUE_SIZE` | `50`                                                             | Max pending proposals in the in-memory queue.                                                                      |
 | `AUTO_UPDATE`                 | `true`                                                             | Check for releases periodically.                                                                                   |
-| `UPDATE_CHANNEL`              | `stable`                                                           | `stable`, `beta` or `dev`.                                                                                         |
+| `UPDATE_CHANNEL`              | `stable`                                                           | `stable`, `beta`, `dev` or `canary`.                                                                               |
 | `UPDATE_R2_PUBLIC_URL`        | `https://pub-2f55c98709e74d1d900b89ec20f8f1fc.r2.dev`              | Release CDN. `.env.example` contains a stale `r2.prism-agent.com` value; the code fallback is the source of truth. |
 | `PRISM_CONFIG_DIR`            | `~/.config/prism`                                                  | Override the shared credentials and config directory.                                                              |
 | `PRISM_FEEDBACK_OPT_OUT`      | `false`                                                            | Disable automatic feedback.                                                                                        |

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Use `prism update --check-only` and `prism update` for upgrades. Do not edit the
 
 `bun add --global prism` is not a supported command because this project is not published as an npm package named `prism`. A GitHub global install such as `bun add --global github:irfndi/prism-liquidity-agent#<release-tag>` is a source fallback, not the production path; it does not provide the platform bundle or the release installer's checksum guarantee.
 
+### Canary builds
+
+Every merge to `main` that passes CI publishes a canary build -- the latest code, rebuilt and uploaded to R2 automatically, like Bun's own canary channel. A canary is versioned `<next patch>-canary.<UTC timestamp>` and the `releases/channel/canary.json` pointer always tracks the newest one.
+
+```bash
+prism update --canary       # move to the latest canary build
+```
+
+Canary builds are not for production. They run exactly what is on `main` right now, with no tag, no GitHub Release, and no GPG signature -- only the SHA-256 checks the updater always performs. Use them to test an unreleased fix or feature before it ships.
+
+To go back, run plain `prism update`: the next stable release supersedes the canary version and pulls you back onto the stable channel.
+
 ### For AI Agents (OpenClaw, Hermes, acpx, custom agents)
 
 Prism is agent-friendly by design. The CLI is the operating boundary; registration is required before setup/dev so usage, errors, and feedback are tied to the agent account. Telegram remains optional.

--- a/bench/update-utils.test.ts
+++ b/bench/update-utils.test.ts
@@ -5,6 +5,7 @@ import {
   githubReleaseToInfo,
   r2ManifestToInfo,
   getPlatformKey,
+  R2_MANIFEST_PATHS,
 } from "../engine/update-utils.js";
 
 describe("update-utils", () => {
@@ -30,6 +31,14 @@ describe("update-utils", () => {
       expect(() => compareVersions("not-a-version", "1.2.3")).toThrow();
       expect(() => compareVersions("1.2.3", "not-a-version")).toThrow();
     });
+
+    it("orders canary versions by timestamp and against stable", () => {
+      expect(
+        compareVersions("0.0.32-canary.20260721T000001", "0.0.32-canary.20260720T000000"),
+      ).toBeGreaterThan(0);
+      expect(compareVersions("0.0.32-canary.20260720T000000", "0.0.31")).toBeGreaterThan(0);
+      expect(compareVersions("0.0.32", "0.0.32-canary.20260720T000000")).toBeGreaterThan(0);
+    });
   });
 
   describe("isValidVersion", () => {
@@ -46,6 +55,16 @@ describe("update-utils", () => {
       expect(isValidVersion("1.2")).toBe(false);
       expect(isValidVersion("1")).toBe(false);
       expect(isValidVersion("1.2.3.4")).toBe(false);
+    });
+
+    it("accepts canary prerelease versions", () => {
+      expect(isValidVersion("0.0.32-canary.20260720T000000")).toBe(true);
+    });
+  });
+
+  describe("R2_MANIFEST_PATHS", () => {
+    it("exposes the canary channel manifest path", () => {
+      expect(R2_MANIFEST_PATHS.canary).toBe("releases/channel/canary.json");
     });
   });
 
@@ -192,6 +211,36 @@ describe("update-utils", () => {
       expect(info.signatureUrl).toBe("");
       expect(info.channel).toBe("dev");
       expect(info.bundleUrl).toBe(bundle.url);
+    });
+
+    it("maps a canary manifest commit onto ReleaseInfo.commit", () => {
+      const manifest = {
+        version: "0.0.32-canary.20260720T000000",
+        channel: "canary" as const,
+        tarball_url: "https://r2.example.com/prism-canary.tar.gz",
+        sha256_url: "https://r2.example.com/prism-canary.tar.gz.sha256",
+        published_at: "2026-07-20T00:00:00Z",
+        min_cli_version: "1.0.0",
+        commit: "abcdef0123456789abcdef0123456789abcdef01",
+      };
+
+      const info = r2ManifestToInfo(manifest);
+      expect(info.channel).toBe("canary");
+      expect(info.commit).toBe("abcdef0123456789abcdef0123456789abcdef01");
+    });
+
+    it("yields an empty commit when the manifest omits it", () => {
+      const manifest = {
+        version: "1.0.0",
+        channel: "stable" as const,
+        tarball_url: "https://r2.example.com/prism-v1.0.0.tar.gz",
+        sha256_url: "https://r2.example.com/prism-v1.0.0.tar.gz.sha256",
+        published_at: "2024-01-01T00:00:00Z",
+        min_cli_version: "1.0.0",
+      };
+
+      const info = r2ManifestToInfo(manifest);
+      expect(info.commit).toBe("");
     });
   });
 });

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -647,8 +647,9 @@ export const updateCommand = new Command("update")
       }
 
       console.log(`Update available: ${current} → ${latest}`);
-      if (release.channel === "canary" && release.commit) {
-        console.log(`Canary build: ${release.version} (commit ${release.commit.slice(0, 8)})`);
+      if (release.channel === "canary") {
+        const commitSuffix = release.commit ? ` (commit ${release.commit.slice(0, 8)})` : "";
+        console.log(`Canary build: ${release.version}${commitSuffix}`);
       }
       console.log(`Source: ${release.source === "r2" ? "Cloudflare R2" : "GitHub Releases"}`);
       if (release.bundleUrl) {

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -600,7 +600,8 @@ async function updateFromBundle(
 export const updateCommand = new Command("update")
   .description("Check for and apply updates")
   .option("--check-only", "Only check for updates, don't apply")
-  .option("--channel <channel>", "Release channel (stable, beta, dev)", "stable")
+  .option("--channel <channel>", "Release channel (stable, beta, dev, canary)", "stable")
+  .option("--canary", "Update to the latest canary build (latest main-branch build that passed CI)")
   .option("--r2-url <url>", "R2 public URL for release bundles", R2_PUBLIC_URL)
   .option("--skip-smoke-test", "Skip post-install smoke test")
   .action(async (options) => {
@@ -611,12 +612,20 @@ export const updateCommand = new Command("update")
     try {
       const repo = "irfndi/prism-liquidity-agent";
       const channelValue = String(options.channel);
-      if (channelValue !== "stable" && channelValue !== "beta" && channelValue !== "dev") {
+      if (options.canary && channelValue !== "stable") {
+        throw new UpdateAbort("--canary cannot be combined with --channel");
+      }
+      if (
+        channelValue !== "stable" &&
+        channelValue !== "beta" &&
+        channelValue !== "dev" &&
+        channelValue !== "canary"
+      ) {
         throw new UpdateAbort(
-          `Invalid release channel '${channelValue}'. Use stable, beta, or dev.`,
+          `Invalid release channel '${channelValue}'. Use stable, beta, dev, or canary.`,
         );
       }
-      const channel = channelValue;
+      const channel = options.canary ? "canary" : channelValue;
       const r2Url = options.r2Url as string;
 
       const release = await Effect.runPromise(fetchLatestRelease(repo, channel, r2Url));
@@ -638,6 +647,9 @@ export const updateCommand = new Command("update")
       }
 
       console.log(`Update available: ${current} → ${latest}`);
+      if (release.channel === "canary" && release.commit) {
+        console.log(`Canary build: ${release.version} (commit ${release.commit.slice(0, 8)})`);
+      }
       console.log(`Source: ${release.source === "r2" ? "Cloudflare R2" : "GitHub Releases"}`);
       if (release.bundleUrl) {
         console.log(`Download: ${release.bundleUrl}`);

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -44,7 +44,7 @@ export interface AppConfig {
   // Auto-update settings
   readonly autoUpdate: boolean;
   readonly updateCheckIntervalMs: number;
-  readonly updateChannel: "stable" | "beta" | "dev";
+  readonly updateChannel: "stable" | "beta" | "dev" | "canary";
   readonly updateGithubRepo: string;
   readonly updateAllowDirty: boolean;
   // Force auto-update settings
@@ -672,7 +672,7 @@ const loadConfig = Effect.gen(function* () {
   const updateChannelRaw = yield* Config.string("UPDATE_CHANNEL").pipe(
     Effect.orElseSucceed(() => "stable"),
   );
-  const validChannels = ["stable", "beta", "dev"] as const;
+  const validChannels = ["stable", "beta", "dev", "canary"] as const;
   const updateChannel = validChannels.includes(updateChannelRaw as (typeof validChannels)[number])
     ? (updateChannelRaw as (typeof validChannels)[number])
     : "stable";

--- a/engine/update-utils.ts
+++ b/engine/update-utils.ts
@@ -33,7 +33,7 @@ export function isValidVersion(version: string): boolean {
 
 export interface ReleaseInfo {
   readonly version: string;
-  readonly channel: "stable" | "beta" | "dev";
+  readonly channel: "stable" | "beta" | "dev" | "canary";
   readonly tarballUrl: string;
   readonly sha256Url: string;
   readonly signatureUrl: string;
@@ -42,6 +42,7 @@ export interface ReleaseInfo {
   readonly source: "r2" | "github";
   readonly bundleUrl: string;
   readonly bundleSha256Url: string;
+  readonly commit: string;
 }
 
 export interface BundleManifest {
@@ -51,13 +52,14 @@ export interface BundleManifest {
 
 export interface R2Manifest {
   readonly version: string;
-  readonly channel: "stable" | "beta" | "dev";
+  readonly channel: "stable" | "beta" | "dev" | "canary";
   readonly tarball_url: string;
   readonly sha256_url: string;
   readonly signature_url?: string;
   readonly published_at: string;
   readonly min_cli_version: string;
   readonly bundles?: Record<string, BundleManifest>;
+  readonly commit?: string;
 }
 
 export interface GitHubRelease {
@@ -74,14 +76,15 @@ export interface GitHubRelease {
 
 export const R2_PUBLIC_URL = "https://pub-2f55c98709e74d1d900b89ec20f8f1fc.r2.dev";
 export const R2_RELEASES_BUCKET = "prism-backups";
-export const R2_MANIFEST_PATHS: Record<"stable" | "beta" | "dev", string> = {
+export const R2_MANIFEST_PATHS: Record<"stable" | "beta" | "dev" | "canary", string> = {
   stable: "releases/latest.json",
   beta: "releases/channel/beta.json",
   dev: "releases/channel/dev.json",
+  canary: "releases/channel/canary.json",
 };
 
 export function fetchR2Manifest(
-  channel: "stable" | "beta" | "dev",
+  channel: "stable" | "beta" | "dev" | "canary",
   r2PublicUrl: string = R2_PUBLIC_URL,
 ): Effect.Effect<R2Manifest | null, Error> {
   return Effect.gen(function* () {
@@ -118,7 +121,7 @@ export function fetchR2Manifest(
 
 export function fetchGitHubRelease(
   repo: string,
-  channel: "stable" | "beta" | "dev",
+  channel: "stable" | "beta" | "dev" | "canary",
   token?: string,
 ): Effect.Effect<GitHubRelease | null, Error> {
   return Effect.gen(function* () {
@@ -244,7 +247,7 @@ export function getPlatformKey(): string {
 
 export function githubReleaseToInfo(
   release: GitHubRelease,
-  channel: "stable" | "beta" | "dev",
+  channel: "stable" | "beta" | "dev" | "canary",
 ): ReleaseInfo {
   const platformKey = getPlatformKey();
   const tarballAsset = release.assets.find(
@@ -277,6 +280,7 @@ export function githubReleaseToInfo(
     source: "github",
     bundleUrl: bundleAsset?.browser_download_url ?? "",
     bundleSha256Url: bundleSha256Asset?.browser_download_url ?? "",
+    commit: "",
   };
 }
 
@@ -294,12 +298,13 @@ export function r2ManifestToInfo(manifest: R2Manifest): ReleaseInfo {
     source: "r2",
     bundleUrl: bundle?.url ?? "",
     bundleSha256Url: bundle?.sha256_url ?? "",
+    commit: manifest.commit ?? "",
   };
 }
 
 export function fetchLatestRelease(
   repo: string,
-  channel: "stable" | "beta" | "dev",
+  channel: "stable" | "beta" | "dev" | "canary",
   r2PublicUrl?: string,
   token?: string,
 ): Effect.Effect<ReleaseInfo | null, Error> {
@@ -313,6 +318,20 @@ export function fetchLatestRelease(
       }
     }
     const r2Error = r2Result._tag === "Left" ? r2Result.left : null;
+
+    // Canary builds are R2-only: they have no GitHub Releases representation,
+    // so falling through to the "newest release" GitHub semantics would install
+    // the wrong artifact. Fail with a clear, actionable message instead.
+    if (channel === "canary") {
+      const detail = r2Error ? `: ${r2Error.message}` : " (no valid canary manifest found)";
+      return yield* Effect.fail(
+        new Error(
+          `Canary builds are served exclusively from R2 (releases/channel/canary.json). ` +
+            `Failed to resolve a canary build${detail}. ` +
+            `Check the R2 public URL and that the canary pipeline has published a build.`,
+        ),
+      );
+    }
 
     const ghResult = yield* Effect.either(fetchGitHubRelease(repo, channel, token));
     if (ghResult._tag === "Right") {

--- a/scripts/generate-release-manifest.ts
+++ b/scripts/generate-release-manifest.ts
@@ -3,8 +3,10 @@ import path from "path";
 
 const version = process.env.VERSION ?? "";
 const channel = (process.env.CHANNEL ?? "stable") as "stable" | "beta" | "dev" | "canary";
-const r2Base = process.env.R2_BASE_URL ?? "https://pub-2f55c98709e74d1d900b89ec20f8f1fc.r2.dev";
-const keyPrefix = process.env.R2_KEY_PREFIX ?? `releases/v${version}`;
+const r2Base = (
+  process.env.R2_BASE_URL ?? "https://pub-2f55c98709e74d1d900b89ec20f8f1fc.r2.dev"
+).replace(/\/+$/, "");
+const keyPrefix = (process.env.R2_KEY_PREFIX ?? `releases/v${version}`).replace(/^\/+|\/+$/g, "");
 const commit = process.env.COMMIT;
 const outFile = process.env.OUT_FILE ?? "manifest.json";
 const requireAllBundles = (process.env.REQUIRE_ALL_BUNDLES ?? "true") === "true";

--- a/scripts/generate-release-manifest.ts
+++ b/scripts/generate-release-manifest.ts
@@ -2,8 +2,10 @@ import fs from "fs";
 import path from "path";
 
 const version = process.env.VERSION ?? "";
-const channel = (process.env.CHANNEL ?? "stable") as "stable" | "beta" | "dev";
+const channel = (process.env.CHANNEL ?? "stable") as "stable" | "beta" | "dev" | "canary";
 const r2Base = process.env.R2_BASE_URL ?? "https://pub-2f55c98709e74d1d900b89ec20f8f1fc.r2.dev";
+const keyPrefix = process.env.R2_KEY_PREFIX ?? `releases/v${version}`;
+const commit = process.env.COMMIT;
 const outFile = process.env.OUT_FILE ?? "manifest.json";
 const requireAllBundles = (process.env.REQUIRE_ALL_BUNDLES ?? "true") === "true";
 
@@ -12,7 +14,7 @@ if (!version) {
   process.exit(1);
 }
 
-if (!["stable", "beta", "dev"].includes(channel)) {
+if (!["stable", "beta", "dev", "canary"].includes(channel)) {
   console.error(`Invalid channel: ${channel}`);
   process.exit(1);
 }
@@ -35,7 +37,7 @@ for (const file of files) {
     console.warn(`Missing checksum for ${file}, skipping`);
     continue;
   }
-  const url = `${r2Base}/releases/v${version}/${file}`;
+  const url = `${r2Base}/${keyPrefix}/${file}`;
   bundles[platformKey] = { url, sha256_url: `${url}.sha256` };
 }
 
@@ -51,12 +53,13 @@ if (Object.keys(bundles).length === 0) {
   console.warn("No bundles found; manifest will have no per-platform bundles.");
 }
 
-const tarballUrl = `${r2Base}/releases/v${version}/prism-v${version}.tar.gz`;
+const tarballUrl = `${r2Base}/${keyPrefix}/prism-v${version}.tar.gz`;
 const signatureUrl = `${tarballUrl}.asc`;
 
-const manifest = {
+const manifest: Record<string, unknown> = {
   version,
   channel,
+  ...(commit ? { commit } : {}),
   tarball_url: tarballUrl,
   sha256_url: `${tarballUrl}.sha256`,
   signature_url: signatureUrl,


### PR DESCRIPTION
## Summary

Adds a **canary release channel**: every merge to `main` that passes CI publishes a canary build to R2, installable with:

```bash
prism update --canary
```

Design modeled on **Bun's canary channel** (identity = commit sha + UTC timestamp, published per main commit), adapted to Prism's manifest-driven R2 transport instead of Bun's single-rolling-GitHub-release + binary-hash-comparison — which would require downloading a ~50MB bundle just to learn there's nothing new.

**Pipeline** (`ci.yml`, only on `push` to `main`, after the existing `build` job is green):

```
build (lint+build+test, existing)
 └─ canary-prepare   → computes version + build dir
     └─ canary-build → 4-platform matrix (linux/darwin × x64/arm64)
         └─ canary-publish → upload bundles → flip manifest pointer LAST → GC
```

**Versioning** — pure semver, zero changes to the existing comparison logic:

- Canary version = `<next patch>-canary.<YYYYMMDDTHHMMSS UTC>` (e.g. `0.1.1-canary.20260720T130412`), stamped into `package.json` before the bundle build so `getCurrentVersion()` reports it.
- Strictly greater than the stable it branches from → `prism update --canary` from stable works; fixed-width timestamp → later canary > earlier canary.
- `0.1.1 > 0.1.1-canary.*` (semver prerelease ordering) → canary users **auto-graduate to stable** at the next release via plain `prism update`.

**R2 layout** (canary fully isolated from the stable namespace):

```
prism-backups/releases/
├── latest.json, channel/{beta,dev}.json    (untouched)
├── channel/canary.json                     (single pointer, uploaded LAST = atomic flip)
└── canary/<ts>-<sha8>/                     (per-build dir, GC'd)
    └── prism-v<version>-<platform>.tar.gz{,.sha256} + source tarball
```

The canary manifest carries a `commit` field; `prism update --canary` prints `Canary build: <version> (commit <sha8>)`.

**R2 storage lifecycle**:
1. **Count-based GC (primary)** — after every publish, keeps the **5 newest** build dirs under `releases/canary/`, deletes the rest. Guards: dir names must match `^\d{8}T\d{6}-[0-9a-f]{8}$`; the just-published dir is never deleted; `continue-on-error` so a cleanup hiccup never fails a published build; self-heals on the next publish.
2. **Age-based lifecycle rule (optional safety net)** — see Follow-ups.

**Cost ceiling**: 5 builds × 4 platforms ≈ ~1.5GB ≈ <$0.03/month, bounded forever.

**Design decisions**:
- **Canary is R2-only** — no GitHub Release, no tag, no GPG. `fetchLatestRelease` fails with a clear message instead of falling through to the GitHub "newest release" semantics (which would install the wrong artifact).
- **wrangler v4 has no `r2 object list`** (verified: `r2 object` = get/put/delete only in wrangler 4.112.0, what `npx wrangler` resolves to in CI). GC lists via the Cloudflare R2 admin API (`GET /r2/buckets/{bucket}/objects`, paginated) and deletes via `wrangler r2 object delete`. Documented inline.
- **No wasted CI**: canary jobs reuse the existing `build` gate (`needs: build`) and share a `canary-publish` concurrency group (cancel-in-progress) so rapid merges don't race. Never runs on PRs or `workflow_dispatch` → R2 write secrets never touch fork PRs.
- **Checksum contract preserved**: every canary bundle ships its SHA-256 sidecar; the updater still refuses to install without a valid checksum.

**Changes**:

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | +303: `canary-prepare` → `canary-build` (4-platform matrix) → `canary-publish` (upload, atomic manifest flip, GC, summary) |
| `scripts/generate-release-manifest.ts` | canary channel, `R2_KEY_PREFIX` env (default preserves existing `releases/v<version>/` paths byte-identically), optional `commit` field |
| `engine/update-utils.ts` | `canary` in all channel unions, `R2_MANIFEST_PATHS.canary`, `commit` on `R2Manifest`/`ReleaseInfo`, R2-only fallback guard |
| `engine/config-service.ts` | `UPDATE_CHANNEL=canary` accepted (engine auto-check path) |
| `cli/update.ts` | `--canary` flag (mutually exclusive with a non-default `--channel`), canary channel validation, target-commit printout |
| `bench/update-utils.test.ts` | canary manifest path, version ordering (incl. stable graduation), `isValidVersion`, commit mapping |
| `README.md`, `AGENTS.md` | "Canary builds" section; `UPDATE_CHANNEL` docs |

## Testing

- [ ] Not run
- [x] `bun run build`
- [x] `bun run test`

Locally, fully green:
- `bun run lint` (tsc --noEmit + oxlint) → exit 0
- `bun run test` → 83 files, **980/980 passed**
- `bun run build` → exit 0
- `bun run format:check` → clean
- Manifest generator verified locally in both canary and default (stable) configs: canary emits `channel: canary` + `commit` + `releases/canary/<ts>-<sha8>/` URLs; stable output is byte-identical to before.

The canary pipeline itself gets its first live run on the merge of this PR (or any `main` push after it).

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Additive only: existing `build` job, `release.yml`, and stable/beta/dev manifest generation are untouched on any code path (generator defaults are byte-identical; canary jobs are gated to `push` on `main` and chain `needs: build`).

## Follow-ups

- **Optional R2 lifecycle safety net** (age-based, complements the count-based GC). Not encoded in CI because `wrangler r2 bucket lifecycle policy update` **replaces the entire bucket policy** and `prism-backups` is shared with DB backups — merge with any existing rules:
  ```bash
  npx wrangler r2 bucket lifecycle policy get prism-backups --remote   # inspect first
  # add/merge: { "id": "canary-expiry", "prefix": "releases/canary/", "enabled": true, "expiration": { "days": 30 } }
  npx wrangler r2 bucket lifecycle policy update prism-backups --rules '<merged JSON>' --remote
  ```
- After the first canary publishes: smoke-test `prism update --canary` on a throwaway install, then `prism update` to return to stable.
- GC requires the existing `CLOUDFLARE_API_TOKEN` to include R2 Storage list permission (R2 Storage:Edit — the level `release.yml` already needs for put/delete — includes it).
