### PR TITLE
fix(workers): atomic telegram link + surface API errors in bot replies

### DIFF
--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -584,28 +584,37 @@ app.post("/v1/link-telegram/confirm", async (c) => {
       return c.json({ error: "Code expired" }, 400);
     }
 
-    const updateResult = yield* Effect.tryPromise(() =>
-      DB.prepare(
-        `UPDATE telegram_link_codes
-         SET used_at = CURRENT_TIMESTAMP
-         WHERE code = ? AND used_at IS NULL`,
-      )
-        .bind(body.code)
-        .run(),
-    );
-
-    if (!updateResult.success || updateResult.meta.changes === 0) {
-      return c.json({ error: "Code already used" }, 400);
-    }
-
     const userId = typeof codeRow.user_id === "string" ? codeRow.user_id : null;
     if (!userId) return c.json({ error: "Linking failed" }, 500);
 
-    yield* Effect.tryPromise(() =>
-      DB.prepare("UPDATE users SET telegram_id = ? WHERE id = ?")
-        .bind(body.telegram_id, userId)
-        .run(),
+    // Atomic link: claim the code AND bind the telegram_id in ONE D1 batch
+    // (a single transaction). Claim-then-link used to be separate statements;
+    // a transient D1 failure between them burnt the code without linking the
+    // account, stranding the user with a dead code (observed in production:
+    // the bot's second confirm hit 500 mid-link and the code was unusable).
+    // In one batch, a failure rolls BOTH statements back and the code stays
+    // usable; a lost claim race (concurrent confirm) surfaces as "already used".
+    const linkBatch = yield* Effect.tryPromise(() =>
+      DB.batch([
+        DB.prepare(
+          `UPDATE telegram_link_codes
+           SET used_at = CURRENT_TIMESTAMP
+           WHERE code = ? AND used_at IS NULL`,
+        ).bind(body.code),
+        DB.prepare("UPDATE users SET telegram_id = ? WHERE id = ?").bind(
+          body.telegram_id,
+          userId,
+        ),
+      ]),
     );
+    const [claimResult, linkResult] = linkBatch;
+    if (!claimResult?.success || claimResult.meta.changes === 0) {
+      return c.json({ error: "Code already used" }, 400);
+    }
+    if (!linkResult?.success || linkResult.meta.changes === 0) {
+      return c.json({ error: "Linking failed" }, 500);
+    }
+
     yield* logAudit(DB, userId, "telegram_link", { telegram_id: body.telegram_id });
 
     return c.json({ success: true, user_id: userId });

--- a/cloudflare/workers/api/link-telegram.test.ts
+++ b/cloudflare/workers/api/link-telegram.test.ts
@@ -188,6 +188,53 @@ describe("Telegram linking security", () => {
       expect(body.error).toMatch(/invalid code/i);
     });
 
+    it("does not burn the code when the link write fails (atomic batch)", async () => {
+      await insertUser("user-1");
+      // user-2 already owns the target telegram_id, so the users UPDATE hits
+      // the UNIQUE constraint and the batch fails. Because claim + link run
+      // in ONE transaction, the claim rolls back too — the code must survive
+      // the failure and confirm successfully once the conflict is cleared.
+      await env.DB.prepare("INSERT INTO users (id, telegram_id) VALUES (?, ?)")
+        .bind("user-2", "555000001")
+        .run();
+      await insertCode("LINK-ATOMIC1", "user-1", nowEpoch() + 600);
+
+      const failed = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/confirm", {
+          code: "LINK-ATOMIC1",
+          telegram_id: "555000001",
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(failed.status).toBe(500);
+
+      const notBurnt = await env.DB.prepare(
+        "SELECT used_at FROM telegram_link_codes WHERE code = ?",
+      )
+        .bind("LINK-ATOMIC1")
+        .first();
+      expect(notBurnt?.used_at).toBeNull();
+
+      await env.DB.prepare("DELETE FROM users WHERE id = ?").bind("user-2").run();
+      const retry = await worker.fetch(
+        buildRequest("POST", "/v1/link-telegram/confirm", {
+          code: "LINK-ATOMIC1",
+          telegram_id: "555000001",
+        }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(retry.status).toBe(200);
+      const body = (await retry.json()) as { success: boolean; user_id: string };
+      expect(body.success).toBe(true);
+      expect(body.user_id).toBe("user-1");
+      const linked = await env.DB.prepare("SELECT telegram_id FROM users WHERE id = ?")
+        .bind("user-1")
+        .first();
+      expect(linked?.telegram_id).toBe("555000001");
+    });
+
     it("burns a code after 5 attempts (6th attempt rejected)", async () => {
       await insertUser("user-1");
       await insertCode("LINK-BURN01", "user-1", nowEpoch() + 600);

--- a/cloudflare/workers/telegram-bot/index.ts
+++ b/cloudflare/workers/telegram-bot/index.ts
@@ -142,9 +142,24 @@ function callPrismApi(
       }),
     );
     if (!response.ok) {
+      // Prefer the API's own error message ("Code expired", "Too many
+      // attempts") over the bare status line ("404 Not Found" / "500
+      // Internal Server Error"), which tells the user nothing actionable.
+      const statusText = `${response.status} ${response.statusText}`;
+      const apiError = yield* Effect.tryPromise(() => response.text()).pipe(
+        Effect.map((text) => {
+          try {
+            const parsed = JSON.parse(text) as { error?: unknown };
+            return typeof parsed.error === "string" ? parsed.error : null;
+          } catch {
+            return null;
+          }
+        }),
+        Effect.orElseSucceed(() => null),
+      );
       return {
         ok: false,
-        error: `Prism API error: ${response.status} ${response.statusText}`,
+        error: `Prism API error: ${apiError ?? statusText}`,
       };
     }
     const data = yield* Effect.tryPromise(() => response.json()).pipe(

--- a/cloudflare/workers/telegram-bot/telegram-bot.test.ts
+++ b/cloudflare/workers/telegram-bot/telegram-bot.test.ts
@@ -306,6 +306,23 @@ describe("Telegram Bot Worker", () => {
       expect(headers.get("X-Bot-Api-Secret")).toBe(BOT_API_SECRET);
     });
 
+    it("surfaces the API error message to the user on confirm failure", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          new Response(JSON.stringify({ error: "Code expired" }), { status: 400 }),
+        );
+
+      const { url, ...init } = postWebhook(privateMessage(205, "LINK-EXPIRED1"));
+      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      expect(response.status).toBe(200);
+
+      // The bot's reply (last fetch call = Telegram sendMessage) must carry the
+      // API's own error, not a bare "400 Bad Request" status line.
+      const lastCall = fetchSpy.mock.calls.at(-1) as [string, RequestInit];
+      expect(String(lastCall[1].body)).toContain("Link failed: Prism API error: Code expired");
+    });
+
     it("should ignore non-link-code text messages", async () => {
       const fetchSpy = vi
         .spyOn(globalThis, "fetch")


### PR DESCRIPTION
**Forensics of the user's failed link** (D1 rows + live probes + full E2E repro):
1. First confirm attempt got a plain **404 at the edge** — the handler never ran (attempts counter untouched). Transient Cloudflare routing failure on the API host.
2. The retry (still inside the 10-minute window) reached the handler, committed `used_at`, then the `UPDATE users SET telegram_id` **failed mid-link on a transient D1 fault** → 500. Old code ran those as separate statements, so the code was burnt with no link → the user stranded with a dead code and an unlinked account (confirmed: `users.telegram_id` is still NULL).
3. Fresh E2E repro against the live workers (register → start → confirm): **`{"success":true}` 200** — the flow itself is sound; the failure was transient CF instability exploiting a non-atomic window.

**Fixes (this PR):**
- **Atomic link** — claim + bind now run in ONE D1 batch (single transaction). Failed link → claim rolls back → code stays usable (proven by a new test: force a UNIQUE failure on the users UPDATE → 500 → retry the SAME code after clearing the conflict → 200). Lost claim race → 'Code already used'.
- **Bot error surfacing** — the bot now shows the API's JSON error ('Code expired' / 'Too many attempts') instead of a bare '404 Not Found' / '500 Internal Server Error' status line. Pinned by a new test.

**Verification:** CF suite **196/196** (194 + 2 new), tsc clean across both workspace packages. Deploy is triggered by merge (cloudflare/** change).

## Summary by Sourcery

Make Telegram account linking atomic and improve Telegram bot error messaging for link failures.

Bug Fixes:
- Ensure Telegram link confirmation updates the link code and user record atomically so transient database errors do not burn a code without linking the account.
- Return clearer errors from the API when Telegram link confirmation fails due to already-used codes or failed user updates.
- Have the Telegram bot surface the Prism API's JSON error message (e.g. code expiration) instead of only the HTTP status line on confirm failures.

Tests:
- Add an integration test confirming that a failed atomic link batch does not burn the link code and allows a successful retry after clearing the conflict.
- Add a bot worker test verifying that API error messages are relayed to the user in Telegram replies on link confirmation failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram account linking so failed attempts no longer invalidate a link code.
  * Prevented linking when a Telegram account is already associated with another account, while preserving the code for retry.
  * Telegram linking errors now display clearer, service-provided messages, such as “Code expired,” instead of generic status details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->