### PR TITLE
fix(portfolio): surface true wallet equity in portfolio/status CLIs

### DIFF
--- a/bench/pnl-equity.test.ts
+++ b/bench/pnl-equity.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { computePortfolioEquity } from "../engine/pnl.js";
+
+describe("computePortfolioEquity (issue #149)", () => {
+  const pos = (overrides: Partial<{ v: number; d: number; f: number; r: number }> = {}) => ({
+    currentValueUsd: overrides.v ?? 100,
+    depositedUsd: overrides.d ?? 80,
+    cumulativeFeesClaimedUsd: overrides.f ?? 5,
+    cumulativeRewardsClaimedUsd: overrides.r ?? 0,
+  });
+
+  it("adds the liquid wallet to position value for true equity", () => {
+    const result = computePortfolioEquity({
+      walletBalanceUsd: 54.18,
+      positions: [pos()],
+    });
+    expect(result.positionsValueUsd).toBe(100);
+    expect(result.walletBalanceUsd).toBe(54.18);
+    expect(result.totalEquityUsd).toBeCloseTo(154.18, 2);
+  });
+
+  it("computes equity-based unrealized P&L against total deposits", () => {
+    // wallet 54.18 + positions 36.82 = 91.00 equity; deposits 41.89 → up.
+    const result = computePortfolioEquity({
+      walletBalanceUsd: 54.18,
+      positions: [
+        {
+          currentValueUsd: 36.82,
+          depositedUsd: 41.89,
+          cumulativeFeesClaimedUsd: 0,
+          cumulativeRewardsClaimedUsd: 0,
+        },
+      ],
+    });
+    expect(result.totalEquityUsd).toBeCloseTo(91.0, 2);
+    // The issue's real numbers: wallet ≈ $91 vs $41.89 deposited → POSITIVE.
+    expect(result.unrealizedPnlUsd).toBeGreaterThan(0);
+    expect(result.walletKnown).toBe(true);
+  });
+
+  it("includes claimed fees and rewards in unrealized P&L", () => {
+    const result = computePortfolioEquity({
+      walletBalanceUsd: 10,
+      positions: [
+        {
+          currentValueUsd: 100,
+          depositedUsd: 100,
+          cumulativeFeesClaimedUsd: 4,
+          cumulativeRewardsClaimedUsd: 2,
+        },
+      ],
+    });
+    // equity 110 + fees 4 + rewards 2 − deposits 100 = 16
+    expect(result.unrealizedPnlUsd).toBeCloseTo(16, 6);
+    expect(result.unrealizedPnlPct).toBeCloseTo(16, 6);
+  });
+
+  it("falls back to positions-only equity when the wallet is unknown (no fabrication)", () => {
+    const result = computePortfolioEquity({
+      walletBalanceUsd: null,
+      positions: [pos()],
+    });
+    expect(result.walletKnown).toBe(false);
+    expect(result.walletBalanceUsd).toBe(0);
+    expect(result.totalEquityUsd).toBeCloseTo(100, 6);
+    // 100 + 5 − 80 = 25, same as the positions-only figure.
+    expect(result.unrealizedPnlUsd).toBeCloseTo(25, 6);
+  });
+
+  it("skips non-finite position values and deposits", () => {
+    const result = computePortfolioEquity({
+      walletBalanceUsd: 10,
+      positions: [
+        {
+          currentValueUsd: Number.NaN,
+          depositedUsd: 50,
+          cumulativeFeesClaimedUsd: 0,
+          cumulativeRewardsClaimedUsd: 0,
+        },
+        {
+          currentValueUsd: 20,
+          depositedUsd: Number.POSITIVE_INFINITY,
+          cumulativeFeesClaimedUsd: 0,
+          cumulativeRewardsClaimedUsd: 0,
+        },
+        {
+          currentValueUsd: 30,
+          depositedUsd: 10,
+          cumulativeFeesClaimedUsd: 0,
+          cumulativeRewardsClaimedUsd: 0,
+        },
+      ],
+    });
+    expect(result.positionsValueUsd).toBeCloseTo(50, 6); // 20 + 30 (Infinity is in deposited, not value)
+    expect(result.totalDepositedUsd).toBeCloseTo(60, 6); // 50 (NaN-value pos) + 10; Infinity deposit skipped
+    expect(result.totalEquityUsd).toBeCloseTo(60, 6); // 50 + 10 wallet
+  });
+
+  it("handles an empty portfolio with a known wallet", () => {
+    const result = computePortfolioEquity({ walletBalanceUsd: 100, positions: [] });
+    expect(result.totalEquityUsd).toBe(100);
+    expect(result.positionsValueUsd).toBe(0);
+    expect(result.unrealizedPnlUsd).toBe(100); // 100 + 0 − 0
+    expect(result.unrealizedPnlPct).toBe(0);
+    expect(result.walletKnown).toBe(true);
+  });
+});

