### PR TITLE
fix: Telegram /status now returns real engine data via KV-backed status reporting

### DIFF
--- a/cli/dev.ts
+++ b/cli/dev.ts
@@ -64,9 +64,13 @@ export const devCommand = new Command("dev")
       cleanup(code);
     };
 
+    // The engine owns SIGINT/SIGTERM: its gracefulShutdown posts a final
+    // "stopped" status to the API before exiting, so Telegram /status updates
+    // on shutdown. If the CLI also handled these signals here and called
+    // process.exit first, that stopped report would never run and /status would
+    // show a stale "running" until the KV TTL expired. We hook only "exit" to
+    // guarantee the lockfile is released once the process actually ends.
     process.on("exit", () => cleanup());
-    process.on("SIGINT", () => doCleanup(130));
-    process.on("SIGTERM", () => doCleanup(143));
 
     console.log("Starting Prism trading agent...");
     await runEngine();

--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -379,9 +379,13 @@ const registerTelegramHandler = (db: D1Database, telegramId: string, firstName: 
     return { user_id: userId, api_key: apiKey, first_name: firstName };
   });
 
-// Agent status (called by the Telegram bot). Placeholder until the live agent
-// runtime exposes telemetry; real numbers can replace this later.
-const agentStatusHandler = (db: D1Database, telegramId: string) =>
+// Agent status (called by the Telegram bot). Query KV for the latest engine
+// status reported by the live agent runtime. Returns the stored status when
+// fresh (within the KV TTL, approximately 2× the scan interval); falls back
+// to not_running when no recent heartbeat exists or when KV is unavailable.
+const AGENT_STATUS_CACHE_TTL_SEC = 30 * 60; // 30 minutes
+
+const agentStatusHandler = (db: D1Database, cache: KVNamespace, telegramId: string) =>
   Effect.gen(function* () {
     const result = yield* Effect.tryPromise(() =>
       db.prepare("SELECT id FROM users WHERE telegram_id = ?").bind(telegramId).first(),
@@ -391,7 +395,55 @@ const agentStatusHandler = (db: D1Database, telegramId: string) =>
       return yield* Effect.fail(new Error("User not found"));
     }
 
+    const userId = typeof result.id === "string" ? result.id : null;
+    if (!userId) {
+      return { status: "not_running", positions: 0, pnl: 0 };
+    }
+
+    // Try KV first for the latest engine heartbeat.
+    const cached = yield* Effect.tryPromise(() =>
+      cache.get(`agent_status:${userId}`),
+    ).pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached) as {
+          status: string;
+          positions: number;
+          pnl: number;
+          reportedAt: number;
+        };
+        return {
+          status: parsed.status,
+          positions: parsed.positions,
+          pnl: parsed.pnl,
+        };
+      } catch {
+        // Malformed JSON — fall through to not_running.
+      }
+    }
+
     return { status: "not_running", positions: 0, pnl: 0 };
+  });
+
+// Engine status report (called by the engine itself via its API key).
+// Stores the engine's live state in KV so the Telegram bot can query it.
+const agentStatusReportHandler = (db: D1Database, cache: KVNamespace, apiKey: string) =>
+  Effect.gen(function* () {
+    const loginResult = yield* loginHandler(db, apiKey);
+    const userId = (loginResult as { id: string }).id;
+
+    return {
+      userId,
+      storeStatus: (status: string, positions: number, pnl: number) =>
+        Effect.tryPromise(() =>
+          cache.put(
+            `agent_status:${userId}`,
+            JSON.stringify({ status, positions, pnl, reportedAt: Date.now() }),
+            { expirationTtl: AGENT_STATUS_CACHE_TTL_SEC },
+          ),
+        ).pipe(Effect.catchAll(() => Effect.void)),
+    };
   });
 
 // Main app
