### PR TITLE
feat(bot): deliver alerts via D1 poll + bot flush endpoint (error 1042 workaround)

### DIFF
--- a/.github/workflows/alert-flush.yml
+++ b/.github/workflows/alert-flush.yml
@@ -1,0 +1,41 @@
+# Flush undelivered Telegram alerts.
+#
+# The telegram-bot worker delivers alerts by polling D1 via its authenticated
+# POST /internal/flush-alerts endpoint. Cloudflare rejects API->bot worker->
+# worker fetches on the same workers.dev zone (error 1042) and the alchemy beta
+# has no scheduled-trigger support for workers, so this external GitHub Actions
+# cron is the trigger. Delivery latency is bounded by the cron cadence (<= 5 min).
+#
+# Alerts are non-critical: continue-on-error keeps a failed flush from turning
+# the cron history red, while the echoed response/exit code stays visible.
+
+name: Alert Delivery Flush
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  flush:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flush undelivered alerts via the bot
+        continue-on-error: true
+        env:
+          BOT_API_SECRET: ${{ secrets.BOT_API_SECRET }}
+        run: |
+          set +e
+          body=$(curl -sS -f -X POST \
+            https://prism-telegram-bot.irfndi.workers.dev/internal/flush-alerts \
+            -H "X-Bot-Api-Secret: $BOT_API_SECRET")
+          code=$?
+          echo "response body: $body"
+          echo "curl exit code: $code"
+          if [ "$code" -ne 0 ]; then
+            echo "::error::alert flush failed (curl exit $code)"
+            exit "$code"
+          fi

--- a/cloudflare/migrations/0014_alert_delivery_attempts.sql
+++ b/cloudflare/migrations/0014_alert_delivery_attempts.sql
@@ -1,0 +1,12 @@
+-- Migration: alert delivery retry tracking
+-- Created: 2026-07-28
+--
+-- The Telegram bot now delivers alerts by POLLING the `alerts` table (the
+-- bot's `POST /internal/flush-alerts` endpoint, flushed by an external GitHub
+-- Actions cron) instead of the dead API->bot worker->worker forward, which
+-- Cloudflare rejects on the same workers.dev zone with error 1042. Each failed
+-- send bumps `delivery_attempts`; a row that reaches 5 attempts is abandoned
+-- (filtered out of future flushes) so a permanently undeliverable alert cannot
+-- be retried forever. `delivered_at IS NULL` still means "not yet delivered".
+
+ALTER TABLE alerts ADD COLUMN delivery_attempts INTEGER NOT NULL DEFAULT 0;

--- a/cloudflare/workers/api/alerts.test.ts
+++ b/cloudflare/workers/api/alerts.test.ts
@@ -182,14 +182,15 @@ describe("Alerts API", () => {
     });
   });
 
