### PR TITLE
fix(bot): route bot→API calls over CF service bindings (error 1042)

### DIFF
--- a/cloudflare/infra/alchemy.run.ts
+++ b/cloudflare/infra/alchemy.run.ts
@@ -154,6 +154,10 @@ export const telegramBot = Cloudflare.Worker("telegramBot", {
     CACHE: cache,
     // Plain var: the workers.dev HTTPS URL the bot calls (NOT a service binding).
     API_BASE_URL: "https://prism-api.irfndi.workers.dev",
+    // Service binding to the API worker. Cloudflare rejects worker->worker
+    // fetches over the same-zone workers.dev hostname (error 1042); the
+    // binding is the sanctioned transport. `api` is declared above, so no TDZ.
+    API_SERVICE: api,
     // Secrets.
     TELEGRAM_BOT_TOKEN: Config.redacted("TELEGRAM_BOT_TOKEN"),
     TELEGRAM_WEBHOOK_SECRET: Config.redacted("TELEGRAM_WEBHOOK_SECRET"),

--- a/cloudflare/worker-configuration.d.ts
+++ b/cloudflare/worker-configuration.d.ts
@@ -10,6 +10,7 @@ declare namespace Cloudflare {
     ENVIRONMENT: string;
     TELEGRAM_WEBHOOK_URL: string;
     API_BASE_URL: string;
+    API_SERVICE?: Fetcher;
     FEE_WALLET_ADDRESS?: string;
     TELEGRAM_BOT_TOKEN?: string;
     TELEGRAM_WEBHOOK_SECRET?: string;

--- a/cloudflare/workers/telegram-bot/index.ts
+++ b/cloudflare/workers/telegram-bot/index.ts
@@ -8,6 +8,11 @@ interface Env {
   TELEGRAM_BOT_TOKEN: string;
   TELEGRAM_WEBHOOK_SECRET?: string;
   API_BASE_URL: string;
+  // Service binding to the API worker (preferred path for bot->API calls).
+  // Cloudflare forbids worker->worker fetches over the same-zone
+  // workers.dev hostname (error 1042); the binding is the sanctioned
+  // transport. Absent in local dev/older deploys -> hostname fallback.
+  API_SERVICE?: Fetcher;
   // Shared secret presented as X-Bot-Api-Secret on bot->API calls. The API
   // rejects telegram_id-keyed endpoints without it (fail closed).
   BOT_API_SECRET?: string;
@@ -129,17 +134,25 @@ function callPrismApi(
   path: string,
   body: Record<string, unknown>,
   botApiSecret?: string,
+  fetcher?: Fetcher,
 ): Effect.Effect<{ ok: boolean; data?: unknown; error?: string }, never> {
   return Effect.gen(function* () {
+    const init = {
+      method: "POST" as const,
+      headers: {
+        "Content-Type": "application/json",
+        ...(botApiSecret ? { "X-Bot-Api-Secret": botApiSecret } : {}),
+      },
+      body: JSON.stringify(body),
+    };
+    // The service binding is the only worker->worker transport Cloudflare
+    // allows: same-zone workers.dev hostname fetches are rejected with
+    // error 1042 (proven live via the bot's own subrequest). The hostname
+    // fallback exists only for local dev / deploys that predate the binding.
     const response = yield* Effect.tryPromise(() =>
-      fetch(`${baseUrl}${path}`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(botApiSecret ? { "X-Bot-Api-Secret": botApiSecret } : {}),
-        },
-        body: JSON.stringify(body),
-      }),
+      fetcher
+        ? fetcher.fetch(new Request(`${baseUrl}${path}`, init))
+        : fetch(`${baseUrl}${path}`, init),
     );
     if (!response.ok) {
       // Prefer the API's own error message ("Code expired", "Too many
@@ -214,6 +227,7 @@ function handleRegister(
   telegramId: string,
   firstName: string,
   botApiSecret?: string,
+  fetcher?: Fetcher,
 ): Effect.Effect<void, never> {
   return Effect.gen(function* () {
     const result = yield* callPrismApi(
@@ -224,6 +238,7 @@ function handleRegister(
         first_name: firstName,
       },
       botApiSecret,
+      fetcher,
     );
 
     if (result.ok && result.data) {
@@ -270,6 +285,7 @@ function handleWhoami(
   chatId: number,
   telegramId: string,
   botApiSecret?: string,
+  fetcher?: Fetcher,
 ): Effect.Effect<void, never> {
   return Effect.gen(function* () {
     const result = yield* callPrismApi(
@@ -279,6 +295,7 @@ function handleWhoami(
         telegram_id: telegramId,
       },
       botApiSecret,
+      fetcher,
     );
 
     if (result.ok && result.data) {
@@ -300,6 +317,7 @@ function handleStatus(
   chatId: number,
   telegramId: string,
   botApiSecret?: string,
+  fetcher?: Fetcher,
 ): Effect.Effect<void, never> {
   return Effect.gen(function* () {
     const result = yield* callPrismApi(
@@ -309,6 +327,7 @@ function handleStatus(
         telegram_id: telegramId,
       },
       botApiSecret,
+      fetcher,
     );
 
     if (result.ok && result.data) {
@@ -335,6 +354,7 @@ function handleAlerts(
   telegramId: string,
   args: string,
   botApiSecret?: string,
+  fetcher?: Fetcher,
 ): Effect.Effect<void, never> {
   return Effect.gen(function* () {
     const arg = args.trim().toLowerCase();
@@ -353,6 +373,7 @@ function handleAlerts(
       "/v1/alerts/preferences",
       { telegram_id: telegramId, enabled },
       botApiSecret,
+      fetcher,
     );
     if (result.ok) {
       yield* sendMessage(
@@ -420,6 +441,7 @@ function processUpdate(
             telegramId,
             firstName,
             env.BOT_API_SECRET,
+            env.API_SERVICE,
           );
           break;
         case "/link":
@@ -435,6 +457,7 @@ function processUpdate(
             chatId,
             telegramId,
             env.BOT_API_SECRET,
+            env.API_SERVICE,
           );
           break;
         case "/status":
@@ -444,6 +467,7 @@ function processUpdate(
             chatId,
             telegramId,
             env.BOT_API_SECRET,
+            env.API_SERVICE,
           );
           break;
         case "/alerts":
@@ -454,6 +478,7 @@ function processUpdate(
             telegramId,
             text.slice(rawCommand.length),
             env.BOT_API_SECRET,
+            env.API_SERVICE,
           );
           break;
         default:
@@ -483,6 +508,7 @@ function processUpdate(
           telegram_id: telegramId,
         },
         env.BOT_API_SECRET,
+        env.API_SERVICE,
       );
 
       if (result.ok) {

--- a/cloudflare/workers/telegram-bot/telegram-bot.test.ts
+++ b/cloudflare/workers/telegram-bot/telegram-bot.test.ts
@@ -63,7 +63,10 @@ function groupMessage(updateId: number, text: string) {
 }
 
 /** Extracts the JSON body of the nth mocked fetch call. */
-function sentJson(fetchSpy: ReturnType<typeof vi.spyOn>, callIndex: number): Record<string, unknown> {
+function sentJson(
+  fetchSpy: ReturnType<typeof vi.spyOn>,
+  callIndex: number,
+): Record<string, unknown> {
   const init = fetchSpy.mock.calls[callIndex]?.[1] as { body?: string } | undefined;
   return JSON.parse(init?.body ?? "{}") as Record<string, unknown>;
 }
@@ -92,19 +95,31 @@ describe("Telegram Bot Worker", () => {
   describe("Webhook Security", () => {
     it("should reject webhook without secret token when configured", async () => {
       const { url, ...init } = postWebhook({ update_id: 1 }, { omitSecretHeader: true });
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(401);
     });
 
     it("should reject webhook with a wrong secret token", async () => {
       const { url, ...init } = postWebhook({ update_id: 1 }, { secret: "not-the-secret" });
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(401);
     });
 
     it("should accept webhook with valid secret token", async () => {
       const { url, ...init } = postWebhook({ update_id: 1 });
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
     });
 
@@ -124,7 +139,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(privateMessage(1, "/start"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
 
       // Verify Telegram API was called
@@ -140,7 +159,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(privateMessage(2, "/help"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -151,7 +174,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(privateMessage(3, "/link"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -162,7 +189,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(privateMessage(4, "/unknown"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -173,7 +204,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(groupMessage(100, "/start@prism_agent_bot"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       const sentBody = fetchSpy.mock.calls[0]?.[1] as { body?: string } | undefined;
       expect(sentBody?.body).toContain("Welcome to Prism");
@@ -185,7 +220,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(privateMessage(5, "/start", "<b>Evil</b>"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       const sent = sentJson(fetchSpy, 0);
       expect(sent.text).toContain("&lt;b&gt;Evil&lt;/b&gt;");
@@ -203,7 +242,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(groupMessage(updateId, text));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
 
       // Exactly one call: the refusal message to Telegram. No Prism API call.
@@ -246,7 +289,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(privateMessage(200, "LINK-ABC123"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
       const parsed = sentJson(fetchSpy, 0) as { code?: string };
@@ -259,7 +306,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(privateMessage(201, "abc123"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       const parsed = sentJson(fetchSpy, 0) as { code?: string };
       // The server stores codes with LINK- prefix; a bare 6-char must be
@@ -273,7 +324,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(privateMessage(202, "LINK-A1B2C3D4E5F60718"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       const parsed = sentJson(fetchSpy, 0) as { code?: string };
       expect(parsed.code).toBe("LINK-A1B2C3D4E5F60718");
@@ -285,7 +340,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(privateMessage(203, "ABC123"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -296,7 +355,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook(privateMessage(204, "LINK-ABC123"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
 
       // First fetch call goes to the Prism API and must carry the shared secret.
@@ -314,7 +377,11 @@ describe("Telegram Bot Worker", () => {
         );
 
       const { url, ...init } = postWebhook(privateMessage(205, "LINK-EXPIRED1"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
 
       // The bot's reply (last fetch call = Telegram sendMessage) must carry the
@@ -323,15 +390,55 @@ describe("Telegram Bot Worker", () => {
       expect(String(lastCall[1].body)).toContain("Link failed: Prism API error: Code expired");
     });
 
+    it("routes the confirm call over the API_SERVICE binding when present", async () => {
+      // Cloudflare rejects same-zone workers.dev worker->worker fetches
+      // (error 1042); the service binding is the sanctioned transport. When
+      // API_SERVICE is present, callPrismApi must call fetcher.fetch() and
+      // never the global fetch for the API call. A partial mock stands in for
+      // the binding (the full Fetcher interface is not needed at runtime).
+      const bindingFetch = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+      const boundEnv = {
+        ...testEnv,
+        API_SERVICE: { fetch: bindingFetch } as unknown as Fetcher,
+      } as unknown as typeof env;
+
+      const globalFetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+      const { url, ...init } = postWebhook(privateMessage(300, "LINK-ABC123"));
+      const response = await worker.fetch(
+        new Request(url, init),
+        boundEnv,
+        createExecutionContext(),
+      );
+      expect(response.status).toBe(200);
+
+      // The API call went through the binding, carrying the prefixed code.
+      expect(bindingFetch).toHaveBeenCalledTimes(1);
+      const boundRequest = bindingFetch.mock.calls[0]?.[0] as Request;
+      expect(boundRequest.url).toContain("/v1/link-telegram/confirm");
+
+      // Global fetch is used ONLY for the Telegram reply, never the API call.
+      expect(globalFetchSpy).toHaveBeenCalled();
+      for (const call of globalFetchSpy.mock.calls) {
+        expect(String(call[0])).toContain("api.telegram.org");
+      }
+    });
+
     it("should ignore non-link-code text messages", async () => {
       const fetchSpy = vi
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-      const { url, ...init } = postWebhook(
-        privateMessage(6, "Hello, this is a regular message"),
+      const { url, ...init } = postWebhook(privateMessage(6, "Hello, this is a regular message"));
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
       );
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
       expect(response.status).toBe(200);
       // Should not call Telegram API for non-command, non-code messages
       expect(fetchSpy).not.toHaveBeenCalled();
@@ -350,7 +457,11 @@ describe("Telegram Bot Worker", () => {
         );
 
       const { url, ...init } = postWebhook(privateMessage(7, "/register"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       // Should call both Prism API and Telegram API
       expect(fetchSpy).toHaveBeenCalled();
@@ -364,7 +475,11 @@ describe("Telegram Bot Worker", () => {
       );
 
       const { url, ...init } = postWebhook(privateMessage(8, "/register"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -379,7 +494,11 @@ describe("Telegram Bot Worker", () => {
       );
 
       const { url, ...init } = postWebhook(privateMessage(9, "/whoami"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -392,7 +511,11 @@ describe("Telegram Bot Worker", () => {
         );
 
       const { url, ...init } = postWebhook(privateMessage(10, "/whoami"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -411,7 +534,11 @@ describe("Telegram Bot Worker", () => {
       );
 
       const { url, ...init } = postWebhook(privateMessage(11, "/status"));
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).toHaveBeenCalled();
     });
@@ -424,7 +551,11 @@ describe("Telegram Bot Worker", () => {
         .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
       const { url, ...init } = postWebhook({ update_id: 12 });
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).not.toHaveBeenCalled();
     });
@@ -446,7 +577,11 @@ describe("Telegram Bot Worker", () => {
       };
 
       const { url, ...init } = postWebhook(update);
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
       expect(fetchSpy).not.toHaveBeenCalled();
     });
@@ -459,7 +594,11 @@ describe("Telegram Bot Worker", () => {
 
       const { url, ...init } = postWebhook(privateMessage(14, "/start"));
       // Webhook MUST return 200; Telegram retries on >=400 which would cause a retry storm
-      const response = await worker.fetch(new Request(url, init), testEnv, createExecutionContext());
+      const response = await worker.fetch(
+        new Request(url, init),
+        testEnv,
+        createExecutionContext(),
+      );
       expect(response.status).toBe(200);
     });
   });


### PR DESCRIPTION
Root cause: Cloudflare rejects worker->worker fetches over the same-zone
workers.dev hostname. Diagnosed live: the bot's LINK-confirm subrequests to
https://prism-api.irfndi.workers.dev returned {status:404, body:"error code: 1042"},
so every bot->API call (register, whoami, status, alerts, link-confirm) silently
failed and the user saw a bare status-line error.

Fix: give the bot a service binding to the API worker and route all bot->API
calls over it, with a hostname fallback for local dev / deploys that predate
the binding.
- callPrismApi gained a 5th param fetcher?: Fetcher — uses fetcher.fetch() when
  present, global fetch (hostname) otherwise.
- fetcher is threaded through handleRegister, handleWhoami, handleStatus and the
  /alerts preferences handler; the command dispatcher passes env.API_SERVICE at
  every call site (link-confirm already did).
- worker-configuration.d.ts: API_SERVICE?: Fetcher on Cloudflare.Env.
- infra/alchemy.run.ts: API_SERVICE: api on telegramBot's env. The raw Worker
  resource is alchemy's sanctioned pattern — WorkerBindingResource includes
  Worker, which the binding conversion turns into {type:"service", service:<name>}.
  No cast needed; infra typecheck is clean. api is declared before telegramBot,
  so no TDZ.

Verified:
- Live: the wrangler-deployed production bot already carries the binding; the KV
  rate counter increments on a confirm, proving the request reaches the API
  handler over the binding (the hostname path never reached it).
- Tests: new webhook-level test proves the binding branch — with API_SERVICE set,
  callPrismApi calls fetcher.fetch() and global fetch is used ONLY for the
  Telegram reply, never the API call. The hostname-fallback error-surfacing path
  (400 {error:"Code expired"} -> "Link failed: Prism API error: Code expired")
  was already covered by an existing test, so it is not duplicated.
- bun run typecheck (workers + infra) clean; bunx vitest run green (197 = 196
  baseline + 1); bun run build:workers clean.

PENDING — CI alchemy deploys: the 5 worker secrets must be added as GitHub repo
secrets (TELEGRAM_BOT_TOKEN, TELEGRAM_WEBHOOK_SECRET, BOT_API_SECRET,
ADMIN_API_KEY, FEE_WALLET_ADDRESS). Until they are set, the CI deploy steps fail;
production keeps the wrangler-deployed build, which already has the binding.

KNOWN LIMITATION (by design, pending the alert-delivery backlog item): the
API->bot alert-forward (POST /internal/deliver-alert) still uses the hostname and
remains broken by the same error 1042. It is out of scope for this fix.

## Summary by Sourcery

Route Telegram bot worker’s Prism API calls through an optional Cloudflare service binding, with hostname-based fetch retained as a fallback for environments without the binding.

Bug Fixes:
- Ensure bot→API link-confirm and other commands work in production by avoiding same-zone workers.dev fetches that Cloudflare rejects with error 1042.

Enhancements:
- Propagate an optional Fetcher binding into shared bot→API call helper so all relevant commands can use the service binding when available.

Tests:
- Add a webhook-level test verifying that, when API_SERVICE is configured, the bot routes the link-confirm API call through the service binding and uses global fetch only for Telegram replies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram bot API requests can now use a secure internal service connection when available.
  * Existing external request behavior remains available as a fallback.

* **Tests**
  * Added coverage confirming link-code confirmation uses the internal service connection correctly.
  * Reformatted test calls for improved readability without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->