@@ -716,7 +768,7 @@ app.post("/v1/register-telegram", async (c) => {
 });
 
 app.post("/v1/agent-status", async (c) => {
-  const { DB } = c.env;
+  const { DB, CACHE } = c.env;
   if (!isBotAuthorized(c.env, c.req.header("X-Bot-Api-Secret"))) {
     return c.json({ error: "Unauthorized" }, 401);
   }
@@ -727,7 +779,7 @@ app.post("/v1/agent-status", async (c) => {
   }
 
   return Effect.runPromise(
-    agentStatusHandler(DB, body.telegram_id).pipe(
+    agentStatusHandler(DB, CACHE, body.telegram_id).pipe(
       Effect.match({
         onFailure: (cause) => {
           const message = causeMessage(cause);
@@ -736,6 +788,54 @@ app.post("/v1/agent-status", async (c) => {
             : c.json({ error: "Status unavailable" }, 500);
         },
         onSuccess: (result) => c.json(result),
+      }),
+    ),
+  );
+});
+
+// Engine status report endpoint — called periodically by the running engine to
+// report its live state (running, positions, P&L). Authenticated via Bearer
+// API key. Stored in KV with a 30-minute TTL; the bot-facing /v1/agent-status
+// endpoint reads it to serve the Telegram /status command.
+app.post("/v1/agent-status/report", async (c) => {
+  const { DB, CACHE } = c.env;
+  const apiKey = c.get("apiKey") as string;
+  if (!apiKey) {
+    return c.json({ error: "API key required" }, 401);
+  }
+
+  const body = await Effect.runPromise(
+    readJsonBody<{ status?: string; positions?: number; pnl?: number }>(c.req),
+  );
+
+  if (body.status !== "running" && body.status !== "stopped") {
+    return c.json({ error: "status must be 'running' or 'stopped'" }, 400);
+  }
+  if (typeof body.positions !== "number" || !Number.isFinite(body.positions) || body.positions < 0) {
+    return c.json({ error: "positions must be a non-negative number" }, 400);
+  }
+  const positions = Math.floor(body.positions);
+  if (typeof body.pnl !== "number" || !Number.isFinite(body.pnl)) {
+    return c.json({ error: "pnl must be a finite number" }, 400);
+  }
+  const pnl = body.pnl;
+
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const handler = yield* agentStatusReportHandler(DB, CACHE, apiKey).pipe(
+        Effect.catchAll(() =>
+          Effect.fail(new Error("Authentication failed")),
+        ),
+      );
+      yield* handler.storeStatus(body.status!, positions, pnl);
+      return c.json({ ok: true });
+    }).pipe(
+      Effect.match({
+        onFailure: (cause) => {
+          const message = causeMessage(cause);
+          return c.json({ error: message }, 401);
+        },
+        onSuccess: (response) => response,
       }),
     ),
   );

--- a/cloudflare/workers/api/index.ts
+++ b/cloudflare/workers/api/index.ts
@@ -442,7 +442,16 @@ const agentStatusReportHandler = (db: D1Database, cache: KVNamespace, apiKey: st
             JSON.stringify({ status, positions, pnl, reportedAt: Date.now() }),
             { expirationTtl: AGENT_STATUS_CACHE_TTL_SEC },
           ),
-        ).pipe(Effect.catchAll(() => Effect.void)),
+        ).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() =>
+              console.error("agent-status KV write failed", {
+                userId,
+                err: String(err),
+              }),
+            ),
+          ),
+        ),
     };
   });
 

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -131,60 +131,67 @@ const idleRedeployLogger = createLogger("idle-redeploy");
 const statusLogger = createLogger("engine-status");
 
 /**
- * Post the engine's current status to the Prism Cloud API so the Telegram
- * bot's /status command can serve real data. Reads the API key from the
- * on-disk credentials file and uses fire-and-forget fetch so a transient
- * network error never blocks the scan cycle.
+ * Read the Prism Cloud API key from the on-disk credentials file. Returns null
+ * when the user has not registered — a normal condition, not an error, so status
+ * reporting simply no-ops.
+ */
+const readEngineStatusApiKey = (): string | null => {
+  try {
+    const credentialsFile = join(getPrismUserConfigDir(), "credentials.json");
+    if (!existsSync(credentialsFile)) return null;
+    const value: unknown = JSON.parse(readFileSync(credentialsFile, "utf-8"));
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      typeof (value as Record<string, unknown>).apiKey === "string"
+    ) {
+      return (value as { apiKey: string }).apiKey;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Post the engine's current status to the Prism Cloud API so the Telegram bot's
+ * /status command can serve real data. Runs fully inside the Effect boundary
+ * (filesystem read + HTTP request) and never fails — a missing API key or a
+ * transient network error is logged and swallowed so it can never block the scan
+ * cycle or the shutdown path. Mirrors the fire-and-forget `reportFeeCollection`
+ * reporting pattern in this file.
  */
 function postEngineStatus(
   status: "running" | "stopped",
   positions: number,
-  pnl: number,
-): void {
+  unrealizedPnlUsd: number,
+): Effect.Effect<void> {
   const DEFAULT_API_BASE_URL = "https://prism-api.irfndi.workers.dev";
-  const baseUrl = process.env.PRISM_API_URL ?? DEFAULT_API_BASE_URL;
   const TIMEOUT_MS = 5_000;
-
-  let apiKey: string | null = null;
-  try {
-    const credentialsFile = join(getPrismUserConfigDir(), "credentials.json");
-    if (existsSync(credentialsFile)) {
-      const value: unknown = JSON.parse(readFileSync(credentialsFile, "utf-8"));
-      if (
-        typeof value === "object" &&
-        value !== null &&
-        typeof (value as Record<string, unknown>).apiKey === "string"
-      ) {
-        apiKey = (value as { apiKey: string }).apiKey;
-      }
+  return Effect.gen(function* () {
+    const baseUrl = process.env.PRISM_API_URL ?? DEFAULT_API_BASE_URL;
+    const apiKey = yield* Effect.sync(readEngineStatusApiKey);
+    if (apiKey == null) return;
+    const response = yield* Effect.tryPromise(() =>
+      fetch(`${baseUrl}/v1/agent-status/report`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ status, positions, pnl: unrealizedPnlUsd }),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      }),
+    );
+    if (!response.ok) {
+      statusLogger.warn("Engine status report rejected", { status: response.status });
     }
-  } catch {
-    // No credentials — nothing to report.
-  }
-
-  if (!apiKey) return;
-
-  fetch(`${baseUrl}/v1/agent-status/report`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({ status, positions, pnl }),
-    signal: AbortSignal.timeout(TIMEOUT_MS),
-  }).then(
-    (response) => {
-      if (!response.ok) {
-        statusLogger.warn("Engine status report rejected", {
-          status: response.status,
-        });
-      }
-    },
-    (error: unknown) => {
-      statusLogger.warn("Engine status report failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    },
+  }).pipe(
+    Effect.catchAllCause((cause) =>
+      Effect.sync(() =>
+        statusLogger.warn("Engine status report failed", { cause: String(cause) }),
+      ),
+    ),
   );
 }
 
@@ -2904,13 +2911,23 @@ export const program = Effect.gen(function* () {
         }
 
       // Report engine status to the Prism Cloud API after every scan cycle.
+      // PnL is the aggregate UNREALIZED figure across tracked positions and
+      // INCLUDES claimed fees + claimed rewards (which live on PositionRecord, not
+      // the reduced PositionSnapshot), matching the canonical unrealized-PnL
+      // formula in engine/pnl.ts. Forked fire-and-forget so a transient report
+      // never blocks the cycle.
       {
-        const positions = buildPositionSnapshots(trackedPositions.values());
-        const pnl = positions.reduce(
-          (sum, p) => sum + (p.currentValueUsd - p.depositedUsd),
-          0,
+        let pnl = 0;
+        for (const p of trackedPositions.values()) {
+          pnl +=
+            p.currentValueUsd +
+            p.cumulativeFeesClaimedUsd +
+            p.cumulativeRewardsClaimedUsd -
+            p.depositedUsd;
+        }
+        yield* Effect.fork(postEngineStatus("running", trackedPositions.size, pnl)).pipe(
+          Effect.asVoid,
         );
-        postEngineStatus("running", trackedPositions.size, pnl);
       }
 
       scanCount += 1;
@@ -5806,9 +5823,27 @@ export const program = Effect.gen(function* () {
     if (shuttingDown) return;
     shuttingDown = true;
     console.info(`Received ${signal} — shutting down`);
+    // Report a final "stopped" heartbeat so Telegram /status does not keep serving
+    // a stale "running" until the 30-minute KV TTL expires. Awaited inline (with a
+    // hard timeout) BEFORE process.exit so the fetch is not killed mid-flight; the
+    // per-cycle "running" report stays fire-and-forget.
+    let pnl = 0;
+    for (const p of trackedPositions.values()) {
+      pnl +=
+        p.currentValueUsd +
+        p.cumulativeFeesClaimedUsd +
+        p.cumulativeRewardsClaimedUsd -
+        p.depositedUsd;
+    }
     Effect.runFork(
       Fiber.interrupt(schedulerFiber).pipe(
         Effect.zipRight(agent.disconnect()),
+        Effect.zipRight(
+          postEngineStatus("stopped", trackedPositions.size, pnl).pipe(
+            Effect.timeout("4 seconds"),
+            Effect.catchAll(() => Effect.void),
+          ),
+        ),
         Effect.ensuring(Effect.sync(() => process.exit(0))),
       ),
     );

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -35,8 +35,11 @@ import { McpServerLive } from "./mcp-server.js";
 import { HttpStatusServerLive } from "./http-status-server.js";
 import { EntryPrepLive } from "./entry-prep-service.js";
 import { shouldDiscoverPools } from "./pool-policy.js";
+import { getPrismUserConfigDir } from "./paths.js";
 
 import { checkForAutoUpdate } from "./update-check.js";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
 import type { PositionRecord } from "./db-service.js";
 import { applyCompoundToCostBasis, computeHodlValueUsd, computeRealizedPnlUsd } from "./pnl.js";
 import { buildRewardClaimMetadata, summarizeRewardClaim } from "./rewards.js";
@@ -125,6 +128,65 @@ import { computeCooldownForExit } from "./cooldown.js";
 
 const logger = createLogger("program");
 const idleRedeployLogger = createLogger("idle-redeploy");
+const statusLogger = createLogger("engine-status");
+
+/**
+ * Post the engine's current status to the Prism Cloud API so the Telegram
+ * bot's /status command can serve real data. Reads the API key from the
+ * on-disk credentials file and uses fire-and-forget fetch so a transient
+ * network error never blocks the scan cycle.
+ */
+function postEngineStatus(
+  status: "running" | "stopped",
+  positions: number,
+  pnl: number,
+): void {
+  const DEFAULT_API_BASE_URL = "https://prism-api.irfndi.workers.dev";
+  const baseUrl = process.env.PRISM_API_URL ?? DEFAULT_API_BASE_URL;
+  const TIMEOUT_MS = 5_000;
+
+  let apiKey: string | null = null;
+  try {
+    const credentialsFile = join(getPrismUserConfigDir(), "credentials.json");
+    if (existsSync(credentialsFile)) {
+      const value: unknown = JSON.parse(readFileSync(credentialsFile, "utf-8"));
+      if (
+        typeof value === "object" &&
+        value !== null &&
+        typeof (value as Record<string, unknown>).apiKey === "string"
+      ) {
+        apiKey = (value as { apiKey: string }).apiKey;
+      }
+    }
+  } catch {
+    // No credentials — nothing to report.
+  }
+
+  if (!apiKey) return;
+
+  fetch(`${baseUrl}/v1/agent-status/report`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ status, positions, pnl }),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  }).then(
+    (response) => {
+      if (!response.ok) {
+        statusLogger.warn("Engine status report rejected", {
+          status: response.status,
+        });
+      }
+    },
+    (error: unknown) => {
+      statusLogger.warn("Engine status report failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+  );
+}
 
 /**
  * How far back to look for a previous pool snapshot when computing TVL
@@ -2838,8 +2900,17 @@ export const program = Effect.gen(function* () {
           console.info("[snapshot-retention] Pruned old pool snapshots", {
             pruned,
             retentionDays: config.snapshotRetentionDays,
-          });
+          });          }
         }
+
+      // Report engine status to the Prism Cloud API after every scan cycle.
+      {
+        const positions = buildPositionSnapshots(trackedPositions.values());
+        const pnl = positions.reduce(
+          (sum, p) => sum + (p.currentValueUsd - p.depositedUsd),
+          0,
+        );
+        postEngineStatus("running", trackedPositions.size, pnl);
       }
 
       scanCount += 1;


### PR DESCRIPTION
The Telegram bot `/status` command always returned `Status: not_running`, `Active Positions: 0`, `P&L: $0.00` because the `/v1/agent-status` endpoint was a hardcoded placeholder.

**Root cause:** The Cloudflare API worker had no way to know whether the engine was running locally — `agentStatusHandler` always returned default values.

**Fix (two-part):**
1. **Cloudflare API** — Added `POST /v1/agent-status/report` that accepts authenticated engine status reports and stores them in KV with a 30-minute TTL. Updated `agentStatusHandler` to query KV for the latest reported status.
2. **Engine** — Added `postEngineStatus()` that reads the API key from credentials and POSTs current state to the API after each scan cycle (running, active positions count, unrealized PnL). Fire-and-forget so transient errors never block the loop.

**Review fixes (commit `9f932ad`):**
- `postEngineStatus` now runs fully inside the Effect-TS boundary (FS read via `Effect.sync`, HTTP via `Effect.tryPromise`), matching the `reportFeeCollection` fire-and-forget pattern. Failures become recoverable Effect causes instead of leaking through program flow.
- Per-cycle PnL now includes `cumulativeFeesClaimedUsd` + `cumulativeRewardsClaimedUsd` (the canonical unrealized-PnL formula from `engine/pnl.ts`), instead of only `currentValueUsd − depositedUsd`.
- `gracefulShutdown` now awaits a final `"stopped"` heartbeat (4-second hard timeout) before `process.exit(0)` so Telegram doesn't serve stale `"running"` for the full 30-minute KV TTL after shutdown.
- `storeStatus` in the Cloudflare API worker now logs KV write failures instead of silently swallowing them.

## Summary

KV-backed engine heartbeat wired through the existing Cloudflare auth + bot pipeline; Telegram `/status` now serves real running state, position count, and P&L.

## Testing

- [x] `bunx tsc --noEmit` (engine) — clean
- [x] `bun run --cwd cloudflare typecheck` — worker half clean (`infra/` alchemy dep pre-existing gap)
- [x] `bunx oxlint engine/program.ts cloudflare/workers/api/index.ts` — clean

## Risk

- [x] Medium — engine loop + shutdown path changed; fire-and-forget fetch semantics preserved (no blocking).

## Follow-ups

- `infra/` alchemy dependency needs `cd cloudflare && bun install` to restore the chained typecheck fully (pre-existing, unrelated).

---

## Second-round review fix (commit `65e45b8`)

The Codex P2 comment on `program.ts:5842` correctly noted that the first revision posted `"stopped"` only from the engine's `gracefulShutdown` — but under the supported `prism dev` path, `cli/dev.ts` registered its **own** `SIGINT`/`SIGTERM` handlers *before* the engine and called `process.exit` immediately. Listeners fire in registration order, so the CLI exited before the engine could post `"stopped"`, leaving Telegram showing a stale `"running"` until the 30-minute KV TTL.

**Fix:** Removed the eager `SIGINT`/`SIGTERM` handlers from `cli/dev.ts` so the engine owns those signals (its `gracefulShutdown` posts the `"stopped"` heartbeat and disconnects before exiting). Kept only the `"exit"` hook for lockfile release. Verified `cli-dev-lockfile` and `cli-dev-telemetry` suites still pass (14 tests), `tsc --noEmit` and `oxlint` clean.
