### PR TITLE
fix: mode-aware auto-resolve for latched daily_drawdown safety pause

### DIFF
--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -6,6 +6,7 @@ import {
   nextSettlementRetryAt,
   persistDailyEquityBaseline,
   processSettlementJobs,
+  safetyPauseBlockReason,
   shouldAutoResolveDailyDrawdownPause,
   shouldTriggerSafetyPause,
 } from "../engine/autonomous-runtime.js";
@@ -97,6 +98,37 @@ describe("autonomous token runtime policy", () => {
     expect(isActionAllowedDuringSafetyPause("HOLD")).toBe(true);
     expect(isActionAllowedDuringSafetyPause("ENTER")).toBe(false);
     expect(isActionAllowedDuringSafetyPause("REBALANCE")).toBe(false);
+  });
+
+  it("enforces the safety pause at risk gates except in shadow mode (issue #148)", () => {
+    // Given an unresolved pause on a live account.
+    const pause = {
+      walletAddress: "wallet-1",
+      agentInstanceId: "primary",
+      reason: "daily_drawdown",
+      triggeredAt: 1_000,
+      resolvedAt: null as number | null,
+    };
+
+    // Live blocks entry/rebalance but permits EXIT/HOLD.
+    expect(safetyPauseBlockReason("live", pause, "ENTER")).toBe(
+      "Wallet safety pause active: daily_drawdown",
+    );
+    expect(safetyPauseBlockReason("live", pause, "REBALANCE")).toBe(
+      "Wallet safety pause active: daily_drawdown",
+    );
+    expect(safetyPauseBlockReason("live", pause, "EXIT")).toBeNull();
+    expect(safetyPauseBlockReason("live", pause, "HOLD")).toBeNull();
+
+    // Shadow is informational only — never blocks any action.
+    expect(safetyPauseBlockReason("shadow", pause, "ENTER")).toBeNull();
+    expect(safetyPauseBlockReason("shadow", pause, "REBALANCE")).toBeNull();
+
+    // A resolved pause does not block.
+    expect(safetyPauseBlockReason("live", { ...pause, resolvedAt: 2_000 }, "ENTER")).toBeNull();
+
+    // No pause never blocks.
+    expect(safetyPauseBlockReason("live", null, "ENTER")).toBeNull();
   });
 
   it("triggers each wallet safety threshold at its configured boundary", () => {

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -6,6 +6,7 @@ import {
   nextSettlementRetryAt,
   persistDailyEquityBaseline,
   processSettlementJobs,
+  shouldAutoResolveDailyDrawdownPause,
   shouldTriggerSafetyPause,
 } from "../engine/autonomous-runtime.js";
 import { SOL_MINT } from "../engine/constants.js";
@@ -144,6 +145,77 @@ describe("autonomous token runtime policy", () => {
         settlementMaxPendingMs: 3_600_000,
       }),
     ).toBe("settlement_overdue");
+  });
+
+  it("auto-resolves a latched daily_drawdown pause per the mode table (issue #148)", () => {
+    // Given a disabled threshold (gate off) — a leftover pause never latches.
+    expect(
+      shouldAutoResolveDailyDrawdownPause({
+        mode: "live",
+        dailyDrawdownPct: 99,
+        maxDailyDrawdownPct: 0,
+        dayRolledOver: false,
+      }),
+    ).toBe(true);
+
+    // Shadow is informational only — always auto-resolve, never latch.
+    expect(
+      shouldAutoResolveDailyDrawdownPause({
+        mode: "shadow",
+        dailyDrawdownPct: 99,
+        maxDailyDrawdownPct: 5,
+        dayRolledOver: false,
+      }),
+    ).toBe(true);
+
+    // Canary auto-clears at the day-boundary rollover even while still breached.
+    expect(
+      shouldAutoResolveDailyDrawdownPause({
+        mode: "canary",
+        dailyDrawdownPct: 99,
+        maxDailyDrawdownPct: 5,
+        dayRolledOver: true,
+      }),
+    ).toBe(true);
+
+    // Canary also clears as soon as the drawdown recovers below the threshold.
+    expect(
+      shouldAutoResolveDailyDrawdownPause({
+        mode: "canary",
+        dailyDrawdownPct: 4,
+        maxDailyDrawdownPct: 5,
+        dayRolledOver: false,
+      }),
+    ).toBe(true);
+
+    // Canary stays latched while breached and no rollover has occurred.
+    expect(
+      shouldAutoResolveDailyDrawdownPause({
+        mode: "canary",
+        dailyDrawdownPct: 6,
+        maxDailyDrawdownPct: 5,
+        dayRolledOver: false,
+      }),
+    ).toBe(false);
+
+    // Live re-evaluates fresh each cycle — recovery (or a fresh-day baseline
+    // that drops the measured drawdown to ~0) clears it; a live breach latches.
+    expect(
+      shouldAutoResolveDailyDrawdownPause({
+        mode: "live",
+        dailyDrawdownPct: 4,
+        maxDailyDrawdownPct: 5,
+        dayRolledOver: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAutoResolveDailyDrawdownPause({
+        mode: "live",
+        dailyDrawdownPct: 6,
+        maxDailyDrawdownPct: 5,
+        dayRolledOver: true,
+      }),
+    ).toBe(false);
   });
 
   it("caps deterministic settlement retry backoff", () => {

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -42,6 +42,42 @@ export function shouldTriggerSafetyPause(
   return null;
 }
 
+export interface DailyDrawdownAutoResolveInput {
+  readonly mode: AutonomousTokenMode;
+  readonly dailyDrawdownPct: number;
+  readonly maxDailyDrawdownPct: number;
+  readonly dayRolledOver: boolean;
+}
+
+/**
+ * Mode-aware auto-resolution for a latched `daily_drawdown` safety pause
+ * (issue #148). The daily equity baseline re-seeds every day, but nothing
+ * ever re-evaluated an existing pause — only `prism resume` could clear it,
+ * so the pause silently latched into new days. This mirrors the autonomy
+ * contract:
+ *
+ * - `shadow` — informational only: the pause never blocks and never requires
+ *   a manual resume, so always auto-resolve.
+ * - `canary` — auto-clear at the day-boundary rollover, or as soon as the
+ *   drawdown recovers below `MAX_DAILY_DRAWDOWN_PCT`.
+ * - `live` — re-evaluate fresh every cycle: auto-resolve when the drawdown no
+ *   longer breaches the threshold (a fresh daily baseline after rollover
+ *   normally drops the measured drawdown to ~0).
+ *
+ * A disabled threshold (`maxDailyDrawdownPct <= 0`) means the gate is off, so
+ * a leftover pause from when it was enabled should not latch either.
+ *
+ * Returns true when the caller should clear the active pause (`resolvedAt`).
+ */
+export function shouldAutoResolveDailyDrawdownPause(input: DailyDrawdownAutoResolveInput): boolean {
+  if (input.maxDailyDrawdownPct <= 0) return true;
+  if (input.mode === "shadow") return true;
+  if (input.mode === "canary") {
+    return input.dayRolledOver || input.dailyDrawdownPct < input.maxDailyDrawdownPct;
+  }
+  return input.dailyDrawdownPct < input.maxDailyDrawdownPct;
+}
+
 /** Computes the bounded retry timestamp for a settlement attempt. */
 export function nextSettlementRetryAt(now: number, attempts: number): number {
   const exponent = Math.max(0, Math.min(attempts - 1, 30));

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -2,11 +2,33 @@ import { Effect } from "effect";
 import { SOL_MINT } from "./constants.js";
 import { computeNetRealizedPnlUsd } from "./pnl.js";
 import type { AdapterApi, DbApi } from "./services.js";
-import type { ActionType, AutonomousTokenMode, SettlementJobRecord } from "./types.js";
+import type {
+  ActionType,
+  AutonomousTokenMode,
+  SafetyPauseRecord,
+  SettlementJobRecord,
+} from "./types.js";
 
 /** Returns whether an action remains permitted while the wallet safety pause is active. */
 export function isActionAllowedDuringSafetyPause(action: ActionType): boolean {
   return action === "EXIT" || action === "HOLD";
+}
+
+/**
+ * Returns the reject reason when an active wallet safety pause should block
+ * a decision, or null when the decision proceeds. The pause is informational
+ * in `shadow` mode (no-send by design) — it never blocks a decision there.
+ * EXIT/HOLD remain permitted while the pause is active.
+ */
+export function safetyPauseBlockReason(
+  autonomousMode: AutonomousTokenMode | undefined,
+  activeSafetyPause: SafetyPauseRecord | null,
+  action: ActionType,
+): string | null {
+  if (autonomousMode === "shadow") return null;
+  if (activeSafetyPause === null || activeSafetyPause.resolvedAt !== null) return null;
+  if (isActionAllowedDuringSafetyPause(action)) return null;
+  return `Wallet safety pause active: ${activeSafetyPause.reason}`;
 }
 
 export interface SafetyPauseThresholdInput {
@@ -71,11 +93,17 @@ export interface DailyDrawdownAutoResolveInput {
  */
 export function shouldAutoResolveDailyDrawdownPause(input: DailyDrawdownAutoResolveInput): boolean {
   if (input.maxDailyDrawdownPct <= 0) return true;
-  if (input.mode === "shadow") return true;
-  if (input.mode === "canary") {
-    return input.dayRolledOver || input.dailyDrawdownPct < input.maxDailyDrawdownPct;
+  switch (input.mode) {
+    case "shadow":
+      return true;
+    case "canary":
+      return input.dayRolledOver || input.dailyDrawdownPct < input.maxDailyDrawdownPct;
+    case "live":
+    case "off":
+      return input.dailyDrawdownPct < input.maxDailyDrawdownPct;
+    default:
+      throw new Error(`Unhandled autonomous token mode: ${input.mode}`);
   }
-  return input.dailyDrawdownPct < input.maxDailyDrawdownPct;
 }
 
 /** Computes the bounded retry timestamp for a settlement attempt. */

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -145,6 +145,7 @@ import {
   loadDailyEquityBaseline,
   persistDailyEquityBaseline,
   processSettlementJobs,
+  shouldAutoResolveDailyDrawdownPause,
   shouldTriggerSafetyPause,
 } from "./autonomous-runtime.js";
 import { routeProbeAmountAtomic } from "./route-probe.js";
@@ -3247,7 +3248,11 @@ export const program = Effect.gen(function* () {
           poolAddress: candidate.poolAddress,
           activeBinId: candidate.pool.activeBinId,
         };
+        // Issue #148: the wallet safety pause is informational in shadow mode
+        // (no-send by design) — it must never block a decision there.
         const riskResult: RiskResult =
+          autonomousExecution !== null &&
+          autonomousExecution.mode !== "shadow" &&
           activeSafetyPause?.resolvedAt === null &&
           !isActionAllowedDuringSafetyPause(decision.action)
             ? {
@@ -4837,7 +4842,8 @@ export const program = Effect.gen(function* () {
             : sum,
         0,
       );
-      if (dailyBaselineDay !== dayKey) {
+      const dayRolledOver = dailyBaselineDay !== dayKey;
+      if (dayRolledOver) {
         dailyBaselineDay = dayKey;
         dailyBaselineEquityUsd = portfolioValueUsd - realizedTodayUsd;
         yield* persistDailyEquityBaseline(db, dailyBaselineScope, {
@@ -4850,6 +4856,27 @@ export const program = Effect.gen(function* () {
         dailyBaselineEquityUsd > 0 && dailyEquityUsd < dailyBaselineEquityUsd
           ? ((dailyBaselineEquityUsd - dailyEquityUsd) / dailyBaselineEquityUsd) * 100
           : 0;
+      // Issue #148: a latched daily_drawdown pause must not outlive the
+      // condition that raised it. The daily baseline re-seeds on rollover but
+      // the pause itself only cleared via `prism resume` — auto-resolve it
+      // mode-aware so a fresh-day baseline (or a recovered drawdown) does not
+      // leave the agent silently paused. The trigger block below re-arms it
+      // when the recomputed drawdown still breaches the threshold.
+      if (
+        autonomousExecution &&
+        activeSafetyPause !== null &&
+        activeSafetyPause.resolvedAt === null &&
+        activeSafetyPause.reason === "daily_drawdown" &&
+        shouldAutoResolveDailyDrawdownPause({
+          mode: autonomousExecution.mode,
+          dailyDrawdownPct,
+          maxDailyDrawdownPct: config.maxDailyDrawdownPct,
+          dayRolledOver,
+        })
+      ) {
+        activeSafetyPause = { ...activeSafetyPause, resolvedAt: Date.now() };
+        yield* db.saveSafetyPause(activeSafetyPause).pipe(Effect.catchAll(() => Effect.void));
+      }
       if (
         autonomousExecution &&
         activeSafetyPause?.resolvedAt !== null &&
@@ -6007,7 +6034,11 @@ export const program = Effect.gen(function* () {
           activeBinId: pool.activeBinId,
           positionId: decision.positionId,
         };
+        // Issue #148: the wallet safety pause is informational in shadow mode
+        // (no-send by design) — it must never block a decision there.
         const riskResult: RiskResult =
+          autonomousExecution !== null &&
+          autonomousExecution.mode !== "shadow" &&
           activeSafetyPause?.resolvedAt === null &&
           !isActionAllowedDuringSafetyPause(decision.action)
             ? {

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -141,10 +141,10 @@ import {
 } from "./proposal-backoff.js";
 import { computeCooldownForExit } from "./cooldown.js";
 import {
-  isActionAllowedDuringSafetyPause,
   loadDailyEquityBaseline,
   persistDailyEquityBaseline,
   processSettlementJobs,
+  safetyPauseBlockReason,
   shouldAutoResolveDailyDrawdownPause,
   shouldTriggerSafetyPause,
 } from "./autonomous-runtime.js";
@@ -3250,16 +3250,18 @@ export const program = Effect.gen(function* () {
         };
         // Issue #148: the wallet safety pause is informational in shadow mode
         // (no-send by design) — it must never block a decision there.
+        const pauseBlockReason = safetyPauseBlockReason(
+          autonomousExecution?.mode,
+          activeSafetyPause,
+          decision.action,
+        );
         const riskResult: RiskResult =
-          autonomousExecution !== null &&
-          autonomousExecution.mode !== "shadow" &&
-          activeSafetyPause?.resolvedAt === null &&
-          !isActionAllowedDuringSafetyPause(decision.action)
-            ? {
+          pauseBlockReason === null
+            ? risk.evaluate(decision, riskCtx)
+            : {
                 approved: false,
-                reason: `Wallet safety pause active: ${activeSafetyPause.reason}`,
-              }
-            : risk.evaluate(decision, riskCtx);
+                reason: pauseBlockReason,
+              };
         if (riskResult.adjustedSizeUsd) {
           decision = {
             ...decision,
@@ -6036,18 +6038,17 @@ export const program = Effect.gen(function* () {
         };
         // Issue #148: the wallet safety pause is informational in shadow mode
         // (no-send by design) — it must never block a decision there.
+        const pauseBlockReason = safetyPauseBlockReason(
+          autonomousExecution?.mode,
+          activeSafetyPause,
+          decision.action,
+        );
         const riskResult: RiskResult =
-          autonomousExecution !== null &&
-          autonomousExecution.mode !== "shadow" &&
-          activeSafetyPause?.resolvedAt === null &&
-          !isActionAllowedDuringSafetyPause(decision.action)
-            ? {
-                approved: false,
-                reason: `Wallet safety pause active: ${activeSafetyPause.reason}`,
-              }
-            : decision.action === "HOLD"
+          pauseBlockReason === null
+            ? decision.action === "HOLD"
               ? { approved: true, reason: "HOLD — no execution; risk gates skipped" }
-              : risk.evaluate(decision, riskCtx);
+              : risk.evaluate(decision, riskCtx)
+            : { approved: false, reason: pauseBlockReason };
 
         // Apply risk-adjusted position size cap
         if (riskResult.adjustedSizeUsd && decision.action === "ENTER") {


### PR DESCRIPTION
Closes #148

## Summary

The `daily_drawdown` wallet safety pause was a **one-way latch**: the daily equity baseline re-seeds every calendar day (`program.ts` rollover branch), but an existing unresolved pause was only ever cleared by manual `prism resume`. In `live` (full-auto) mode the agent silently stopped entering forever — even after the drawdown recovered or the fresh-day baseline dropped the measured drawdown to ~0.

## Root cause

1. **Baseline is daily, pause is not.** The rollover branch re-seeds `dailyBaselineEquityUsd` when the day changes, so the *measurement* rolls daily.
2. **Pause re-trigger is gated on a resolved latch.** The trigger block only re-evaluates `shouldTriggerSafetyPause` when `activeSafetyPause?.resolvedAt !== null` — once latched, the threshold is never re-checked.
3. **No auto-clear path.** The only writer of `resolvedAt` was `cli/resume.ts`.

## Fix (mode-aware lifecycle)

New pure helper `shouldAutoResolveDailyDrawdownPause()` in `engine/autonomous-runtime.ts`, wired into `program.ts` at the daily baseline rollover point (after `dailyDrawdownPct` is recomputed, before the trigger block re-arms):

| Mode | Auto-resolve condition |
| --- | --- |
| `shadow` | Always (informational only — never blocks, never requires manual resume) |
| `canary` | Day-boundary rollover **or** drawdown recovers below `MAX_DAILY_DRAWDOWN_PCT` |
| `live` | Re-evaluate fresh each cycle — resolve when no longer breached (fresh-day baseline normally drops drawdown to ~0) |
| `maxDailyDrawdownPct <= 0` | Always (gate off — a leftover pause shouldn't latch) |

The pause is also now **informational in shadow mode**: it no longer blocks decisions at either risk gate (idle-redeploy + main entry), matching the no-send design.

## Traceability

- `engine/autonomous-runtime.ts` — `shouldAutoResolveDailyDrawdownPause()` + input type
- `engine/program.ts` — `dayRolledOver` capture; auto-resolve block after rollover/baseline recompute; shadow-mode enforcement skip at both risk gates
- `bench/program-autonomous-token.test.ts` — full mode-table coverage (shadow/canary/live/off/max<=0)

## Verification

- `bun run lint` — clean (tsc + oxlint)
- `bun run format:check` — clean
- `bun run test -- bench/program-autonomous-token.test.ts` — 23 passed
- `bun run test -- bench/autonomous-token-foundation.test.ts bench/cli-autonomous-status.test.ts` — 15 passed

## Summary by Sourcery

Implement mode-aware auto-resolution of latched daily_drawdown wallet safety pauses and ensure shadow-mode pauses are informational-only and non-blocking.

Bug Fixes:
- Automatically resolve daily_drawdown safety pauses based on mode, daily rollover, and drawdown recovery instead of requiring manual resume.
- Prevent daily_drawdown pauses from remaining latched when the maxDailyDrawdownPct gate is disabled.
- Ensure wallet safety pauses do not block decisions in shadow mode at either risk gate.

Tests:
- Add mode-table coverage tests for daily_drawdown auto-resolution behavior across shadow, canary, live, and disabled-threshold configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily drawdown safety pauses now automatically clear when configured limits are disabled, during shadow mode, after a new trading day begins, or when drawdown recovers.
  * Shadow-mode decisions can proceed without being blocked by execution safety pauses.

* **Bug Fixes**
  * Improved recovery handling so resolved pauses do not immediately re-trigger unless drawdown conditions still require them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->