--- a/cli/portfolio.ts
+++ b/cli/portfolio.ts
@@ -1,9 +1,15 @@
 import { Command } from "commander";
 import { Effect, Layer } from "effect";
 import { DbLive } from "../engine/db-service.js";
-import { DbService, type DbApi } from "../engine/services.js";
+import { DbService, type DbApi, AdapterService } from "../engine/services.js";
+import { AdapterLive } from "../engine/adapter-service.js";
+import { ConfigLive } from "../engine/config-service.js";
 import type { PositionRecord } from "../engine/db-service.js";
-import { computePositionAnalytics } from "../engine/pnl.js";
+import {
+  computePositionAnalytics,
+  computePortfolioEquity,
+  type PortfolioEquity,
+} from "../engine/pnl.js";
 import { createLogger } from "../engine/logger.js";
 import { getPrismDbPath } from "../engine/paths.js";
 
@@ -26,10 +32,35 @@ function sanitizeSymbol(value: string): string {
   return value.replace(ANSI_ESCAPE_RE, "").replace(CONTROL_CHAR_RE, "");
 }
 
-function buildProgram(): Layer.Layer<DbService, never, never> {
-  return DbLive(process.env.SQLITE_DB_PATH ?? getPrismDbPath());
+function buildProgram(): Layer.Layer<DbService | AdapterService, unknown, never> {
+  const dbPath = process.env.SQLITE_DB_PATH ?? getPrismDbPath();
+  const dbLayer = DbLive(dbPath);
+  const adapterLayer = Layer.provide(AdapterLive, ConfigLive);
+  return Layer.merge(dbLayer, adapterLayer);
 }
 
+/**
+ * Read the wallet's liquid balance once, fail-open, bounded. Returns null when
+ * the wallet cannot be read (no wallet, RPC down, timeout) so the caller
+ * falls back to positions-only equity — never fabricates a number.
+ */
+export function readCliWalletBalance(): Effect.Effect<number | null, never, AdapterService> {
+  return Effect.gen(function* () {
+    const adapter = yield* AdapterService;
+    // No wallet configured → the liquid balance is NOT a chain-read wallet
+    // (paper mode seeds paperPortfolioUsd, which positions-only already
+    // reflects). Treat as unknown so equity falls back to positions-only
+    // rather than presenting a fake $0 wallet.
+    if (!adapter.hasWallet()) return null;
+    return yield* adapter.getWalletBalanceUsd().pipe(
+      Effect.timeoutFail({
+        duration: 15_000,
+        onTimeout: () => null as number | null,
+      }),
+      Effect.catchAll(() => Effect.succeed(null as number | null)),
+    );
+  });
+}
 export interface PortfolioSummary {
   totalDepositedUsd: number;
   totalCurrentValueUsd: number;
@@ -38,9 +69,27 @@ export interface PortfolioSummary {
   totalFeesClaimedUsd: number;
   totalRewardsClaimedUsd: number;
   positionCount: number;
+  /** Liquid wallet balance (SOL + SPL). Null when unreadable → positions-only. */
+  walletBalanceUsd: number | null;
+  /** True equity = positions value + wallet. Equals totalCurrentValueUsd when wallet unknown. */
+  totalEquityUsd: number;
+  /** False when the wallet balance could not be read (equity is positions-only). */
+  walletKnown: boolean;
 }
 
 export function computeSummary(positions: ReadonlyArray<PositionRecord>): PortfolioSummary {
+  return computeSummaryWithEquity(positions, null);
+}
+
+/**
+ * Positions summary extended with the wallet's liquid balance (issue #149).
+ * When `walletBalanceUsd` is null (unreadable / not configured) the summary
+ * falls back to positions-only equity — never fabricates a wallet figure.
+ */
+export function computeSummaryWithEquity(
+  positions: ReadonlyArray<PositionRecord>,
+  walletBalanceUsd: number | null,
+): PortfolioSummary {
   const totalDepositedUsd = positions.reduce((sum, p) => sum + p.depositedUsd, 0);
   const totalCurrentValueUsd = positions.reduce((sum, p) => sum + p.currentValueUsd, 0);
   const totalFeesClaimedUsd = positions.reduce((sum, p) => sum + p.cumulativeFeesClaimedUsd, 0);
@@ -48,8 +97,9 @@ export function computeSummary(positions: ReadonlyArray<PositionRecord>): Portfo
     (sum, p) => sum + p.cumulativeRewardsClaimedUsd,
     0,
   );
-  const totalUnrealizedPnlUsd =
-    totalCurrentValueUsd + totalFeesClaimedUsd + totalRewardsClaimedUsd - totalDepositedUsd;
+  const equity = computePortfolioEquity({ walletBalanceUsd, positions });
+  const walletKnown = walletBalanceUsd !== null && Number.isFinite(walletBalanceUsd);
+  const totalUnrealizedPnlUsd = equity.unrealizedPnlUsd;
   const totalUnrealizedPnlPct =
     totalDepositedUsd > 0 ? (totalUnrealizedPnlUsd / totalDepositedUsd) * 100 : 0;
 
@@ -61,6 +111,9 @@ export function computeSummary(positions: ReadonlyArray<PositionRecord>): Portfo
     totalFeesClaimedUsd,
     totalRewardsClaimedUsd,
     positionCount: positions.length,
+    walletBalanceUsd: walletKnown ? walletBalanceUsd : null,
+    totalEquityUsd: equity.totalEquityUsd,
+    walletKnown,
   };
 }
 