-  describe("POST /v1/alerts — storage and forwarding", () => {
-    it("stores a valid alert and forwards it when telegram is linked", async () => {
+  describe("POST /v1/alerts — storage", () => {
+    // Delivery is the bot's job now (it polls D1 via /internal/flush-alerts,
+    // driven by a GHA cron). The API only stores: delivered is always false at
+    // POST time and fetch must NEVER be called to the bot URL (error 1042).
+    it("stores a valid alert, returns delivered:false, and does not forward", async () => {
       await env.DB.prepare("UPDATE users SET telegram_id = ? WHERE id = ?")
         .bind("555777", userId)
         .run();
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
 
       const response = await worker.fetch(
         authed("/v1/alerts", VALID_ALERT, apiKey),
@@ -199,9 +200,9 @@ describe("Alerts API", () => {
       expect(response.status).toBe(200);
       const body = (await response.json()) as { id: string; delivered: boolean };
       expect(body.id).toBeTruthy();
-      expect(body.delivered).toBe(true);
+      expect(body.delivered).toBe(false);
 
-      // Stored in D1 with delivered_at set.
+      // Stored in D1 with delivered_at still NULL (the cron marks it later).
       const row = await env.DB.prepare(
         "SELECT type, severity, message, pool_address, delivered_at FROM alerts WHERE id = ?",
       )
@@ -211,22 +212,13 @@ describe("Alerts API", () => {
       expect(row?.severity).toBe("critical");
       expect(row?.message).toBe(VALID_ALERT.message);
       expect(row?.pool_address).toBe(VALID_ALERT.poolAddress);
-      expect(row?.delivered_at).not.toBeNull();
+      expect(row?.delivered_at).toBeNull();
 
-      // Forwarded to the bot worker's internal endpoint with the shared secret.
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-      const [forwardUrl, forwardInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(String(forwardUrl)).toBe(`${BOT_URL}/internal/deliver-alert`);
-      const headers = new Headers(forwardInit.headers);
-      expect(headers.get("X-Bot-Api-Secret")).toBe(BOT_SECRET);
-      const forwardBody = JSON.parse(String(forwardInit.body)) as Record<string, unknown>;
-      expect(forwardBody.telegram_id).toBe("555777");
-      expect(forwardBody.type).toBe("position_out_of_range");
-      expect(forwardBody.severity).toBe("critical");
-      expect(forwardBody.message).toBe(VALID_ALERT.message);
+      // No worker->worker forward: fetch is never invoked in the store path.
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it("stores but does not forward when the user has no telegram link", async () => {
+    it("stores without forwarding when the user has no telegram link", async () => {
       const fetchSpy = vi.spyOn(globalThis, "fetch");
 
       const response = await worker.fetch(
@@ -246,7 +238,7 @@ describe("Alerts API", () => {
       expect(row?.delivered_at).toBeNull();
     });
 
-    it("stores but does not forward when alerts_enabled = 0", async () => {
+    it("stores without forwarding when alerts_enabled = 0", async () => {
       await env.DB.prepare("UPDATE users SET telegram_id = ?, alerts_enabled = 0 WHERE id = ?")
         .bind("555777", userId)
         .run();
@@ -266,11 +258,13 @@ describe("Alerts API", () => {
       expect(count?.n).toBe(1);
     });
 
-    it("fails open (200, delivered:false) when the bot worker is unreachable", async () => {
+    it("still stores (200, delivered:false) with no fetch even if a rejecting fetch mock is installed", async () => {
       await env.DB.prepare("UPDATE users SET telegram_id = ? WHERE id = ?")
         .bind("555777", userId)
         .run();
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("connection refused"));
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValue(new Error("connection refused"));
 
       const response = await worker.fetch(
         authed("/v1/alerts", VALID_ALERT, apiKey),
@@ -280,6 +274,8 @@ describe("Alerts API", () => {
       expect(response.status).toBe(200);
       const body = (await response.json()) as { id: string; delivered: boolean };
       expect(body.delivered).toBe(false);
+      // The store path never reaches fetch, so the rejecting mock is not hit.
+      expect(fetchSpy).not.toHaveBeenCalled();
 
       const row = await env.DB.prepare("SELECT delivered_at FROM alerts WHERE id = ?")
         .bind(body.id)

--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -1311,10 +1311,12 @@ app.get("/v1/errors/stats", async (c) => {
 });
 
 // ── Proactive Telegram alerts (Wave 5) ──────────────────────────────────────
-// Engine POSTs alert events with its API key. Every alert is persisted first
-// (delivered_at NULL), then pushed to the telegram-bot worker, which is the
-// only component that can reach the Telegram API. Push is best-effort: the
-// row stays auditable even when delivery is skipped or fails.
+// Engine POSTs alert events with its API key. Every alert is persisted
+// (delivered_at NULL). Delivery is handled by the telegram-bot worker POLLING
+// D1 via its /internal/flush-alerts endpoint, triggered by an external GitHub
+// Actions cron: Cloudflare rejects API->bot worker->worker fetches over the
+// same workers.dev zone (error 1042) and the alchemy beta has no scheduled-
+// trigger support for workers. The API only stores; the cron marks delivered_at.
 
 const VALID_ALERT_TYPES = new Set([
   "position_out_of_range",
@@ -1330,7 +1332,6 @@ const VALID_ALERT_SEVERITIES = new Set(["info", "warning", "critical"]);
 const MAX_ALERT_MESSAGE_LENGTH = 1000;
 const MAX_ALERT_DATA_LENGTH = 4096;
 const ALERT_RATE_LIMIT_PER_HOUR = 60;
-const ALERT_FORWARD_TIMEOUT_MS = 5000;
 
 app.post("/v1/alerts", async (c) => {
   const { DB, CACHE } = c.env;
@@ -1394,10 +1395,8 @@ app.post("/v1/alerts", async (c) => {
   const alertType = body.type;
   const alertSeverity = body.severity;
   const alertMessage = body.message;
-  const botUrl = c.env.TELEGRAM_BOT_URL;
-  const botSecret = c.env.BOT_API_SECRET;
 
-  const storeAndForward = Effect.gen(function* () {
+  const storeAlert = Effect.gen(function* () {
     const id = generateId();
     yield* Effect.tryPromise(() =>
       DB.prepare(
@@ -1416,59 +1415,15 @@ app.post("/v1/alerts", async (c) => {
         .run(),
     );
 
-    const userRow = yield* Effect.tryPromise(() =>
-      DB.prepare("SELECT telegram_id, alerts_enabled FROM users WHERE id = ?")
-        .bind(user.id)
-        .first(),
-    );
-    const telegramId =
-      userRow && typeof userRow.telegram_id === "string" && userRow.telegram_id.length > 0
-        ? userRow.telegram_id
-        : null;
-    const alertsEnabled = !userRow || userRow.alerts_enabled !== 0;
-
-    let delivered = false;
-    if (telegramId && alertsEnabled && botUrl && botSecret) {
-      const forward = yield* Effect.tryPromise(() =>
-        fetch(`${botUrl}/internal/deliver-alert`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Bot-Api-Secret": botSecret,
-          },
-          body: JSON.stringify({
-            alert_id: id,
-            telegram_id: telegramId,
-            type: alertType,
-            severity: alertSeverity,
-            message: alertMessage,
-            pool_address: body.poolAddress ?? null,
-            data: body.data ?? null,
-          }),
-          signal: AbortSignal.timeout(ALERT_FORWARD_TIMEOUT_MS),
-        }),
-      ).pipe(Effect.catchAll(() => Effect.succeed(null)));
-
-      if (forward?.ok) {
-        delivered = true;
-        yield* Effect.tryPromise(() =>
-          DB.prepare("UPDATE alerts SET delivered_at = CURRENT_TIMESTAMP WHERE id = ?")
-            .bind(id)
-            .run(),
-        ).pipe(Effect.catchAll(() => Effect.succeed(null)));
-      } else {
-        console.error(
-          "[Alerts] telegram-bot forward failed",
-          forward ? `status ${forward.status}` : "network error",
-        );
-      }
-    }
-
-    return c.json({ id, delivered });
+    // Delivery happens via the bot's /internal/flush-alerts poll (GitHub
+    // Actions cron), not here: Cloudflare rejects API->bot worker->worker
+    // fetches over the same workers.dev zone (error 1042). delivered:false
+    // until the cron marks delivered_at.
+    return c.json({ id, delivered: false });
   });
 
   return Effect.runPromise(
-    storeAndForward.pipe(
+    storeAlert.pipe(
       Effect.catchAll(() => Effect.succeed(c.json({ error: "Failed to store alert" }, 500))),
     ),
   );

--- a/cloudflare/workers/telegram-bot/index.ts
+++ b/cloudflare/workers/telegram-bot/index.ts
@@ -595,6 +595,26 @@ function shortenAddress(address: string): string {
   return address.length > 12 ? `${address.slice(0, 4)}…${address.slice(-4)}` : address;
 }
 
+// Shared alert formatting for BOTH the push endpoint (/internal/deliver-alert)
+// and the poll endpoint (/internal/flush-alerts): severity emoji + bold type
+// label + optional shortened pool address + message, all escapeHtml'd before
+// being interpolated into a parse_mode: HTML message.
+function formatAlertLines(
+  type: unknown,
+  severity: string,
+  message: string,
+  poolAddress: string | null,
+): string[] {
+  const typeLabel = typeof type === "string" ? (ALERT_TYPE_LABEL[type] ?? "Alert") : "Alert";
+  const emoji = ALERT_SEVERITY_EMOJI[severity] ?? ALERT_SEVERITY_EMOJI.info;
+  const lines = [`${emoji} <b>${escapeHtml(typeLabel)}</b>`];
+  if (poolAddress) {
+    lines.push(`Pool: <code>${escapeHtml(shortenAddress(poolAddress))}</code>`);
+  }
+  lines.push(escapeHtml(message));
+  return lines;
+}
+
 function deliverTelegramMessage(
   botToken: string,
   chatId: number,
@@ -652,15 +672,7 @@ app.post("/internal/deliver-alert", async (c) => {
     typeof body.pool_address === "string" && body.pool_address.length > 0
       ? body.pool_address.slice(0, 64)
       : null;
-  const typeLabel =
-    typeof body.type === "string" ? (ALERT_TYPE_LABEL[body.type] ?? "Alert") : "Alert";
-
-  const emoji = ALERT_SEVERITY_EMOJI[body.severity] ?? ALERT_SEVERITY_EMOJI.info;
-  const lines = [`${emoji} <b>${escapeHtml(typeLabel)}</b>`];
-  if (poolAddress) {
-    lines.push(`Pool: <code>${escapeHtml(shortenAddress(poolAddress))}</code>`);
-  }
-  lines.push(escapeHtml(body.message));
+  const lines = formatAlertLines(body.type, body.severity, body.message, poolAddress);
 
   const delivered = await Effect.runPromise(
     deliverTelegramMessage(c.env.TELEGRAM_BOT_TOKEN, Number(body.telegram_id), lines.join("\n")),
@@ -668,6 +680,123 @@ app.post("/internal/deliver-alert", async (c) => {
   return delivered
     ? c.json({ ok: true, delivered: true })
     : c.json({ error: "Telegram delivery failed" }, 502);
+});
+
+// ── Internal alert delivery poll (D1 → bot → Telegram) ──────────────────────
+// Cloudflare rejects worker->worker fetches over the same workers.dev zone with
+// error 1042, so the API worker can no longer push alerts here. Instead the bot
+// POLLS D1 for undelivered rows; an external GitHub Actions cron (no worker
+// scheduled-trigger support on the alchemy beta) triggers this endpoint on a
+// fixed cadence. Same BOT_API_SECRET gate as /internal/deliver-alert (fail
+// closed). A row at FLUSH_ABANDON_ATTEMPTS is dropped from future flushes so a
+// permanently undeliverable alert is never retried forever. One bad row must
+// not abort the batch: every row runs under Effect.catchAll and is counted.
+
+const FLUSH_BATCH_LIMIT = 10;
+const FLUSH_ABANDON_ATTEMPTS = 5;
+
+app.post("/internal/flush-alerts", async (c) => {
+  const botSecret = c.env.BOT_API_SECRET;
+  const headerSecret = c.req.header("X-Bot-Api-Secret");
+  if (!botSecret || !headerSecret || !constantTimeEqual(headerSecret, botSecret)) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const rows = yield* Effect.tryPromise(() =>
+        c.env.DB.prepare(
+          `SELECT a.id, a.type, a.severity, a.message, a.pool_address, u.telegram_id
+           FROM alerts a
+           JOIN users u ON a.user_id = u.id
+           WHERE a.delivered_at IS NULL
+             AND a.delivery_attempts < ?
+             AND u.telegram_id IS NOT NULL
+             AND u.alerts_enabled != 0
+           ORDER BY a.created_at ASC
+           LIMIT ?`,
+        )
+          .bind(FLUSH_ABANDON_ATTEMPTS, FLUSH_BATCH_LIMIT)
+          .all(),
+      );
+
+      let checked = 0;
+      let delivered = 0;
+      let failed = 0;
+
+      for (const raw of rows.results) {
+        const id = typeof raw.id === "string" ? raw.id : null;
+        const severity = typeof raw.severity === "string" ? raw.severity : "info";
+        const message = typeof raw.message === "string" ? raw.message : "";
+        const poolAddress =
+          typeof raw.pool_address === "string" && raw.pool_address.length > 0
+            ? raw.pool_address
+            : null;
+        const telegramId =
+          typeof raw.telegram_id === "string" && /^\d+$/.test(raw.telegram_id)
+            ? raw.telegram_id
+            : null;
+
+        checked += 1;
+        const outcome = yield* Effect.gen(function* () {
+          if (id === null || telegramId === null) return "failed" as const;
+          const lines = formatAlertLines(raw.type, severity, message, poolAddress);
+          const ok = yield* deliverTelegramMessage(
+            c.env.TELEGRAM_BOT_TOKEN,
+            Number(telegramId),
+            lines.join("\n"),
+          );
+          if (ok) {
+            yield* Effect.tryPromise(() =>
+              c.env.DB.prepare("UPDATE alerts SET delivered_at = CURRENT_TIMESTAMP WHERE id = ?")
+                .bind(id)
+                .run(),
+            );
+            return "delivered" as const;
+          }
+          yield* Effect.tryPromise(() =>
+            c.env.DB.prepare(
+              "UPDATE alerts SET delivery_attempts = delivery_attempts + 1 WHERE id = ?",
+            )
+              .bind(id)
+              .run(),
+          );
+          return "failed" as const;
+        }).pipe(Effect.catchAll(() => Effect.succeed("failed" as const)));
+
+        if (outcome === "delivered") {
+          delivered += 1;
+        } else {
+          failed += 1;
+        }
+      }
+
+      const abandonedRow = (yield* Effect.tryPromise(() =>
+        c.env.DB.prepare(
+          `SELECT COUNT(*) as n
+           FROM alerts a
+           JOIN users u ON a.user_id = u.id
+           WHERE a.delivered_at IS NULL
+             AND a.delivery_attempts >= ?
+             AND u.telegram_id IS NOT NULL
+             AND u.alerts_enabled != 0`,
+        )
+          .bind(FLUSH_ABANDON_ATTEMPTS)
+          .first(),
+      )) as { n?: unknown } | null;
+      const abandoned = abandonedRow && typeof abandonedRow.n === "number" ? abandonedRow.n : 0;
+
+      return { ok: true, checked, delivered, failed, abandoned };
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() => console.error("Alert flush failed", error)).pipe(
+          Effect.as({ ok: false, checked: 0, delivered: 0, failed: 0, abandoned: 0 }),
+        ),
+      ),
+    ),
+  );
+
+  return c.json(result);
 });
 
 export default {

--- a/cloudflare/workers/telegram-bot/telegram-bot.test.ts
+++ b/cloudflare/workers/telegram-bot/telegram-bot.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { env, createExecutionContext } from "cloudflare:test";
 import worker from "./index";
 
@@ -600,6 +600,230 @@ describe("Telegram Bot Worker", () => {
         createExecutionContext(),
       );
       expect(response.status).toBe(200);
+    });
+  });
+});
+
+describe("/internal/flush-alerts (D1 alert poll)", () => {
+  // Base `env` (from wrangler.telegram.test.toml) has no BOT_API_SECRET, so it
+  // exercises the fail-closed path; testEnv (defined above) sets it.
+  function postFlush(options: { secret?: string; omitSecretHeader?: boolean } = {}): Request {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (!options.omitSecretHeader) {
+      headers["X-Bot-Api-Secret"] = options.secret ?? BOT_API_SECRET;
+    }
+    return new Request("https://example.com/internal/flush-alerts", {
+      method: "POST",
+      headers,
+      body: "{}",
+    });
+  }
+
+  async function seedUser(
+    id = "user-1",
+    telegramId: string | null = "12345",
+    alertsEnabled = 1,
+  ): Promise<void> {
+    await env.DB.prepare("INSERT INTO users (id, telegram_id, alerts_enabled) VALUES (?, ?, ?)")
+      .bind(id, telegramId, alertsEnabled)
+      .run();
+  }
+
+  async function seedAlert(
+    opts: {
+      id?: string;
+      userId?: string;
+      type?: string;
+      severity?: string;
+      message?: string;
+      poolAddress?: string | null;
+      deliveryAttempts?: number;
+    } = {},
+  ): Promise<void> {
+    await env.DB.prepare(
+      `INSERT INTO alerts
+         (id, user_id, type, pool_address, severity, message, delivery_attempts)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        opts.id ?? "alert-1",
+        opts.userId ?? "user-1",
+        opts.type ?? "position_out_of_range",
+        opts.poolAddress ?? "Pool1111111111111111111111111111111111111",
+        opts.severity ?? "critical",
+        opts.message ?? "Position out of range on SOL/USDC",
+        opts.deliveryAttempts ?? 0,
+      )
+      .run();
+  }
+
+  beforeAll(async () => {
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS users (
+         id TEXT PRIMARY KEY,
+         telegram_id TEXT,
+         tier TEXT NOT NULL DEFAULT 'free',
+         alerts_enabled INTEGER NOT NULL DEFAULT 1,
+         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+       )`,
+    ).run();
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS alerts (
+         id TEXT PRIMARY KEY,
+         user_id TEXT NOT NULL,
+         type TEXT NOT NULL,
+         pool_address TEXT,
+         severity TEXT NOT NULL,
+         message TEXT NOT NULL,
+         data TEXT,
+         delivered_at DATETIME,
+         delivery_attempts INTEGER NOT NULL DEFAULT 0,
+         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+       )`,
+    ).run();
+    // Defensive: a shared D1 may predate these columns from an earlier file run.
+    await env.DB.prepare(
+      "ALTER TABLE alerts ADD COLUMN delivery_attempts INTEGER NOT NULL DEFAULT 0",
+    )
+      .run()
+      .catch(() => {});
+    await env.DB.prepare("ALTER TABLE users ADD COLUMN alerts_enabled INTEGER NOT NULL DEFAULT 1")
+      .run()
+      .catch(() => {});
+  });
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    await env.DB.prepare("DELETE FROM alerts").run();
+    await env.DB.prepare("DELETE FROM users").run();
+  });
+
+  describe("auth", () => {
+    it("rejects requests without the bot secret (401)", async () => {
+      const response = await worker.fetch(
+        postFlush({ omitSecretHeader: true }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("rejects requests with a wrong bot secret (401)", async () => {
+      const response = await worker.fetch(
+        postFlush({ secret: "wrong-secret" }),
+        testEnv,
+        createExecutionContext(),
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("fails closed when BOT_API_SECRET is unset on the worker", async () => {
+      const response = await worker.fetch(postFlush(), env, createExecutionContext());
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("delivery", () => {
+    it("delivers a pending alert to Telegram and marks delivered_at", async () => {
+      await seedUser();
+      await seedAlert({ id: "alert-a", message: "First alert" });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+      const response = await worker.fetch(postFlush(), testEnv, createExecutionContext());
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        ok: boolean;
+        checked: number;
+        delivered: number;
+        failed: number;
+      };
+      expect(body).toMatchObject({ ok: true, checked: 1, delivered: 1, failed: 0 });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(String(url)).toContain("api.telegram.org/bot");
+      const sent = JSON.parse(String(init.body)) as Record<string, unknown>;
+      expect(sent.chat_id).toBe(12345);
+      const text = String(sent.text);
+      expect(text).toContain("🚨");
+      expect(text).toContain("Position out of range");
+
+      const row = await env.DB.prepare(
+        "SELECT delivered_at, delivery_attempts FROM alerts WHERE id = ?",
+      )
+        .bind("alert-a")
+        .first();
+      expect(row?.delivered_at).not.toBeNull();
+    });
+
+    it("increments delivery_attempts and leaves delivered_at NULL on failure", async () => {
+      await seedUser();
+      await seedAlert({ id: "alert-b" });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ ok: false }), { status: 400 }),
+      );
+
+      const response = await worker.fetch(postFlush(), testEnv, createExecutionContext());
+      const body = (await response.json()) as { delivered: number; failed: number };
+      expect(body.delivered).toBe(0);
+      expect(body.failed).toBe(1);
+
+      const row = await env.DB.prepare(
+        "SELECT delivered_at, delivery_attempts FROM alerts WHERE id = ?",
+      )
+        .bind("alert-b")
+        .first();
+      expect(row?.delivered_at).toBeNull();
+      expect(row?.delivery_attempts).toBe(1);
+    });
+
+    it("skips rows whose user has disabled alerts or no telegram link", async () => {
+      await seedUser("user-off", "222", 0);
+      await seedUser("user-nolink", null, 1);
+      await seedAlert({ id: "alert-off", userId: "user-off" });
+      await seedAlert({ id: "alert-nolink", userId: "user-nolink" });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+      const response = await worker.fetch(postFlush(), testEnv, createExecutionContext());
+      const body = (await response.json()) as { checked: number; delivered: number };
+      expect(body.checked).toBe(0);
+      expect(body.delivered).toBe(0);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("abandons a row at 5 attempts and never retries it", async () => {
+      await seedUser();
+      await seedAlert({ id: "alert-c", deliveryAttempts: 4 });
+
+      // First flush: send fails -> attempts 4 -> 5.
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ ok: false }), { status: 400 }),
+      );
+      await worker.fetch(postFlush(), testEnv, createExecutionContext());
+      let row = await env.DB.prepare("SELECT delivery_attempts FROM alerts WHERE id = ?")
+        .bind("alert-c")
+        .first();
+      expect(row?.delivery_attempts).toBe(5);
+
+      // Second flush: filtered out (attempts >= 5) -> not retried. Restore the
+      // shared fetch spy first so its call history is clean for this assertion.
+      vi.restoreAllMocks();
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+      const response = await worker.fetch(postFlush(), testEnv, createExecutionContext());
+      const body = (await response.json()) as {
+        checked: number;
+        delivered: number;
+        abandoned: number;
+      };
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(body.checked).toBe(0);
+      expect(body.abandoned).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Root cause\nCloudflare rejects worker→worker fetches over the same-zone `workers.dev` hostname with **error 1042** — proven live via the bot's own diag subrequest. Alchemy beta () also has **no scheduled-trigger support for workers**, so the cron must live outside the worker.\n\n## Design\n\n1. **New bot endpoint `POST /internal/flush-alerts`** — gated with the same BOT_API_SECRET constant-time check. Behavior:  undelivered alerts () for users with , ordered by age, LIMIT 10. Per row: format (existing  extraction) →  → mark  on success, increment  on failure. Rows hitting 5 attempts stop being retried (abandoned).\n2. **GHA cron** (every 5 min) curls the flush endpoint with  from GH secrets. Max delivery latency ~5 min; survives bot downtime (alerts queue in D1 until next cron).\n3. **API **: removed the dead hostname forward; stores the alert row and returns . Cron marks .\n4. **Migration 0014**: .\n5.  retained (tested; may be used by other flows).\n\n## Verification\n- `bun run typecheck` (workers + infra): clean\n- CF suite: **204/204 passing** (16 files, 197 baseline + 7 new)\n\n## E2E plan (post-deploy)\n1. Test user already seeded: user `1785218940806-305h2w2w5u320r3c` linked to fake TG `777000999`, one alert in queue.\n2. After deploy: `curl -X POST https://prism-telegram-bot.irfndi.workers.dev/internal/flush-alerts -H "X-Bot-Api-Secret: $BOT_API_SECRET"` → expect `{"ok":true,"checked":1,...,"failed":1}` (fake chat → sendMessage fails) → D1 shows `delivery_attempts = 1`.

## Summary by Sourcery

Add a D1-backed alert delivery poll endpoint in the Telegram bot and switch the API to store-only alerts, driven by a GitHub Actions cron-based flush, with delivery retry tracking.

New Features:
- Introduce an internal /internal/flush-alerts endpoint in the Telegram bot worker to poll D1 for undelivered alerts and send them to Telegram.
- Add a GitHub Actions scheduled workflow to trigger the bot's alert flush endpoint every 5 minutes.

Bug Fixes:
- Work around Cloudflare worker-to-worker same-zone fetch error 1042 by removing direct API-to-bot alert forwarding.

Enhancements:
- Refactor alert formatting into a shared helper used by both push and poll delivery paths.
- Track alert delivery attempts in D1 and abandon alerts after a fixed number of failed attempts to avoid infinite retries.

Documentation:
- Document the new poll-based alert delivery flow and its constraints in API and migration comments.

Tests:
- Add comprehensive tests for the /internal/flush-alerts endpoint covering auth, delivery, retry, and abandonment behaviors, and update alerts API tests to assert store-only behavior.