### PR TITLE
fix(ci): retry alchemy deploy on transient Cloudflare API errors

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -64,9 +64,23 @@ jobs:
       # alchemy CLI + its Effect-4 runtime resolve). Config.redacted worker
       # secrets resolve from these env vars at deploy time and are uploaded to
       # Cloudflare as `secret_text`.
+      # Alchemy's deploy is idempotent (adopt-by-read + reconcile), so bounded
+      # retries are safe and absorb transient Cloudflare API failures
+      # (observed in production: 504 gateway timeouts with retry_after=120s).
       - name: Deploy via Alchemy
         if: github.ref == 'refs/heads/main'
-        run: bun run deploy
+        run: |
+          for attempt in 1 2 3; do
+            if bun run deploy; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Deploy attempt $attempt failed — retrying in 130s (Cloudflare API backoff)..."
+              sleep 130
+            fi
+          done
+          echo "::error::Deploy failed after 3 attempts"
+          exit 1
         env:
           # Cloudflare provider credentials (Alchemy auth + remote state store).
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -281,6 +281,7 @@ The GitHub Actions workflow at `.github/workflows/deploy-cloudflare.yml` runs on
 1. Installs dependencies with Bun at `cloudflare/` (the workspace install covers the `infra/` package)
 2. Runs the type check (`bun run typecheck`), which covers both the workers' `tsc` and the `infra` package's `tsc`
 3. **On PRs, stops there.** The deploy runs only on merge to `main`: `bun run deploy`, which delegates to `infra/` and runs `alchemy deploy --stage prod --yes`
+4. Deploys retry up to **3 attempts** (~130s apart) on transient Cloudflare API errors (observed: 504s with `retry_after=120s`). Alchemy deploys are idempotent (adopt-by-read + reconcile), so retries are safe.
 
 **There are no PR preview deploys, by design.** Every stage would share the single production D1 / KV / R2 / Vectorize, so a per-PR stage destroyed on PR close could drop production data. One production stack, stage `prod`.
 


### PR DESCRIPTION
The first alchemy deploy from `main` (#127) hit a Cloudflare-side **504 gateway timeout** flagged `retryable: true, retry_after: 120`. Alchemy deploys are idempotent (adopt-by-read + reconcile), so the deploy step now retries up to 3 times ~130s apart. README CI/CD section documents the behavior. The cloudflare/README touch also triggers this workflow on merge, exercising the loop.

## Summary by Sourcery

Add bounded retries to the Cloudflare deploy GitHub Action to handle transient API failures and document the behavior in the Cloudflare CI/CD README.

CI:
- Update the Cloudflare deploy GitHub Action to retry the Alchemy deploy step up to three times with backoff on failure.

Documentation:
- Document the deploy retry behavior and rationale in the Cloudflare CI/CD README section.