@@ -172,7 +225,11 @@ function formatSummary(summary: PortfolioSummary): string {
     "=================",
     `  Positions:        ${summary.positionCount}`,
     `  Total Deposited:  ${formatCurrency(summary.totalDepositedUsd)}`,
+    ...(summary.walletKnown
+      ? [`  Wallet Balance:  ${formatCurrency(summary.walletBalanceUsd ?? 0)}`]
+      : []),
     `  Total Current:    ${formatCurrency(summary.totalCurrentValueUsd)}`,
+    `  Total Equity:     ${formatCurrency(summary.totalEquityUsd)}`,
     `  Fees Claimed:     ${formatCurrency(summary.totalFeesClaimedUsd)}`,
     ...(summary.totalRewardsClaimedUsd > 0
       ? [`  Rewards Claimed:  ${formatCurrency(summary.totalRewardsClaimedUsd)}`]
@@ -268,14 +325,25 @@ export interface PortfolioJsonOutput {
     outOfRangeSince: number | null;
     age: string;
   }>;
+  /** Wallet liquid balance read (null when unreadable). Issue #149. */
+  wallet: { balanceUsd: number | null; known: boolean };
+  /** True equity summary = positions + wallet. Issue #149. */
+  equity: PortfolioSummary;
+  /** Positions-only summary (kept for backward compatibility). */
   summary: PortfolioSummary;
 }
 
 export function toJsonOutput(
   positions: ReadonlyArray<PositionRecord>,
   prices: ReadonlyMap<string, number> = new Map(),
+  walletBalanceUsd: number | null = null,
 ): PortfolioJsonOutput {
   return {
+    wallet: {
+      balanceUsd: walletBalanceUsd,
+      known: walletBalanceUsd !== null && Number.isFinite(walletBalanceUsd),
+    },
+    equity: computeSummaryWithEquity(positions, walletBalanceUsd),
     positions: positions.map((pos) => {
       const analytics = computePositionAnalytics(
         {
@@ -397,14 +465,15 @@ portfolioCommand.action(async function (this: Command, opts: { json?: boolean })
         const db = yield* DbService;
         const positions = yield* db.getAllPositions();
         const prices = yield* latestPrices(db, positions);
+        const walletBalanceUsd = yield* readCliWalletBalance();
 
         if (isJson) {
-          console.log(JSON.stringify(toJsonOutput(positions, prices), null, 2));
+          console.log(JSON.stringify(toJsonOutput(positions, prices, walletBalanceUsd), null, 2));
           return;
         }
 
         console.log(formatPositionsList(positions, prices));
-        console.log(formatSummary(computeSummary(positions)));
+        console.log(formatSummary(computeSummaryWithEquity(positions, walletBalanceUsd)));
       }).pipe(Effect.provide(program)),
     );
   });
@@ -425,7 +494,8 @@ portfolioCommand
         Effect.gen(function* () {
           const db = yield* DbService;
           const positions = yield* db.getAllPositions();
-          const summary = computeSummary(positions);
+          const walletBalanceUsd = yield* readCliWalletBalance();
+          const summary = computeSummaryWithEquity(positions, walletBalanceUsd);
 
           if (isJson) {
             console.log(JSON.stringify({ summary }, null, 2));

--- a/cli/portfolio.ts
+++ b/cli/portfolio.ts
@@ -36,7 +36,7 @@ function buildProgram(): Layer.Layer<DbService | AdapterService, unknown, never>
   const dbPath = process.env.SQLITE_DB_PATH ?? getPrismDbPath();
   const dbLayer = DbLive(dbPath);
   const adapterLayer = Layer.provide(AdapterLive, ConfigLive);
-  return Layer.merge(dbLayer, adapterLayer);
+  return Layer.mergeAll(dbLayer, adapterLayer);
 }
 
 /**
@@ -53,11 +53,19 @@ export function readCliWalletBalance(): Effect.Effect<number | null, never, Adap
     // rather than presenting a fake $0 wallet.
     if (!adapter.hasWallet()) return null;
     return yield* adapter.getWalletBalanceUsd().pipe(
-      Effect.timeoutFail({
-        duration: 15_000,
-        onTimeout: () => null as number | null,
+      Effect.timeout(15_000),
+      Effect.matchEffect({
+        onFailure: (err) => {
+          // A genuine read failure (RPC down, parse error) is logged so it is
+          // not silently masked as "no wallet"; the caller still degrades to
+          // positions-only equity (fail-open for a reporting CLI).
+          logger.warn("Wallet balance read failed; equity is positions-only", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return Effect.succeed(null as number | null);
+        },
+        onSuccess: (value) => Effect.succeed(value ?? null),
       }),
-      Effect.catchAll(() => Effect.succeed(null as number | null)),
     );
   });
 }
@@ -90,30 +98,24 @@ export function computeSummaryWithEquity(
   positions: ReadonlyArray<PositionRecord>,
   walletBalanceUsd: number | null,
 ): PortfolioSummary {
-  const totalDepositedUsd = positions.reduce((sum, p) => sum + p.depositedUsd, 0);
-  const totalCurrentValueUsd = positions.reduce((sum, p) => sum + p.currentValueUsd, 0);
-  const totalFeesClaimedUsd = positions.reduce((sum, p) => sum + p.cumulativeFeesClaimedUsd, 0);
-  const totalRewardsClaimedUsd = positions.reduce(
-    (sum, p) => sum + p.cumulativeRewardsClaimedUsd,
-    0,
-  );
   const equity = computePortfolioEquity({ walletBalanceUsd, positions });
-  const walletKnown = walletBalanceUsd !== null && Number.isFinite(walletBalanceUsd);
-  const totalUnrealizedPnlUsd = equity.unrealizedPnlUsd;
   const totalUnrealizedPnlPct =
-    totalDepositedUsd > 0 ? (totalUnrealizedPnlUsd / totalDepositedUsd) * 100 : 0;
+    equity.totalDepositedUsd > 0 ? (equity.unrealizedPnlUsd / equity.totalDepositedUsd) * 100 : 0;
 
   return {
-    totalDepositedUsd,
-    totalCurrentValueUsd,
-    totalUnrealizedPnlUsd,
+    totalDepositedUsd: equity.totalDepositedUsd,
+    totalCurrentValueUsd: equity.positionsValueUsd,
+    totalUnrealizedPnlUsd: equity.unrealizedPnlUsd,
     totalUnrealizedPnlPct,
-    totalFeesClaimedUsd,
-    totalRewardsClaimedUsd,
+    totalFeesClaimedUsd: equity.totalFeesClaimedUsd,
+    totalRewardsClaimedUsd: equity.totalRewardsClaimedUsd,
     positionCount: positions.length,
-    walletBalanceUsd: walletKnown ? walletBalanceUsd : null,
+    // computePortfolioEquity is the single source of truth for wallet/equity
+    // normalization (non-finite -> 0, walletKnown flag); the summary mirrors
+    // it so the two surfaces can never diverge.
+    walletBalanceUsd: equity.walletKnown ? equity.walletBalanceUsd : null,
     totalEquityUsd: equity.totalEquityUsd,
-    walletKnown,
+    walletKnown: equity.walletKnown,
   };
 }
 

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -1,13 +1,18 @@
 import { Command } from "commander";
 import { Effect, Layer } from "effect";
 import { DbLive } from "../engine/db-service.js";
-import { DbService, AuditService } from "../engine/services.js";
+import { DbService, AuditService, AdapterService } from "../engine/services.js";
 import { AuditLive } from "../engine/audit-service.js";
 import { ConfigLive, ConfigService } from "../engine/config-service.js";
+import { AdapterLive } from "../engine/adapter-service.js";
 import type { PositionRecord } from "../engine/db-service.js";
-import { computeSummary, toJsonOutput, type PortfolioSummary } from "./portfolio.js";
+import {
+  computeSummaryWithEquity,
+  readCliWalletBalance,
+  toJsonOutput,
+  type PortfolioSummary,
+} from "./portfolio.js";
 import { createLogger } from "../engine/logger.js";
-
 import { readLockfile, isProcessAlive, findRunningEngineProcess } from "./lockfile.js";
 import { getPrismDbPath } from "../engine/paths.js";
 import { resolveEffectivePubkey } from "./wallet.js";
@@ -82,12 +87,17 @@ export interface StatusJsonOutput {
   };
 }
 
-function buildProgram(): Layer.Layer<DbService | AuditService | ConfigService, unknown, never> {
+function buildProgram(): Layer.Layer<
+  DbService | AuditService | ConfigService | AdapterService,
+  unknown,
+  never
+> {
   const dbPath = process.env.SQLITE_DB_PATH ?? getPrismDbPath();
   const dbLayer = DbLive(dbPath);
   const auditLayer = Layer.provide(AuditLive, dbLayer);
   const configLayer = ConfigLive;
-  return Layer.merge(auditLayer, Layer.merge(dbLayer, configLayer));
+  const adapterLayer = Layer.provide(AdapterLive, configLayer);
+  return Layer.merge(auditLayer, Layer.merge(dbLayer, Layer.merge(configLayer, adapterLayer)));
 }
 
 export const statusCommand = new Command("status")
@@ -115,7 +125,8 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
 
           const positions = yield* db.getAllPositions();
           const recentAudit = yield* audit.getRecentDecisions(10);
-          const summary = computeSummary(positions);
+          const walletBalanceUsd = yield* readCliWalletBalance();
+          const summary = computeSummaryWithEquity(positions, walletBalanceUsd);
           const effectiveWallet = resolveEffectivePubkey();
           const walletAddress = effectiveWallet?.error ? null : (effectiveWallet?.pubkey ?? null);
           const autonomousWalletAddress = walletAddress ?? "paper";
@@ -256,6 +267,10 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
               `Positions: ${activePositions.length} active`,
               `Deposited: $${summary.totalDepositedUsd.toFixed(2)}`,
               `Current:   $${summary.totalCurrentValueUsd.toFixed(2)}`,
+              ...(summary.walletKnown
+                ? [`Wallet:    $${(summary.walletBalanceUsd ?? 0).toFixed(2)}`]
+                : []),
+              `Equity:    $${summary.totalEquityUsd.toFixed(2)}`,
               `Fees:      $${summary.totalFeesClaimedUsd.toFixed(2)}`,
               ...(summary.totalRewardsClaimedUsd > 0
                 ? [`Rewards:   $${summary.totalRewardsClaimedUsd.toFixed(2)}`]
@@ -288,6 +303,10 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
               `  Positions:   ${activePositions.length} active`,
               `  Deposited:   $${summary.totalDepositedUsd.toFixed(2)}`,
               `  Current:     $${summary.totalCurrentValueUsd.toFixed(2)}`,
+              ...(summary.walletKnown
+                ? [`  Wallet:      $${(summary.walletBalanceUsd ?? 0).toFixed(2)}`]
+                : []),
+              `  Equity:      $${summary.totalEquityUsd.toFixed(2)}`,
               `  Fees:        $${summary.totalFeesClaimedUsd.toFixed(2)}`,
               ...(summary.totalRewardsClaimedUsd > 0
                 ? [`  Rewards:     $${summary.totalRewardsClaimedUsd.toFixed(2)}`]

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -97,7 +97,7 @@ function buildProgram(): Layer.Layer<
   const auditLayer = Layer.provide(AuditLive, dbLayer);
   const configLayer = ConfigLive;
   const adapterLayer = Layer.provide(AdapterLive, configLayer);
-  return Layer.merge(auditLayer, Layer.merge(dbLayer, Layer.merge(configLayer, adapterLayer)));
+  return Layer.mergeAll(dbLayer, auditLayer, configLayer, adapterLayer);
 }
 
 export const statusCommand = new Command("status")

--- a/engine/pnl.ts
+++ b/engine/pnl.ts
@@ -202,3 +202,95 @@ export function applyCompoundToCostBasis(input: {
   const highest = Math.max(input.highestValueUsd ?? input.depositedUsd, currentValueUsd);
   return { depositedUsd, currentValueUsd, highestValueUsd: highest };
 }
+
+// ─── Portfolio equity (issue #149) ───────────────────────────────────────────
+//
+// The wallet's liquid balance (SOL + SPL across Token Program and Token-2022)
+// is real operator equity that the per-position rows do not hold. Reporting
+// positions-only equity understates the portfolio by the full liquid balance,
+// which trips phantom drawdown pauses and misleads the operator/Telegram.
+// One canonical function: equity = liquid wallet + open-position value. The
+// equity-based unrealized P&L is (equity + claimed fees + claimed rewards −
+// total deposits) — the same shape as the per-position model, extended to the
+// whole wallet.
+
+export interface PortfolioEquityInput {
+  /** Liquid wallet balance (native SOL + SPL), or null when unreadable. */
+  readonly walletBalanceUsd: number | null;
+  readonly positions: ReadonlyArray<{
+    readonly currentValueUsd: number;
+    readonly depositedUsd: number;
+    readonly cumulativeFeesClaimedUsd: number;
+    readonly cumulativeRewardsClaimedUsd?: number | undefined;
+  }>;
+}
+
+export interface PortfolioEquity {
+  /** Current value of all positions. */
+  readonly positionsValueUsd: number;
+  /** Liquid wallet balance (same as input; 0 when unknown). */
+  readonly walletBalanceUsd: number;
+  /** True equity = positions + wallet. */
+  readonly totalEquityUsd: number;
+  /** Sum of position cost bases. */
+  readonly totalDepositedUsd: number;
+  /** Sum of claimed swap fees across positions. */
+  readonly totalFeesClaimedUsd: number;
+  /** Sum of claimed farm rewards across positions. */
+  readonly totalRewardsClaimedUsd: number;
+  /**
+   * Equity-based unrealized P&L: (equity + fees + rewards − deposits).
+   * When the wallet balance is unknown (null input), this falls back to the
+   * positions-only figure exactly as before — never fabricates a wallet.
+   */
+  readonly unrealizedPnlUsd: number;
+  /** unrealizedPnlUsd / totalDepositedUsd (0 when no deposits). */
+  readonly unrealizedPnlPct: number;
+  /** False when the wallet balance could not be read (equity is positions-only). */
+  readonly walletKnown: boolean;
+}
+
+export function computePortfolioEquity(input: PortfolioEquityInput): PortfolioEquity {
+  const positionsValueUsd = input.positions.reduce(
+    (sum, pos) => (Number.isFinite(pos.currentValueUsd) ? sum + pos.currentValueUsd : sum),
+    0,
+  );
+  const totalDepositedUsd = input.positions.reduce(
+    (sum, pos) => (Number.isFinite(pos.depositedUsd) ? sum + pos.depositedUsd : sum),
+    0,
+  );
+  const totalFeesClaimedUsd = input.positions.reduce(
+    (sum, pos) =>
+      Number.isFinite(pos.cumulativeFeesClaimedUsd) ? sum + pos.cumulativeFeesClaimedUsd : sum,
+    0,
+  );
+  const totalRewardsClaimedUsd = input.positions.reduce(
+    (sum, pos) =>
+      Number.isFinite(pos.cumulativeRewardsClaimedUsd ?? 0)
+        ? sum + (pos.cumulativeRewardsClaimedUsd ?? 0)
+        : sum,
+    0,
+  );
+
+  const walletBalanceUsd =
+    input.walletBalanceUsd !== null && Number.isFinite(input.walletBalanceUsd)
+      ? input.walletBalanceUsd
+      : 0;
+  const walletKnown = input.walletBalanceUsd !== null && Number.isFinite(input.walletBalanceUsd);
+  const totalEquityUsd = positionsValueUsd + walletBalanceUsd;
+  const unrealizedPnlUsd =
+    totalEquityUsd + totalFeesClaimedUsd + totalRewardsClaimedUsd - totalDepositedUsd;
+  const unrealizedPnlPct = totalDepositedUsd > 0 ? (unrealizedPnlUsd / totalDepositedUsd) * 100 : 0;
+
+  return {
+    positionsValueUsd,
+    walletBalanceUsd,
+    totalEquityUsd,
+    totalDepositedUsd,
+    totalFeesClaimedUsd,
+    totalRewardsClaimedUsd,
+    unrealizedPnlUsd,
+    unrealizedPnlPct,
+    walletKnown,
+  };
+}


### PR DESCRIPTION
Closes #149

## Problem
`prism portfolio` / `prism status` report **positions-only equity** — the wallet's liquid SOL + USDC balance is never added. A live wallet worth ~$91 (liquid $54.18 + positions $36.82) showed a phantom **-12%..-16%** unrealized loss and could trip a phantom `daily_drawdown` safety pause (the #148/#150 latch family).

## Fix
- **`engine/pnl.ts`** — new canonical `computePortfolioEquity`: true equity = liquid wallet + open-position value; equity-based unrealized P&L = (equity + claimed fees + claimed rewards − total deposits). Unknown wallet (null) falls back to positions-only — never fabricates a figure.
- **`cli/portfolio.ts`** — `readCliWalletBalance()` (fail-open, 15s bound, null when no wallet configured); `computeSummaryWithEquity` extends `PortfolioSummary` with `walletBalanceUsd` / `totalEquityUsd` / `walletKnown`. Portfolio CLI, summary subcommand and JSON now surface **Wallet Balance** and **Total Equity**.
- **`cli/status.ts`** — same equity-aware summary in human, `--message` and `--json` output; layer gains the adapter (ConfigLive-provided).
- Paper mode (no wallet) keeps the exact pre-fix output — no fake $0 wallet line.

## Verification
- Full suite: **110 files / 1401 tests pass** (6 new `computePortfolioEquity` cases incl. the issue's real numbers: wallet 54.18 + positions 36.82 = 91 equity vs 41.89 deposited → profit).
- Paper CLI output byte-identical to pre-fix (positions-only, no wallet line).
- Live-with-dead-RPC fails open to positions-only (no crash, no fake number).

## Summary by Sourcery

Surface true wallet-inclusive portfolio equity in CLI status and portfolio commands and centralize equity computation in the PnL engine.

New Features:
- Expose wallet liquid balance and total equity in portfolio and status CLI human and JSON outputs.
- Provide JSON fields for wallet metadata and equity summary alongside positions-only summaries for backward compatibility.

Bug Fixes:
- Correct unrealized P&L calculations to account for wallet balances, eliminating understated equity and phantom drawdown signals when a real wallet is present.
- Ensure paper mode and unreadable wallets fall back to positions-only equity without fabricating a zero wallet balance.

Enhancements:
- Introduce a canonical computePortfolioEquity helper to aggregate wallet, position value, deposits, and claimed rewards/fees.
- Extend CLI infrastructure to read wallet balances via the adapter layer with bounded, fail-open behavior.

Tests:
- Add unit tests covering portfolio equity computation, including real-world regression numbers and edge cases like non-finite values and empty portfolios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portfolio summaries now include wallet balance, total equity, and whether the wallet is known.
  * Added portfolio-level equity accounting, including unrealized P&L, claimed fees, rewards, and optional wallet funds (when available).
  * CLI portfolio and status outputs (human-readable and JSON) now show wallet and equity details.
* **Bug Fixes**
  * Unknown or non-finite wallet balances are treated as zero, preserving positions-only equity reporting.
* **Tests**
  * Added coverage for wallet-inclusive and fallback equity scenarios, including empty and invalid-wallet cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->