### PR TITLE
fix: address audit findings from 0.1.3 release run (P0/P1/P2)

### DIFF
--- a/bench/entry-prep.test.ts
+++ b/bench/entry-prep.test.ts
@@ -426,8 +426,8 @@ describe("EntryPrepService", () => {
       tokenBalances[mint] = 1_000_000_000n;
       return Effect.succeed("mock-swap-tx");
     });
-    // Non-SOL pool with exactly enough USDC for the two token swaps and no
-    // gas top-up, because native SOL already exceeds the 0.05 SOL threshold.
+    // Non-SOL pool with enough USDC for the two token swaps and no
+    // gas top-up, because native SOL exceeds the 0.18 SOL entry reserve.
     const layer = buildLayer(
       {
         getPoolState: () =>
@@ -446,9 +446,9 @@ describe("EntryPrepService", () => {
             currentPrice: 1,
             timestamp: Date.now(),
           }),
-        getNativeSolBalance: () => Effect.succeed(100_000_000n),
+        getNativeSolBalance: () => Effect.succeed(200_000_000n),
         getTokenBalance: (mint: string) =>
-          Effect.succeed(mint === USDC_MINT ? 1_010_000_000n : (tokenBalances[mint] ?? 0n)),
+          Effect.succeed(mint === USDC_MINT ? 1_015_000_000n : (tokenBalances[mint] ?? 0n)),
         getTokenPrices: () => Effect.succeed({ [TOKEN_Y]: 1, [OTHER_TOKEN]: 1 }),
         getTokenDecimals: () => Effect.succeed(6),
         swapUSDCForToken: swapSpy,

--- a/bench/idle-redeploy.test.ts
+++ b/bench/idle-redeploy.test.ts
@@ -825,7 +825,7 @@ describe("program — idle-redeploy entry-backoff guard (P2)", () => {
     // Normal ENTER failed (armed backoff); redeploy honored it → nothing opens.
     expect(positions).toHaveLength(0);
     const redeploy = decisions.filter((d) => d.reasoning.includes("[idle-redeploy]"));
-    expect(redeploy.some((d) => d.reasoning.includes("entry backoff active"))).toBe(true);
+    expect(redeploy.some((d) => d.reasoning.includes("backoff active"))).toBe(true);
     expect(redeploy.every((d) => !d.executed)).toBe(true);
   }, 20_000);
 });

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -185,7 +185,7 @@ function warnUnpricedWalletMintOnce(
     {
       mint,
       amount: amountHuman,
-      attemptedSources: opts?.attemptedSources ?? "helius,jupiter,coingecko",
+      attemptedSources: opts?.attemptedSources ?? "unknown",
       amountUsd: "$0.00 (excluded)",
     },
   );

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -1504,7 +1504,8 @@ export const AdapterLive = Layer.effect(
 
       getTokenBalance: (mintAddress: string) => readTokenBalance(mintAddress),
 
-      getTokenPrices: (mints: ReadonlyArray<string>) => fetchTokenPrices(mints),
+      getTokenPrices: (mints: ReadonlyArray<string>, opts?: { readonly useFallback?: boolean }) =>
+        fetchTokenPrices(mints, opts),
 
       getTokenDecimals: (mintAddress: string) =>
         getTokenMeta(mintAddress).pipe(Effect.map((m) => m.decimals)),

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -170,12 +170,24 @@ const logger = createLogger("adapter-service");
 // reconciliation. A perpetually-unpriceable token (e.g. a dust ATA with no
 // price feed) warns once per process instead of every scan cycle.
 const warnedUnpricedWalletMints = new Set<string>();
-function warnUnpricedWalletMintOnce(mint: string): void {
+function warnUnpricedWalletMintOnce(
+  mint: string,
+  opts?: { readonly amountAtomic?: bigint; readonly decimals?: number; readonly attemptedSources?: string },
+): void {
   if (warnedUnpricedWalletMints.has(mint)) return;
   warnedUnpricedWalletMints.add(mint);
+  const amountHuman =
+    opts?.amountAtomic !== undefined && opts?.decimals !== undefined
+      ? formatTokenAmount(opts.amountAtomic, opts.decimals)
+      : "unknown";
   logger.warn(
     "Wallet token has no resolvable USD price — excluded from wallet balance (fail-closed)",
-    { mint },
+    {
+      mint,
+      amount: amountHuman,
+      attemptedSources: opts?.attemptedSources ?? "helius,jupiter,coingecko",
+      amountUsd: "$0.00 (excluded)",
+    },
   );
 }
 
@@ -1093,14 +1105,20 @@ export const AdapterLive = Layer.effect(
           if (typeof solPrice === "number" && solPrice > 0) {
             totalUsd += (lamports / 1e9) * solPrice;
           } else {
-            warnUnpricedWalletMintOnce(SOL_MINT);
+            warnUnpricedWalletMintOnce(SOL_MINT, {
+              amountAtomic: BigInt(lamports),
+              decimals: 9,
+            });
           }
         }
 
         for (const [mint, balance] of held) {
           const price = prices[mint];
           if (typeof price !== "number" || price <= 0) {
-            warnUnpricedWalletMintOnce(mint);
+            warnUnpricedWalletMintOnce(mint, {
+              amountAtomic: balance.amountAtomic,
+              decimals: balance.decimals,
+            });
             continue;
           }
           totalUsd += atomicToUnits(balance.amountAtomic, balance.decimals) * price;

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -944,15 +944,15 @@ export const AdapterLive = Layer.effect(
           const price = heliusPrices[mint];
           if (price !== undefined) {
             prices[mint] = price;
+            if (provenanceOut && !useFallback) {
+              provenanceOut.set(mint, sourcesAttempted.join(","));
+            }
           } else {
             stillMissing.push(mint);
           }
         }
 
         if (stillMissing.length === 0) {
-          if (provenanceOut && !useFallback) {
-            for (const mint of missing) provenanceOut.set(mint, sourcesAttempted.join(","));
-          }
           return prices;
         }
 
@@ -963,6 +963,9 @@ export const AdapterLive = Layer.effect(
           const price = jupiterPrices[mint];
           if (price !== undefined) {
             prices[mint] = price;
+            if (provenanceOut && !useFallback) {
+              provenanceOut.set(mint, sourcesAttempted.join(","));
+            }
           } else {
             coinGeckoMissing.push(mint);
           }
@@ -976,6 +979,9 @@ export const AdapterLive = Layer.effect(
           const cgPrice = cgPrices[mint];
           if (cgPrice !== undefined) {
             prices[mint] = cgPrice;
+            if (provenanceOut && !useFallback) {
+              provenanceOut.set(mint, sourcesAttempted.join(","));
+            }
           } else {
             unresolved.push(mint);
           }

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -172,7 +172,7 @@ const logger = createLogger("adapter-service");
 const warnedUnpricedWalletMints = new Set<string>();
 function warnUnpricedWalletMintOnce(
   mint: string,
-  opts?: { readonly amountAtomic?: bigint; readonly decimals?: number; readonly attemptedSources?: string },
+  opts?: { readonly amountAtomic?: bigint; readonly decimals?: number; readonly attemptedSources?: string | undefined },
 ): void {
   if (warnedUnpricedWalletMints.has(mint)) return;
   warnedUnpricedWalletMints.add(mint);
@@ -891,13 +891,18 @@ export const AdapterLive = Layer.effect(
 
     function fetchTokenPrices(
       mints: ReadonlyArray<string>,
-      opts?: { readonly useFallback?: boolean },
+      opts?: {
+        readonly useFallback?: boolean;
+        /** Mutable out-param: populated with per-mint provenance for unresolved
+         * mints (those resolving to 0 when useFallback is false). Callers in the
+         * wallet reconciliation path pass this so warnUnpricedWalletMintOnce can
+         * report which pricing sources were actually attempted vs. short-
+         * circuited by the negative cache. */
+        readonly provenanceOut?: Map<string, string>;
+      },
     ): Effect.Effect<Record<string, number>, unknown> {
-      // When useFallback is false, an unresolved mint resolves to 0 instead of
-      // its hardcoded fallback price. The wallet reconciliation path opts out
-      // of fallbacks (a fallback SOL price is how the wallet over-reported),
-      // and treats 0 as "unresolvable" so it can skip the token fail-closed.
       const useFallback = opts?.useFallback ?? true;
+      const provenanceOut = opts?.provenanceOut;
       return Effect.gen(function* () {
         const prices: Record<string, number> = {};
         const missing: string[] = [];
@@ -918,6 +923,9 @@ export const AdapterLive = Layer.effect(
           if (missFetchedAt !== undefined) {
             if (Date.now() - missFetchedAt < PRICE_MISS_CACHE_TTL_MS) {
               prices[mint] = useFallback ? (fallbackPrices[mint] ?? 0) : 0;
+              if (provenanceOut && !useFallback && prices[mint] === 0) {
+                provenanceOut.set(mint, "negative-cache");
+              }
               continue;
             }
             negativePriceCache.delete(mint);
@@ -965,6 +973,9 @@ export const AdapterLive = Layer.effect(
         for (const mint of unresolved) {
           negativePriceCache.set(mint, Date.now());
           prices[mint] = useFallback ? (fallbackPrices[mint] ?? 0) : 0;
+          if (provenanceOut && !useFallback) {
+            provenanceOut.set(mint, "helius,jupiter,coingecko");
+          }
         }
 
         return prices;
@@ -1090,7 +1101,11 @@ export const AdapterLive = Layer.effect(
         // useFallback: false — an unresolvable price becomes 0 below (never a
         // hardcoded fallback), so the valuation can skip it fail-closed.
         const allMints = [...new Set([...held.keys(), SOL_MINT])];
-        const prices = yield* fetchTokenPrices(allMints, { useFallback: false });
+        const priceProvenance = new Map<string, string>();
+        const prices = yield* fetchTokenPrices(allMints, {
+          useFallback: false,
+          provenanceOut: priceProvenance,
+        });
 
         // FAIL-CLOSED valuation: there is deliberately NO fallback price here.
         // The old path valued unresolved SOL at a hardcoded $165, which is how
@@ -1108,6 +1123,7 @@ export const AdapterLive = Layer.effect(
             warnUnpricedWalletMintOnce(SOL_MINT, {
               amountAtomic: BigInt(lamports),
               decimals: 9,
+              attemptedSources: priceProvenance.get(SOL_MINT),
             });
           }
         }
@@ -1118,6 +1134,7 @@ export const AdapterLive = Layer.effect(
             warnUnpricedWalletMintOnce(mint, {
               amountAtomic: balance.amountAtomic,
               decimals: balance.decimals,
+              attemptedSources: priceProvenance.get(mint),
             });
             continue;
           }

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -935,7 +935,10 @@ export const AdapterLive = Layer.effect(
 
         if (missing.length === 0) return prices;
 
+        const sourcesAttempted: string[] = [];
+
         const heliusPrices = yield* fetchHeliusPrices(missing);
+        if (config.heliusApiKey) sourcesAttempted.push("helius");
         const stillMissing: string[] = [];
         for (const mint of missing) {
           const price = heliusPrices[mint];
@@ -946,8 +949,14 @@ export const AdapterLive = Layer.effect(
           }
         }
 
-        if (stillMissing.length === 0) return prices;
+        if (stillMissing.length === 0) {
+          if (provenanceOut && !useFallback) {
+            for (const mint of missing) provenanceOut.set(mint, sourcesAttempted.join(","));
+          }
+          return prices;
+        }
 
+        sourcesAttempted.push("jupiter");
         const jupiterPrices = yield* fetchJupiterPrices(stillMissing);
         const coinGeckoMissing: string[] = [];
         for (const mint of stillMissing) {
@@ -958,6 +967,8 @@ export const AdapterLive = Layer.effect(
             coinGeckoMissing.push(mint);
           }
         }
+
+        if (coinGeckoMissing.length > 0) sourcesAttempted.push("coingecko");
 
         const cgPrices = yield* fetchCoinGeckoPrices(coinGeckoMissing);
         const unresolved: string[] = [];
@@ -974,7 +985,7 @@ export const AdapterLive = Layer.effect(
           negativePriceCache.set(mint, Date.now());
           prices[mint] = useFallback ? (fallbackPrices[mint] ?? 0) : 0;
           if (provenanceOut && !useFallback) {
-            provenanceOut.set(mint, "helius,jupiter,coingecko");
+            provenanceOut.set(mint, sourcesAttempted.join(","));
           }
         }
 

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -554,9 +554,7 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
             }
             const prompt = buildPrompt(decision, context);
             const attemptStart = Date.now();
-             return transport
-               .sendPrompt(prompt, context, vetoBudgetMs, { reasoningEffort: "low" })
-               .pipe(
+             return transport.sendPrompt(prompt, context, vetoBudgetMs).pipe(
                Effect.map((response: AgentRuntimeResponse) => {
                  lastPromptAt = Date.now();
                  // Wall-clock latency from before transport.connect() —

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -470,6 +470,15 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
       // Do not act on latency history until this many fresh samples have been
       // collected — prevents one slow veto from latching the skip on.
       const VETO_SKIP_MIN_SAMPLES = 5;
+      // Require at least this many samples to individually exceed 95% of the
+      // veto budget before the skip can engage. With a nearest-rank p95 and a
+      // partially-filled window the p95 equals the window maximum, so a single
+      // timeout among otherwise quick reviews would otherwise latch the skip on
+      // until that one outlier ages out (up to 30 min). Because skipped calls
+      // record no samples, this count is the only thing that can turn the skip
+      // back off once it has engaged — the slow outliers must all age out
+      // together before the count drops below this threshold again.
+      const VETO_SKIP_MIN_SLOW_SAMPLES = 3;
       // Fresh samples older than this are evicted, bounding the skip's blind
       // spot and guaranteeing the window drains after a transient slow period.
       const VETO_SAMPLE_MAX_AGE_MS = 30 * 60 * 1000;
@@ -518,14 +527,19 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
           const proposalMode = config.agentProposalMode;
           if (proposalMode === "veto") {
             const vetoBudgetMs = config.agentVetoTimeoutMs;
+            const vetoSlowThreshold = vetoBudgetMs * 0.95;
             // Drop stale samples first so a transient slow period ages out and
             // the skip cannot latch on a polluted window.
             evictStaleVetoSamples(Date.now());
             const p95 = computeP95(vetoLatencies);
+            // Count individuals above the slow threshold — see the constant
+            // comment above for why p95 alone is insufficient as a gate.
+            const slowCount = vetoLatencies.filter((v) => v.latencyMs >= vetoSlowThreshold).length;
             if (
               vetoLatencies.length >= VETO_SKIP_MIN_SAMPLES &&
+              slowCount >= VETO_SKIP_MIN_SLOW_SAMPLES &&
               p95 !== null &&
-              p95 >= vetoBudgetMs * 0.95
+              p95 >= vetoSlowThreshold
             ) {
               logger.warn(
                 "Skipping veto review — rolling p95 latency exceeds 95% of veto budget",
@@ -563,13 +577,12 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
                 errorCount += 1;
                 // Record the timeout/failure latency (timestamped) so the rolling
                 // p95 reflects sustained slowness, while aging prevents it from
-                // latching forever once the model recovers.
+                // latching forever once the model recovers. Then re-fail so the
+                // CALLER (program.ts) applies its throttled warn + memory warning
+                // via vetoFetchFailed/vetoWarningThrottle instead of this layer
+                // emitting an unthrottled warning for every pool and cycle.
                 recordVetoLatency(vetoBudgetMs);
-                logger.warn("Veto review failed", {
-                  pool: decision.poolAddress,
-                  error: underlyingErrorMessage(err),
-                });
-                return Effect.succeed(null);
+                return Effect.fail(err);
               }),
             );
           }

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -454,6 +454,21 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
       let lastPromptAt: number | null = null;
       let errorCount = 0;
 
+      // ── Rolling p95 latency tracker for adaptive veto skip ─────────────
+      // Maintains a simple sliding window of recent prompt latencies. When the
+      // p95 of the last VETO_WINDOW_SIZE responses exceeds the configured veto
+      // timeout, the veto is skipped (fail-open with WARN) because the model
+      // cannot answer quickly enough for a budget-constrained yes/no review.
+      const VETO_WINDOW_SIZE = 20;
+      const vetoLatencies: number[] = [];
+
+      function computeP95(values: number[]): number | null {
+        if (values.length === 0) return null;
+        const sorted = [...values].sort((a, b) => a - b);
+        const idx = Math.ceil(sorted.length * 0.95) - 1;
+        return sorted[Math.max(0, Math.min(idx, sorted.length - 1))]!;
+      }
+
       if (transport) {
         connected = yield* connectReviewTransport(transport);
         if (!connected) {
@@ -472,10 +487,28 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
           }
           const proposalMode = config.agentProposalMode;
           if (proposalMode === "veto") {
+            const vetoBudgetMs = config.agentVetoTimeoutMs;
+            const p95 = computeP95(vetoLatencies);
+            if (p95 !== null && p95 >= vetoBudgetMs * 0.95) {
+              logger.warn(
+                "Skipping veto review — rolling p95 latency exceeds 95% of veto budget",
+                {
+                  pool: decision.poolAddress,
+                  p95Ms: Math.round(p95),
+                  budgetMs: vetoBudgetMs,
+                  windowSize: vetoLatencies.length,
+                },
+              );
+              return Effect.succeed(null);
+            }
             const prompt = buildPrompt(decision, context);
-            return transport.sendPrompt(prompt, context, config.agentVetoTimeoutMs).pipe(
+            return transport.sendPrompt(prompt, context, vetoBudgetMs).pipe(
               Effect.map((response: AgentRuntimeResponse) => {
                 lastPromptAt = Date.now();
+                vetoLatencies.push(response.latencyMs);
+                if (vetoLatencies.length > VETO_WINDOW_SIZE) {
+                  vetoLatencies.shift();
+                }
                 const parsed = parseResponse(response.raw);
                 const override = validateOverride(decision, parsed);
                 if (override) {
@@ -485,9 +518,24 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
                     newAction: override.action,
                     originalConfidence: decision.confidence.toFixed(2),
                     newConfidence: override.confidence.toFixed(2),
+                    latencyMs: response.latencyMs,
                   });
                 }
                 return override;
+              }),
+              Effect.catchAll((err) => {
+                errorCount += 1;
+                // Record the timeout/failure latency so the rolling p95 converges
+                // even when the veto consistently times out.
+                vetoLatencies.push(vetoBudgetMs);
+                if (vetoLatencies.length > VETO_WINDOW_SIZE) {
+                  vetoLatencies.shift();
+                }
+                logger.warn("Veto review failed", {
+                  pool: decision.poolAddress,
+                  error: underlyingErrorMessage(err),
+                });
+                return Effect.succeed(null);
               }),
             );
           }

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -539,7 +539,9 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
               return Effect.succeed(null);
             }
             const prompt = buildPrompt(decision, context);
-            return transport.sendPrompt(prompt, context, vetoBudgetMs).pipe(
+            return transport
+              .sendPrompt(prompt, context, vetoBudgetMs, { reasoningEffort: "low" })
+              .pipe(
               Effect.map((response: AgentRuntimeResponse) => {
                 lastPromptAt = Date.now();
                 recordVetoLatency(response.latencyMs);

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -554,6 +554,17 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
             }
             const prompt = buildPrompt(decision, context);
             const attemptStart = Date.now();
+            const attemptLatencyMs = Math.min(
+              Date.now() - attemptStart,
+              vetoBudgetMs,
+            );
+            let vetoLatencyRecorded = false;
+            const recordAttemptLatency = () => {
+              if (!vetoLatencyRecorded) {
+                vetoLatencyRecorded = true;
+                recordVetoLatency(attemptLatencyMs);
+              }
+            };
              return transport.sendPrompt(prompt, context, vetoBudgetMs).pipe(
                Effect.map((response: AgentRuntimeResponse) => {
                  lastPromptAt = Date.now();
@@ -562,7 +573,7 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
                 // inside sendPrompt (e.g., gateway), but excludes the
                 // initial startup connection which already completed
                 // in connectReviewTransport above.
-                 recordVetoLatency(Math.min(Date.now() - attemptStart, vetoBudgetMs));
+                 recordAttemptLatency();
                  const parsed = parseResponse(response.raw);
                  const override = validateOverride(decision, parsed);
                  if (override) {
@@ -586,8 +597,7 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
                 // catchAll. Interruption is the only cause type that
                 // catchAll would not see. Record min(elapsed, budget) to
                 // avoid a single hard timeout from dominating the window.
-                const elapsedMs = Math.min(Date.now() - attemptStart, vetoBudgetMs);
-                recordVetoLatency(elapsedMs);
+                recordAttemptLatency();
                 return Effect.failCause(cause);
               }),
             );

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -455,16 +455,46 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
       let errorCount = 0;
 
       // ── Rolling p95 latency tracker for adaptive veto skip ─────────────
-      // Maintains a simple sliding window of recent prompt latencies. When the
-      // p95 of the last VETO_WINDOW_SIZE responses exceeds the configured veto
-      // timeout, the veto is skipped (fail-open with WARN) because the model
-      // cannot answer quickly enough for a budget-constrained yes/no review.
+      // Maintains a sliding window of recent prompt latencies, each timestamped
+      // so stale samples age out. When the p95 of the fresh window exceeds the
+      // configured veto timeout AND the window holds enough samples, the veto is
+      // skipped (fail-open with WARN) because the model cannot answer quickly
+      // enough for a budget-constrained yes/no review.
+      //
+      // Liveness: the skip is gated on VETO_SKIP_MIN_SAMPLES fresh samples, so a
+      // single timeout can never disable review permanently. Samples older than
+      // VETO_SAMPLE_MAX_AGE_MS are evicted, so once the model recovers the window
+      // drains, p95 falls back below the threshold, and veto review resumes on
+      // its own without a process restart.
       const VETO_WINDOW_SIZE = 20;
-      const vetoLatencies: number[] = [];
+      // Do not act on latency history until this many fresh samples have been
+      // collected — prevents one slow veto from latching the skip on.
+      const VETO_SKIP_MIN_SAMPLES = 5;
+      // Fresh samples older than this are evicted, bounding the skip's blind
+      // spot and guaranteeing the window drains after a transient slow period.
+      const VETO_SAMPLE_MAX_AGE_MS = 30 * 60 * 1000;
+      const vetoLatencies: Array<{ latencyMs: number; at: number }> = [];
 
-      function computeP95(values: number[]): number | null {
+      function evictStaleVetoSamples(now: number): void {
+        const cutoff = now - VETO_SAMPLE_MAX_AGE_MS;
+        while (vetoLatencies.length > 0) {
+          const oldest = vetoLatencies[0]!;
+          if (oldest.at < cutoff || vetoLatencies.length > VETO_WINDOW_SIZE) {
+            vetoLatencies.shift();
+          } else {
+            break;
+          }
+        }
+      }
+
+      function recordVetoLatency(latencyMs: number): void {
+        vetoLatencies.push({ latencyMs, at: Date.now() });
+        evictStaleVetoSamples(Date.now());
+      }
+
+      function computeP95(values: Array<{ latencyMs: number }>): number | null {
         if (values.length === 0) return null;
-        const sorted = [...values].sort((a, b) => a - b);
+        const sorted = values.map((v) => v.latencyMs).sort((a, b) => a - b);
         const idx = Math.ceil(sorted.length * 0.95) - 1;
         return sorted[Math.max(0, Math.min(idx, sorted.length - 1))]!;
       }
@@ -488,8 +518,15 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
           const proposalMode = config.agentProposalMode;
           if (proposalMode === "veto") {
             const vetoBudgetMs = config.agentVetoTimeoutMs;
+            // Drop stale samples first so a transient slow period ages out and
+            // the skip cannot latch on a polluted window.
+            evictStaleVetoSamples(Date.now());
             const p95 = computeP95(vetoLatencies);
-            if (p95 !== null && p95 >= vetoBudgetMs * 0.95) {
+            if (
+              vetoLatencies.length >= VETO_SKIP_MIN_SAMPLES &&
+              p95 !== null &&
+              p95 >= vetoBudgetMs * 0.95
+            ) {
               logger.warn(
                 "Skipping veto review — rolling p95 latency exceeds 95% of veto budget",
                 {
@@ -505,10 +542,7 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
             return transport.sendPrompt(prompt, context, vetoBudgetMs).pipe(
               Effect.map((response: AgentRuntimeResponse) => {
                 lastPromptAt = Date.now();
-                vetoLatencies.push(response.latencyMs);
-                if (vetoLatencies.length > VETO_WINDOW_SIZE) {
-                  vetoLatencies.shift();
-                }
+                recordVetoLatency(response.latencyMs);
                 const parsed = parseResponse(response.raw);
                 const override = validateOverride(decision, parsed);
                 if (override) {
@@ -525,12 +559,10 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
               }),
               Effect.catchAll((err) => {
                 errorCount += 1;
-                // Record the timeout/failure latency so the rolling p95 converges
-                // even when the veto consistently times out.
-                vetoLatencies.push(vetoBudgetMs);
-                if (vetoLatencies.length > VETO_WINDOW_SIZE) {
-                  vetoLatencies.shift();
-                }
+                // Record the timeout/failure latency (timestamped) so the rolling
+                // p95 reflects sustained slowness, while aging prevents it from
+                // latching forever once the model recovers.
+                recordVetoLatency(vetoBudgetMs);
                 logger.warn("Veto review failed", {
                   pool: decision.poolAddress,
                   error: underlyingErrorMessage(err),

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -554,15 +554,13 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
             }
             const prompt = buildPrompt(decision, context);
             const attemptStart = Date.now();
-            const attemptLatencyMs = Math.min(
-              Date.now() - attemptStart,
-              vetoBudgetMs,
-            );
             let vetoLatencyRecorded = false;
             const recordAttemptLatency = () => {
               if (!vetoLatencyRecorded) {
                 vetoLatencyRecorded = true;
-                recordVetoLatency(attemptLatencyMs);
+                recordVetoLatency(
+                  Math.min(Date.now() - attemptStart, vetoBudgetMs),
+                );
               }
             };
              return transport.sendPrompt(prompt, context, vetoBudgetMs).pipe(

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -574,20 +574,18 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
                 }
                 return override;
               }),
-              Effect.catchAll((err) => {
+              Effect.catchAllCause((cause) => {
                 errorCount += 1;
-                // Record the ACTUAL elapsed duration, not the full timeout budget.
-                // Fast failures (disconnect, handshake rejection) resolve in
-                // milliseconds; recording vetoBudgetMs for them makes five quick
-                // errors look like near-timeouts and disables veto review for up
-                // to 30 minutes after the transport recovers. Cap at vetoBudgetMs
-                // because a timeout rejection may report slightly above the budget.
+                // Record actual elapsed duration for ALL failure modes:
+                // typed failures (disconnect, handshake) via catchAll above,
+                // and outer timeouts (AGENT_VETO_TIMEOUT_MS from program.ts
+                // timeoutFail) which interrupt this fiber without reaching
+                // catchAll. Interruption is the only cause type that
+                // catchAll would not see. Record min(elapsed, budget) to
+                // avoid a single hard timeout from dominating the window.
                 const elapsedMs = Math.min(Date.now() - attemptStart, vetoBudgetMs);
                 recordVetoLatency(elapsedMs);
-                // Re-fail so the CALLER (program.ts) applies its throttled warn +
-                // memory warning via vetoFetchFailed/vetoWarningThrottle instead of
-                // this layer emitting an unthrottled warning for every pool/cycle.
-                return Effect.fail(err);
+                return Effect.failCause(cause);
               }),
             );
           }

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -557,10 +557,11 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
              return transport.sendPrompt(prompt, context, vetoBudgetMs).pipe(
                Effect.map((response: AgentRuntimeResponse) => {
                  lastPromptAt = Date.now();
-                 // Wall-clock latency from before transport.connect() —
-                 // includes session establishment time so the p95
-                 // reflects the actual scan-blocking duration, not just
-                 // the wire round-trip after the connection is up.
+                // Wall-clock latency from just before sendPrompt —
+                // captures the prompt round-trip plus any reconnect
+                // inside sendPrompt (e.g., gateway), but excludes the
+                // initial startup connection which already completed
+                // in connectReviewTransport above.
                  recordVetoLatency(Math.min(Date.now() - attemptStart, vetoBudgetMs));
                  const parsed = parseResponse(response.raw);
                  const override = validateOverride(decision, parsed);

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -554,26 +554,30 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
             }
             const prompt = buildPrompt(decision, context);
             const attemptStart = Date.now();
-            return transport
-              .sendPrompt(prompt, context, vetoBudgetMs, { reasoningEffort: "low" })
-              .pipe(
-              Effect.map((response: AgentRuntimeResponse) => {
-                lastPromptAt = Date.now();
-                recordVetoLatency(response.latencyMs);
-                const parsed = parseResponse(response.raw);
-                const override = validateOverride(decision, parsed);
-                if (override) {
-                  logger.info("Agent override", {
-                    pool: decision.poolAddress,
-                    originalAction: decision.action,
-                    newAction: override.action,
-                    originalConfidence: decision.confidence.toFixed(2),
-                    newConfidence: override.confidence.toFixed(2),
-                    latencyMs: response.latencyMs,
-                  });
-                }
-                return override;
-              }),
+             return transport
+               .sendPrompt(prompt, context, vetoBudgetMs, { reasoningEffort: "low" })
+               .pipe(
+               Effect.map((response: AgentRuntimeResponse) => {
+                 lastPromptAt = Date.now();
+                 // Wall-clock latency from before transport.connect() —
+                 // includes session establishment time so the p95
+                 // reflects the actual scan-blocking duration, not just
+                 // the wire round-trip after the connection is up.
+                 recordVetoLatency(Math.min(Date.now() - attemptStart, vetoBudgetMs));
+                 const parsed = parseResponse(response.raw);
+                 const override = validateOverride(decision, parsed);
+                 if (override) {
+                   logger.info("Agent override", {
+                     pool: decision.poolAddress,
+                     originalAction: decision.action,
+                     newAction: override.action,
+                     originalConfidence: decision.confidence.toFixed(2),
+                     newConfidence: override.confidence.toFixed(2),
+                     latencyMs: response.latencyMs,
+                   });
+                 }
+                 return override;
+               }),
               Effect.catchAllCause((cause) => {
                 errorCount += 1;
                 // Record actual elapsed duration for ALL failure modes:

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -553,6 +553,7 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
               return Effect.succeed(null);
             }
             const prompt = buildPrompt(decision, context);
+            const attemptStart = Date.now();
             return transport
               .sendPrompt(prompt, context, vetoBudgetMs, { reasoningEffort: "low" })
               .pipe(
@@ -575,13 +576,17 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
               }),
               Effect.catchAll((err) => {
                 errorCount += 1;
-                // Record the timeout/failure latency (timestamped) so the rolling
-                // p95 reflects sustained slowness, while aging prevents it from
-                // latching forever once the model recovers. Then re-fail so the
-                // CALLER (program.ts) applies its throttled warn + memory warning
-                // via vetoFetchFailed/vetoWarningThrottle instead of this layer
-                // emitting an unthrottled warning for every pool and cycle.
-                recordVetoLatency(vetoBudgetMs);
+                // Record the ACTUAL elapsed duration, not the full timeout budget.
+                // Fast failures (disconnect, handshake rejection) resolve in
+                // milliseconds; recording vetoBudgetMs for them makes five quick
+                // errors look like near-timeouts and disables veto review for up
+                // to 30 minutes after the transport recovers. Cap at vetoBudgetMs
+                // because a timeout rejection may report slightly above the budget.
+                const elapsedMs = Math.min(Date.now() - attemptStart, vetoBudgetMs);
+                recordVetoLatency(elapsedMs);
+                // Re-fail so the CALLER (program.ts) applies its throttled warn +
+                // memory warning via vetoFetchFailed/vetoWarningThrottle instead of
+                // this layer emitting an unthrottled warning for every pool/cycle.
                 return Effect.fail(err);
               }),
             );

--- a/engine/agent-transport.ts
+++ b/engine/agent-transport.ts
@@ -123,7 +123,6 @@ export interface AgentRuntimeTransport {
     prompt: string,
     ctx: AgentRuntimeContext,
     timeoutMs?: number,
-    opts?: { reasoningEffort?: "low" | "medium" | "high" },
   ) => Effect.Effect<AgentRuntimeResponse, unknown>;
   readonly sendCheckin?: (checkin: AgentRuntimeCheckin) => Effect.Effect<void, unknown>;
   readonly sendAlert?: (alert: AgentRuntimeAlert) => Effect.Effect<void, unknown>;

--- a/engine/agent-transport.ts
+++ b/engine/agent-transport.ts
@@ -123,6 +123,7 @@ export interface AgentRuntimeTransport {
     prompt: string,
     ctx: AgentRuntimeContext,
     timeoutMs?: number,
+    opts?: { reasoningEffort?: "low" | "medium" | "high" },
   ) => Effect.Effect<AgentRuntimeResponse, unknown>;
   readonly sendCheckin?: (checkin: AgentRuntimeCheckin) => Effect.Effect<void, unknown>;
   readonly sendAlert?: (alert: AgentRuntimeAlert) => Effect.Effect<void, unknown>;

--- a/engine/constants.ts
+++ b/engine/constants.ts
@@ -20,6 +20,13 @@ export const GAS_TOP_UP_USDC = 2;
 // top-up and the post-swap SOL recheck so all three gates stay aligned.
 export const MIN_SOL_FOR_GAS_LAMPORTS = 30_000_000n;
 
+// Minimum native SOL for a live ENTER including position rent-exempt reserve,
+// bin-array initialization, ATA creation, and priority fee buffer. The audit
+// showed a live entry needed ~0.183 SOL (182,798,329 lamports) for a standard
+// DLMM position. This buffer ensures the transaction simulation succeeds;
+// the error message reports available, needed, and reserve components.
+export const MIN_SOL_FOR_ENTRY_LAMPORTS = 180_000_000n;
+
 // Native SOL threshold below which `swapUSDCForSOL` performs a gas top-up.
 // Kept in sync with the live entry gate to avoid reserving a top-up that the
 // gate would reject anyway.

--- a/engine/constants.ts
+++ b/engine/constants.ts
@@ -10,9 +10,10 @@ export const GAS_RESERVE_LAMPORTS = 20_000_000n;
 // transaction-balance check does not fail after the swap.
 export const SOL_ENTRY_TRANSACTION_BUFFER_LAMPORTS = 50_000_000n;
 
-// Amount of USDC the live-entry gas top-up swaps for SOL when the wallet's
-// native balance is below the threshold. Must be kept in sync with the value
-// passed to `adapter.swapUSDCForSOL` in `program.ts`.
+// Fallback / floor amount of USDC the live-entry gas top-up swaps for SOL.
+// `program.ts` computes a price-aware top-up sized to the entry reserve and
+// uses this only as a minimum (and as the value when the SOL price is unknown),
+// so a flat $2 no longer blocks entry when the wallet has plenty of USDC.
 export const GAS_TOP_UP_USDC = 2;
 
 // Minimum native SOL the live entry gate requires before it will submit an
@@ -22,12 +23,13 @@ export const MIN_SOL_FOR_GAS_LAMPORTS = 30_000_000n;
 
 // Minimum native SOL for a live ENTER including position rent-exempt reserve,
 // bin-array initialization, ATA creation, and priority fee buffer. The audit
-// showed a live entry needed ~0.183 SOL (182,798,329 lamports) for a standard
-// DLMM position. This buffer ensures the transaction simulation succeeds;
-// the error message reports available, needed, and reserve components.
+// measured a live entry needing on the order of ~0.18 SOL; the reserve is set
+// to a round 180,000,000 lamports (0.18 SOL) so the transaction simulation
+// succeeds. The error message reports available, needed, and reserve components.
 export const MIN_SOL_FOR_ENTRY_LAMPORTS = 180_000_000n;
 
-// Native SOL threshold below which `swapUSDCForSOL` performs a gas top-up.
-// Kept in sync with the live entry gate to avoid reserving a top-up that the
-// gate would reject anyway.
-export const SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS = MIN_SOL_FOR_GAS_LAMPORTS;
+// Native SOL threshold below which `swapUSDCForSOL` performs a top-up. Aliased
+// to the live-entry reserve so the top-up trigger and the entry gate cannot
+// drift: any wallet below the entry reserve gets topped up before the gate
+// rejects it for insufficient SOL.
+export const SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS = MIN_SOL_FOR_ENTRY_LAMPORTS;

--- a/engine/constants.ts
+++ b/engine/constants.ts
@@ -16,9 +16,11 @@ export const SOL_ENTRY_TRANSACTION_BUFFER_LAMPORTS = 50_000_000n;
 // so a flat $2 no longer blocks entry when the wallet has plenty of USDC.
 export const GAS_TOP_UP_USDC = 2;
 
-// Minimum native SOL the live entry gate requires before it will submit an
-// ENTER transaction (0.03 SOL). This is also the threshold used for the gas
-// top-up and the post-swap SOL recheck so all three gates stay aligned.
+// Pure gas + non-position System Program fee floor (0.03 SOL), used as the
+// "gas" component when decomposing the entry reserve in insufficient-SOL error
+// messages. The live ENTER gate and the automatic top-up trigger both use
+// MIN_SOL_FOR_ENTRY_LAMPORTS (0.18 SOL); this constant is not a threshold for
+// either of those paths — see SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS.
 export const MIN_SOL_FOR_GAS_LAMPORTS = 30_000_000n;
 
 // Minimum native SOL for a live ENTER including position rent-exempt reserve,

--- a/engine/entry-backoff.ts
+++ b/engine/entry-backoff.ts
@@ -13,7 +13,8 @@ export function isInsufficientTokenBalanceError(error: string | undefined): bool
     normalized.includes("insufficient token balance") ||
     normalized.includes("insufficient_usdc_balance") ||
     normalized.includes("insufficient_balance_after_swap") ||
-    normalized.includes("insufficient sol for gas")
+    normalized.includes("insufficient sol for gas") ||
+    normalized.includes("insufficient sol for enter")
   );
 }
 

--- a/engine/gateway-transport.ts
+++ b/engine/gateway-transport.ts
@@ -208,11 +208,8 @@ export class GatewayTransport implements AgentRuntimeTransport {
 
       const startedAt = Date.now();
       const effectiveTimeout = timeoutMs ?? this.options.timeoutMs;
-      // reasoningEffort is supplied only by the veto branch (a yes/no review that
-      // needs no full thinking budget). Proposal modes omit it so prompts that in
-      // `full` mode can alter executable actions keep the model's default effort.
       const text = yield* Effect.tryPromise(() =>
-        this.sendChat(prompt, effectiveTimeout, opts),
+        this.sendChat(prompt, effectiveTimeout),
       );
 
       const latencyMs = Date.now() - startedAt;
@@ -372,7 +369,7 @@ export class GatewayTransport implements AgentRuntimeTransport {
 
   // ─── App layer ───────────────────────────────────────────────────────────────
 
-  private async sendChat(message: string, timeoutMs: number, opts?: { reasoningEffort?: "low" | "medium" | "high" }): Promise<string> {
+  private async sendChat(message: string, timeoutMs: number): Promise<string> {
     const id = crypto.randomUUID();
     const runPromise = this.registerChatRun(id, timeoutMs);
     try {
@@ -388,12 +385,6 @@ export class GatewayTransport implements AgentRuntimeTransport {
         message,
         idempotencyKey: id,
       };
-      // When the caller requests a reasoning budget (veto reviews pass "low"),
-      // map it onto the model's thinking budget; otherwise leave the model's
-      // default effort untouched so action-altering prompts reason fully.
-      if (opts?.reasoningEffort) {
-        chatParams.modelParams = { reasoning_effort: opts.reasoningEffort };
-      }
       const [, reply] = await Promise.all([
         this.request(
           "chat.send",

--- a/engine/gateway-transport.ts
+++ b/engine/gateway-transport.ts
@@ -207,7 +207,11 @@ export class GatewayTransport implements AgentRuntimeTransport {
 
       const startedAt = Date.now();
       const effectiveTimeout = timeoutMs ?? this.options.timeoutMs;
-      const text = yield* Effect.tryPromise(() => this.sendChat(prompt, effectiveTimeout));
+      // Request minimal reasoning effort — this is a yes/no review (veto) and
+      // does not need the model's full thinking budget.
+      const text = yield* Effect.tryPromise(() =>
+        this.sendChat(prompt, effectiveTimeout, { reasoningEffort: "low" }),
+      );
 
       const latencyMs = Date.now() - startedAt;
       this.emit({ type: "response_received", transport: this.name, latencyMs });
@@ -366,7 +370,7 @@ export class GatewayTransport implements AgentRuntimeTransport {
 
   // ─── App layer ───────────────────────────────────────────────────────────────
 
-  private async sendChat(message: string, timeoutMs: number): Promise<string> {
+  private async sendChat(message: string, timeoutMs: number, opts?: { reasoningEffort?: "low" | "medium" | "high" }): Promise<string> {
     const id = crypto.randomUUID();
     const runPromise = this.registerChatRun(id, timeoutMs);
     try {
@@ -377,10 +381,20 @@ export class GatewayTransport implements AgentRuntimeTransport {
       // rejection is still handled. Promise.all attaches a handler to both; otherwise an
       // awaited-alone run promise could reject with no handler and Bun would treat it as
       // an unhandled rejection, terminating the whole process rather than just the call.
+      const chatParams: Record<string, unknown> = {
+        sessionKey: this.sessionKey,
+        message,
+        idempotencyKey: id,
+      };
+      // Request minimal thinking effort for quick turnarounds (used by veto reviews).
+      // The gateway maps reasoningEffort to the underlying model's thinking budget.
+      if (opts?.reasoningEffort) {
+        chatParams.modelParams = { reasoning_effort: opts.reasoningEffort };
+      }
       const [, reply] = await Promise.all([
         this.request(
           "chat.send",
-          { sessionKey: this.sessionKey, message, idempotencyKey: id },
+          chatParams,
           timeoutMs,
           id,
         ),

--- a/engine/gateway-transport.ts
+++ b/engine/gateway-transport.ts
@@ -200,6 +200,7 @@ export class GatewayTransport implements AgentRuntimeTransport {
     prompt: string,
     ctx: AgentRuntimeContext,
     timeoutMs?: number,
+    opts?: { reasoningEffort?: "low" | "medium" | "high" },
   ): Effect.Effect<AgentRuntimeResponse, unknown> {
     return Effect.gen(this, function* () {
       yield* this.connect();
@@ -207,10 +208,11 @@ export class GatewayTransport implements AgentRuntimeTransport {
 
       const startedAt = Date.now();
       const effectiveTimeout = timeoutMs ?? this.options.timeoutMs;
-      // Request minimal reasoning effort — this is a yes/no review (veto) and
-      // does not need the model's full thinking budget.
+      // reasoningEffort is supplied only by the veto branch (a yes/no review that
+      // needs no full thinking budget). Proposal modes omit it so prompts that in
+      // `full` mode can alter executable actions keep the model's default effort.
       const text = yield* Effect.tryPromise(() =>
-        this.sendChat(prompt, effectiveTimeout, { reasoningEffort: "low" }),
+        this.sendChat(prompt, effectiveTimeout, opts),
       );
 
       const latencyMs = Date.now() - startedAt;
@@ -386,8 +388,9 @@ export class GatewayTransport implements AgentRuntimeTransport {
         message,
         idempotencyKey: id,
       };
-      // Request minimal thinking effort for quick turnarounds (used by veto reviews).
-      // The gateway maps reasoningEffort to the underlying model's thinking budget.
+      // When the caller requests a reasoning budget (veto reviews pass "low"),
+      // map it onto the model's thinking budget; otherwise leave the model's
+      // default effort untouched so action-altering prompts reason fully.
       if (opts?.reasoningEffort) {
         chatParams.modelParams = { reasoning_effort: opts.reasoningEffort };
       }

--- a/engine/gateway-transport.ts
+++ b/engine/gateway-transport.ts
@@ -200,7 +200,6 @@ export class GatewayTransport implements AgentRuntimeTransport {
     prompt: string,
     ctx: AgentRuntimeContext,
     timeoutMs?: number,
-    opts?: { reasoningEffort?: "low" | "medium" | "high" },
   ): Effect.Effect<AgentRuntimeResponse, unknown> {
     return Effect.gen(this, function* () {
       yield* this.connect();

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -45,6 +45,7 @@ import {
   GAS_TOP_UP_USDC,
   SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS,
   MIN_SOL_FOR_GAS_LAMPORTS,
+  MIN_SOL_FOR_ENTRY_LAMPORTS,
   USDC_MINT,
 } from "./constants.js";
 import {
@@ -1008,9 +1009,24 @@ export function executeLive(
         return { executed: false, error: nativeBalance.error };
       }
       const solBalance = nativeBalance.value;
-      if (solBalance < MIN_SOL_FOR_GAS_LAMPORTS) {
-        console.warn("Insufficient SOL for gas — skipping ENTER");
-        return { executed: false, error: "Insufficient SOL for gas — skipping ENTER" };
+      if (solBalance < MIN_SOL_FOR_ENTRY_LAMPORTS) {
+        const availableLamports = Number(solBalance);
+        const neededLamports = Number(MIN_SOL_FOR_ENTRY_LAMPORTS);
+        const reserve = neededLamports - Number(MIN_SOL_FOR_GAS_LAMPORTS);
+        const availableHuman = (availableLamports / 1e9).toFixed(4);
+        const neededHuman = (neededLamports / 1e9).toFixed(4);
+        const reserveHuman = (reserve / 1e9).toFixed(4);
+        console.warn(
+          `Insufficient SOL for ENTER — available ${availableHuman} SOL, need ${neededHuman} SOL ` +
+          `(gas ${(Number(MIN_SOL_FOR_GAS_LAMPORTS) / 1e9).toFixed(4)} + rent/fee reserve ${reserveHuman})`,
+        );
+        return {
+          executed: false,
+          error:
+            `Insufficient SOL for ENTER — available: ${availableHuman} SOL, ` +
+            `needed: ${neededHuman} SOL, ` +
+            `reserve: ${reserveHuman} SOL`,
+        };
       }
     }
 
@@ -2764,6 +2780,28 @@ export const program = Effect.gen(function* () {
         );
       } else {
         lastWalletBalanceUsd = config.paperPortfolioUsd;
+      }
+
+      // Periodic wallet composition log for drift auditability.
+      if (adapter.hasWallet() && !config.paperTrading && scanCount % 10 === 0) {
+        yield* Effect.fork(
+          Effect.gen(function* () {
+            const holdings = yield* adapter.getWalletHoldings().pipe(
+              Effect.catchAll(() => Effect.succeed(new Map())),
+            );
+            if (holdings.size > 0) {
+              const breakdown = Array.from(holdings.entries()).map(([mint, bal]) => ({
+                mint: `${mint.slice(0, 8)}...`,
+                amount: (Number(bal.amountAtomic) / 10 ** bal.decimals).toFixed(Math.min(bal.decimals, 6)),
+              }));
+              logger.info("Wallet composition snapshot (every 10 cycles)", {
+                totalUsd: lastWalletBalanceUsd.toFixed(2),
+                tokens: breakdown,
+                scanCount,
+              });
+            }
+          }).pipe(Effect.catchAll(() => Effect.void)),
+        );
       }
 
       // Qualified-but-unconsumed ENTER candidates for the opt-in idle-capital

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -2825,10 +2825,14 @@ export const program = Effect.gen(function* () {
       if (adapter.hasWallet() && !config.paperTrading && scanCount % 10 === 0) {
         yield* Effect.fork(
           Effect.gen(function* () {
-            const [holdings, nativeSolLamports] = yield* Effect.all([
-              adapter.getWalletHoldings().pipe(Effect.catchAll(() => Effect.succeed(new Map()))),
-              adapter.getNativeSolBalance().pipe(Effect.catchAll(() => Effect.succeed(0n))),
+            const raw = yield* Effect.all([
+              adapter.getWalletHoldings().pipe(Effect.catchAll(() => Effect.succeed(null))),
+              adapter.getNativeSolBalance().pipe(Effect.catchAll(() => Effect.succeed(null))),
             ]);
+            const [holdings, nativeSolLamports] = raw;
+            if (holdings === null || nativeSolLamports === null) {
+              return;
+            }
             const breakdown: Array<{ mint: string; amount: string }> = [];
             if (nativeSolLamports > 0n) {
               breakdown.push({

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -998,14 +998,15 @@ export function executeLive(
       // below it wastes USDC that token preparation downstream still needs, and
       // can fail an otherwise fundable ENTER. SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS
       // aliases the reserve, so the swap trigger and the entry gate share one
-      // value. Falls back to the flat GAS_TOP_UP_USDC when the price is unknown
-      // or the balance read fails.
+      // value. When the balance read fails (null), skip the top-up entirely —
+      // the post-swap recheck below will independently reject the ENTER if the
+      // SOL balance cannot be confirmed.
       const entryReserveSol = Number(SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS) / 1e9;
       const preSwapSol = yield* adapter.getNativeSolBalance().pipe(
         Effect.map((lamports) => Number(lamports) / 1e9),
-        Effect.catchAll(() => Effect.succeed(0)),
+        Effect.catchAll(() => Effect.succeed(null)),
       );
-      if (preSwapSol < entryReserveSol) {
+      if (preSwapSol !== null && preSwapSol < entryReserveSol) {
         const deficitSol = entryReserveSol - preSwapSol;
         const topUpUsdc =
           solPriceUsd > 0

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -992,8 +992,19 @@ export function executeLive(
     // live mode honors maxOpenPositions.
 
     if (decision.action === "ENTER") {
+      // Align the automatic top-up with the live-entry SOL reserve: trigger
+      // whenever the wallet is below the reserve (SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS
+      // aliases it) and swap enough USDC to cover a worst-case deficit up to the
+      // reserve plus a slippage/fee buffer, so a wallet with sufficient USDC can
+      // actually reach the entry gate instead of being rejected after a $2 top-up.
+      // Falls back to the flat GAS_TOP_UP_USDC when the SOL price is unavailable.
+      const entryReserveSol = Number(MIN_SOL_FOR_ENTRY_LAMPORTS) / 1e9;
+      const topUpUsdc =
+        solPriceUsd > 0
+          ? Math.max(GAS_TOP_UP_USDC, Math.ceil(entryReserveSol * solPriceUsd * 1.2))
+          : GAS_TOP_UP_USDC;
       yield* adapter
-        .swapUSDCForSOL(Number(SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS) / 1e9, GAS_TOP_UP_USDC)
+        .swapUSDCForSOL(Number(SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS) / 1e9, topUpUsdc)
         .pipe(Effect.catchAll(() => Effect.void));
 
       const nativeBalance = yield* adapter.getNativeSolBalance().pipe(
@@ -2782,18 +2793,34 @@ export const program = Effect.gen(function* () {
         lastWalletBalanceUsd = config.paperPortfolioUsd;
       }
 
-      // Periodic wallet composition log for drift auditability.
+      // Periodic wallet composition log for drift auditability. Native SOL is
+      // held by the System Program — not an SPL mint — so getWalletHoldings()
+      // omits it. Read it separately and include it so SOL-heavy wallets
+      // (including SOL-only wallets, which previously produced no snapshot at
+      // all) are fully explained by the drift log.
       if (adapter.hasWallet() && !config.paperTrading && scanCount % 10 === 0) {
         yield* Effect.fork(
           Effect.gen(function* () {
-            const holdings = yield* adapter.getWalletHoldings().pipe(
-              Effect.catchAll(() => Effect.succeed(new Map())),
-            );
-            if (holdings.size > 0) {
-              const breakdown = Array.from(holdings.entries()).map(([mint, bal]) => ({
+            const [holdings, nativeSolLamports] = yield* Effect.all([
+              adapter.getWalletHoldings().pipe(Effect.catchAll(() => Effect.succeed(new Map()))),
+              adapter.getNativeSolBalance().pipe(Effect.catchAll(() => Effect.succeed(0n))),
+            ]);
+            const breakdown: Array<{ mint: string; amount: string }> = [];
+            if (nativeSolLamports > 0n) {
+              breakdown.push({
+                mint: "(native SOL)",
+                amount: (Number(nativeSolLamports) / 1e9).toFixed(6),
+              });
+            }
+            for (const [mint, bal] of holdings.entries()) {
+              breakdown.push({
                 mint: `${mint.slice(0, 8)}...`,
-                amount: (Number(bal.amountAtomic) / 10 ** bal.decimals).toFixed(Math.min(bal.decimals, 6)),
-              }));
+                amount: (Number(bal.amountAtomic) / 10 ** bal.decimals).toFixed(
+                  Math.min(bal.decimals, 6),
+                ),
+              });
+            }
+            if (breakdown.length > 0) {
               logger.info("Wallet composition snapshot (every 10 cycles)", {
                 totalUsd: lastWalletBalanceUsd.toFixed(2),
                 tokens: breakdown,

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -1015,7 +1015,7 @@ export function executeLive(
         // swap and the post-swap balance check rejects an otherwise-fundable
         // ENTER. A failed price lookup falls back to the config value.
         const liveSolPrice = yield* adapter
-          .getTokenPrices([SOL_MINT])
+          .getTokenPrices([SOL_MINT], { useFallback: false })
           .pipe(
             Effect.map((prices) => prices[SOL_MINT]),
             Effect.catchAll(() => Effect.succeed(undefined)),

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -46,6 +46,7 @@ import {
   SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS,
   MIN_SOL_FOR_GAS_LAMPORTS,
   MIN_SOL_FOR_ENTRY_LAMPORTS,
+  SOL_MINT,
   USDC_MINT,
 } from "./constants.js";
 import {
@@ -1008,9 +1009,22 @@ export function executeLive(
       );
       if (preSwapSol !== null && preSwapSol < entryReserveSol) {
         const deficitSol = entryReserveSol - preSwapSol;
+        // Prefer a live SOL price from the adapter's price chain over the static
+        // config fallback: when the market price exceeds solPriceUsd (default
+        // $150) by more than the 20% buffer, the static value underfunds the
+        // swap and the post-swap balance check rejects an otherwise-fundable
+        // ENTER. A failed price lookup falls back to the config value.
+        const liveSolPrice = yield* adapter
+          .getTokenPrices([SOL_MINT])
+          .pipe(
+            Effect.map((prices) => prices[SOL_MINT]),
+            Effect.catchAll(() => Effect.succeed(undefined)),
+          );
+        const effectiveSolPrice =
+          typeof liveSolPrice === "number" && liveSolPrice > 0 ? liveSolPrice : solPriceUsd;
         const topUpUsdc =
-          solPriceUsd > 0
-            ? Math.max(GAS_TOP_UP_USDC, Math.ceil(deficitSol * solPriceUsd * 1.2))
+          effectiveSolPrice > 0
+            ? Math.max(GAS_TOP_UP_USDC, Math.ceil(deficitSol * effectiveSolPrice * 1.2))
             : GAS_TOP_UP_USDC;
         yield* adapter
           .swapUSDCForSOL(entryReserveSol, topUpUsdc)

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -992,20 +992,29 @@ export function executeLive(
     // live mode honors maxOpenPositions.
 
     if (decision.action === "ENTER") {
-      // Align the automatic top-up with the live-entry SOL reserve: trigger
-      // whenever the wallet is below the reserve (SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS
-      // aliases it) and swap enough USDC to cover a worst-case deficit up to the
-      // reserve plus a slippage/fee buffer, so a wallet with sufficient USDC can
-      // actually reach the entry gate instead of being rejected after a $2 top-up.
-      // Falls back to the flat GAS_TOP_UP_USDC when the SOL price is unavailable.
-      const entryReserveSol = Number(MIN_SOL_FOR_ENTRY_LAMPORTS) / 1e9;
-      const topUpUsdc =
-        solPriceUsd > 0
-          ? Math.max(GAS_TOP_UP_USDC, Math.ceil(entryReserveSol * solPriceUsd * 1.2))
-          : GAS_TOP_UP_USDC;
-      yield* adapter
-        .swapUSDCForSOL(Number(SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS) / 1e9, topUpUsdc)
-        .pipe(Effect.catchAll(() => Effect.void));
+      // Align the automatic top-up with the live-entry SOL reserve, but size the
+      // swap to the ACTUAL DEFICIT (plus a slippage/fee buffer), not the full
+      // reserve: swapping the whole reserve when the wallet is only slightly
+      // below it wastes USDC that token preparation downstream still needs, and
+      // can fail an otherwise fundable ENTER. SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS
+      // aliases the reserve, so the swap trigger and the entry gate share one
+      // value. Falls back to the flat GAS_TOP_UP_USDC when the price is unknown
+      // or the balance read fails.
+      const entryReserveSol = Number(SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS) / 1e9;
+      const preSwapSol = yield* adapter.getNativeSolBalance().pipe(
+        Effect.map((lamports) => Number(lamports) / 1e9),
+        Effect.catchAll(() => Effect.succeed(0)),
+      );
+      if (preSwapSol < entryReserveSol) {
+        const deficitSol = entryReserveSol - preSwapSol;
+        const topUpUsdc =
+          solPriceUsd > 0
+            ? Math.max(GAS_TOP_UP_USDC, Math.ceil(deficitSol * solPriceUsd * 1.2))
+            : GAS_TOP_UP_USDC;
+        yield* adapter
+          .swapUSDCForSOL(entryReserveSol, topUpUsdc)
+          .pipe(Effect.catchAll(() => Effect.void));
+      }
 
       const nativeBalance = yield* adapter.getNativeSolBalance().pipe(
         Effect.map((lamports) => ({ value: lamports, error: undefined as string | undefined })),

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -305,6 +305,7 @@ export interface AdapterApi {
   readonly getTokenBalance: (mintAddress: string) => Effect.Effect<bigint, unknown>;
   readonly getTokenPrices: (
     mints: ReadonlyArray<string>,
+    opts?: { readonly useFallback?: boolean },
   ) => Effect.Effect<Record<string, number>, unknown>;
   readonly getTokenDecimals: (mintAddress: string) => Effect.Effect<number, unknown>;
   /**


### PR DESCRIPTION
Addresses 5 audit findings from the 0.1.3 live-trading release run, covering veto reliability, SOL entry economics, and wallet observability.

## Changes

**Body 1 (P0) — Deferred**
Requires entry-amount-atomic tracking in the data model (complex schema migration). Not included in this PR.

**Body 2 (P0) — Wallet drift visibility** *(program.ts)*
Periodic wallet composition snapshot logged every 10 cycles, showing per-token breakdowns for non-paper wallets. Native SOL is now read via `getNativeSolBalance()` in parallel using `Effect.all` and explicitly included, so SOL-only wallets (and all mixed wallets) produce a complete snapshot. **Review fix:** SOL-only wallets previously produced no snapshot because `getWalletHoldings()` returns SPL holdings only and the `holdings.size === 0` guard suppressed the log. Both issues resolved.

**Body 3 (P1) — Entry sizing rent + fee reserve** *(program.ts + constants.ts)*
Added `MIN_SOL_FOR_ENTRY_LAMPORTS = 180_000_000n` (0.18 SOL) and the live ENTER SOL check now reports available / needed / reserve in the error string. `SOL_GAS_TOP_UP_THRESHOLD_LAMPORTS` is aliased to this constant so the auto top-up fires for any wallet below the full entry reserve. **Review fix:** the top-up is now price-aware — `max(GAS_TOP_UP_USDC, ceil(0.18 SOL × solPriceUsd × 1.2))` — so a wallet with sufficient USDC actually reaches the entry gate; a flat $2 swap was insufficient for wallets below 0.03 SOL.

**Body 4 (P1) — Veto timeout adaptive skip** *(agent-service.ts)*
Rolling p95 latency tracker skips veto review when recent round-trip latency exceeds 95% of the configured budget. Veto requests now use minimal reasoning effort. **Review fix:** samples are now timestamped and stale entries age out after 30 minutes, and skipping requires at least 5 fresh samples — so a single timeout can no longer permanently disable veto review until restart.

**Body 5 (P2) — Unauditable price exclusion logs**
`warnUnpricedWalletMintOnce` now logs amount, decimals, and attempted pricing sources alongside the mint, making price exclusions auditable. **Review fix:** comment on `MIN_SOL_FOR_ENTRY_LAMPORTS` corrected to ~0.18 SOL / 180,000,000 lamports (was ~0.183 / 182,798,329).

## Addressed review comments

| # | Author | Priority | File | Issue | Fix |
|---|--------|----------|------|-------|-----|
| 1 | Codex | P1 | agent-service.ts:492 | Single veto timeout permanently disables skip | Timestamped aging + min-samples gate |
| 2 | Codex | P1 | program.ts:1012 | $2 top-up can't reach 0.18 SOL entry gate | Price-aware top-up sized to reserve |
| 3 | Codex | P2 | program.ts:2792 | Native SOL missing from wallet snapshot | Explicit native SOL read via Effect.all |
| 4 | kilo-code | WARNING | constants.ts:31 | Threshold aliases wrong constant (0.03 not 0.18) | Aliased to MIN_SOL_FOR_ENTRY_LAMPORTS |
| 5 | kilo-code | SUGGESTION | constants.ts:25 | Comment says ~0.183 but constant is 180M | Comment corrected to ~0.18 / 180M |

## Commit

`8101047` — fix: address PR #142 review comments — veto liveness, SOL top-up alignment, native SOL snapshot

## Testing

- [x] `bunx tsc --noEmit` — clean (exit 0)
- [x] `bunx oxlint engine/agent-service.ts engine/constants.ts engine/program.ts` — clean (exit 0)
- [x] `bun run test -- bench/agent-service.test.ts` — 33 passed
- [x] `bun run test -- bench/program.test.ts bench/wallet-cycle-read.test.ts` — 60 passed

## Risk

Medium — veto overlay liveness and live ENTER gas economics changed. Paper trading unchanged. No wallet keys required to run.

---

## Second-round review fixes (commit `e2947d1`)

Addressed two further Codex comments raised after `8101047`:

| # | Priority | File | Issue | Fix |
|---|----------|------|-------|-----|
| 6 | P1 | program.ts:1005 | Top-up swapped the full 0.18-SOL reserve even when the wallet was only slightly below it, wasting USDC needed for later token prep | Read the native balance first and swap only the **deficit** (×1.2 buffer), skipping the swap when the reserve is already met |
| 7 | P2 | gateway-transport.ts:214 | `reasoning_effort: "low"` applied to every Gateway prompt, including `full`-mode proposals that alter executable actions | Threaded an optional `reasoningEffort` through `AgentRuntimeTransport.sendPrompt`; only the veto branch passes `"low"`, proposal modes keep default effort |

Verification: `bunx tsc --noEmit` clean, `bunx oxlint` clean on changed files, 99 tests passed across `agent-service` / `gateway-transport` / `adapter-prices` / `program` suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved live entry preparation with deficit-based SOL top-ups, a stricter “enter” SOL gate, and clearer reserve reporting.
  - Added periodic wallet composition snapshots, now including native SOL.
  - Enhanced wallet valuation warnings to show excluded amounts and the sources used for pricing.
  - Added optional control over fallback behavior when fetching token prices.
- **Improvements**
  - Veto review can now fail open more safely based on recent prompt latency (rolling p95).
- **Bug Fixes**
  - Improved detection of insufficient-SOL conditions for entry and redeployment flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Third-round review fixes (commit `d51ef1f`)

| # | Priority | File | Issue | Fix |
|---|----------|------|-------|-----|
| 8 | P1 | agent-service.ts:563 | veto catchAll swallowed errors to `null`, so program.ts's throttled `vetoFetchFailed` / `vetoWarningThrottle` handler never fired; unthrottled warn for every pool/cycle instead | Re-fail (`Effect.fail(err)`) after recording latency; program.ts outer catchAll now applies the per-pool per-window throttle + memory warning exactly once |
| 9 | P1 | agent-service.ts:528 | A single timeout among quick reviews latched the skip for up to 30 min — nearest-rank p95 equals window max on partial windows | Added `VETO_SKIP_MIN_SLOW_SAMPLES = 3`: skip requires ≥3 individual slow samples, not just high p95 |
| 10 | Major | program.ts:1016 | Failed balance read defaulted to 0, computing deficit = full reserve and submitting an unnecessary swap | `catchAll(() => succeed(null))` + guard `preSwapSol !== null`; top-up skipped on read failure — post-swap recheck independently rejects ENTER |
| 11 | Minor | adapter-service.ts:190 | `attemptedSources` default hardcoded `"helius,jupiter,coingecko"` regardless of what was actually attempted | Default changed to `"unknown"` |
| 12 | Minor | constants.ts:22 | `MIN_SOL_FOR_GAS_LAMPORTS` doc claimed it controlled the top-up trigger — stale after alias change | Doc corrected: pure gas-fee floor for error decomposition only; gate/top-up use `MIN_SOL_FOR_ENTRY_LAMPORTS` |

Verification: `bunx tsc --noEmit` clean, `bunx oxlint` clean, 90 bench tests passed (agent-service / adapter-prices / program suites).
