### PR TITLE
fix(infra): adopt wrangler-created workers on alchemy deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -60,9 +60,12 @@ jobs:
 
       # Production deploy (main only). `bun run deploy` at the workspace root
       # delegates to `bun run --cwd infra deploy`, i.e. the pinned
-      # `alchemy deploy --stage prod --yes` run from `cloudflare/infra` (where the
-      # alchemy CLI + its Effect-4 runtime resolve). Config.redacted worker
-      # secrets resolve from these env vars at deploy time and are uploaded to
+      # `alchemy deploy --stage prod --adopt --yes` run from `cloudflare/infra`
+      # (where the alchemy CLI + its Effect-4 runtime resolve). `--adopt` takes
+      # over the wrangler-created workers (workers carry ownership tags, so
+      # unlike the data resources they are not silently adopted); it is a no-op
+      # for resources this stack already owns. Config.redacted worker secrets
+      # resolve from these env vars at deploy time and are uploaded to
       # Cloudflare as `secret_text`.
       # Alchemy's deploy is idempotent (adopt-by-read + reconcile), so bounded
       # retries are safe and absorb transient Cloudflare API failures

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -73,7 +73,7 @@ The stack does NOT create new resources. On a first deploy (empty Alchemy state)
 | `BACKUPS` | R2       | `prism-backups`|                                             |
 | `MEMORY`  | Vectorize| `prism-memory` | 384 dimensions, cosine                      |
 
-Physical identity comes from these names, so the `prod` stage never renames anything; the stage only scopes the Alchemy state keyspace.
+Physical identity comes from these names, so the `prod` stage never renames anything; the stage only scopes the Alchemy state keyspace. Data resources adopt implicitly. The two WORKERS adopt explicitly: workers carry ownership tags, and these were created by wrangler (unowned), so the deploy scripts run with `--adopt` — a one-time takeover that tags them for this stack, and a no-op on every later deploy for resources the stack already owns.
 
 ### Guardrails
 

--- a/cloudflare/infra/package.json
+++ b/cloudflare/infra/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "alchemy dev",
-    "deploy": "alchemy deploy --stage prod --yes",
-    "plan": "alchemy deploy --stage prod --dry-run",
+    "deploy": "alchemy deploy --stage prod --adopt --yes",
+    "plan": "alchemy deploy --stage prod --adopt --dry-run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
The first real alchemy deploy fails with `OwnedBySomeoneElse` on the two **workers** (after the API token scope fix cleared the auth errors):

```
ERROR (#3): OwnedBySomeoneElse: Cannot adopt resource 'api' (Cloudflare.Worker): it exists in the cloud but is not owned by this stack/stage/logical-id.
```

The data resources adopt implicitly (their providers have no ownership concept), but Workers **do** have ownership semantics (tags). `prism-api` / `prism-telegram-bot` were created by wrangler — present but unowned — so alchemy requires an explicit takeover.

Fix: `--adopt` on the deploy (and plan) scripts. It imports unowned resources into this stack's state (tagging them) and is a **no-op for resources the stack already owns**, so it stays in the scripts permanently — safe because every resource here is this project's own. Documented in the workflow comment + README. Merge triggers the deploy again (README change touches `cloudflare/**`).

## Summary by Sourcery

Adopt pre-existing Cloudflare workers into the Alchemy stack during production deploys to avoid ownership conflicts

Deployment:
- Add --adopt to Cloudflare deploy and plan scripts so wrangler-created workers are imported into the stack state

Documentation:
- Document explicit worker adoption behaviour and rationale in the Cloudflare README and deployment workflow comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how production deployments adopt existing resources and handle worker ownership.
  * Documented resource scoping, implicit data adoption, and explicit worker adoption.
  * Explained how worker secrets are resolved and uploaded during deployment.

* **Chores**
  * Updated deployment and planning commands to support adopting existing resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->