### PR TITLE
feat(fallen-angel): mean-reversion mode — DB config, Gecko OHLCV + RugCheck fetchers, any-TVL discovery, TP-ladder + invalidation-stop lifecycle

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -10,3 +10,7 @@ paths-ignore:
   # Holds a deliberately-invalid, low-entropy WALLET_PRIVATE_KEY fixture used to
   # exercise the "env key present but undecodable" path. Not a credential.
   - "bench/wallet.test.ts"
+  # Fallen-angel fetcher tests embed public Solana mint addresses (JitoSOL,
+  # ANTFUN) as live-verified API fixtures. Public token addresses, not secrets.
+  - "bench/rugcheck.test.ts"
+  - "bench/gecko-ohlcv.test.ts"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,34 @@
+# gitleaks configuration — mirrors the .gitguardian.yaml suppression convention.
+#
+# All entries here are confirmed FALSE POSITIVES, not real secrets:
+#   - Public Solana mint addresses (USDC/USDT/wSOL) in test fixtures and
+#     helpers look like high-entropy keys to the generic-api-key rule.
+#   - `sk-prism-xxx` curl examples in docs are explicit placeholders.
+#   - `config.<UPPER_SNAKE_CASE>` DB-config registry keys look like API-key env
+#     var names (e.g. FALLEN_ANGEL_MAX_TOP10_HOLDER_PCT) but are key NAMES in a
+#     registry, never values.
+#
+# Paths are Go regexes matched against file paths; TOML literal single-quoted
+# strings keep the backslashes intact (basic strings would reject `\.`).
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = 'Confirmed false positives (public mints, doc placeholders, config key names)'
+regexes = [
+  # Public Solana mint addresses used as pair legs in fixtures/helpers.
+  'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', # USDC
+  'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB', # USDT
+  'So11111111111111111111111111111111111111112',  # SOL/wSOL
+  # Documentation curl examples use an explicit placeholder token.
+  'sk-prism-xxx',
+]
+paths = [
+  'engine/db-config\.ts$',
+  'bench/strategy\.test\.ts$',
+  'bench/helpers\.ts$',
+  'ops/backtest\.ts$',
+  'docs/agent-harness\.md$',
+  'cloudflare/README\.md$',
+]

--- a/.pi-lens.json
+++ b/.pi-lens.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://pi-lens.dev/schema.json",
+  "disabledServers": ["deno"],
+  "ignore": ["node_modules/**", "dist/**", "logs/**", "bench/tmp-audit/**"]
+}

--- a/bench/db-config.test.ts
+++ b/bench/db-config.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Database } from "bun:sqlite";
+import fs from "fs";
+import {
+  dbConfigKey,
+  DB_CONFIG_KEYS,
+  findDbConfigSpec,
+  parseDbConfigValue,
+  readDbConfigOverrides,
+  applyDbConfigOverrides,
+} from "../engine/db-config.js";
+import type { AppConfig } from "../engine/config-service.js";
+
+/** Minimal AppConfig-shaped base for override tests. */
+function baseConfig(): AppConfig {
+  return {
+    minPoolTvlUsd: 50_000,
+    volumeAuthThreshold: 0.7,
+    minFeeIlRatio: 1.2,
+    tvlDropExitPct: 0.3,
+    maxPerPoolAllocationPct: 0.4,
+    maxOpenPositions: 3,
+    fallenAngelEnabled: false,
+    fallenAngelMinTvlUsd: 50_000,
+    fallenAngelMinDrawdownPct: 0.6,
+    fallenAngelMaxDrawdownPct: 0.95,
+    fallenAngelVolBaselineMin: 0.02,
+    fallenAngelVolBaselineMax: 0.35,
+    fallenAngelMinRugcheckScore: 0.7,
+    fallenAngelMinHolders: 300,
+    fallenAngelMaxTop10HolderPct: 0.5,
+    fallenAngelInvalidationStopPct: 0.25,
+    fallenAngelMaxPositions: 2,
+  } as AppConfig;
+}
+
+// Bun auto-loads `.env` into process.env, and this repo's own .env sets many of
+// the same keys (e.g. MIN_POOL_TVL_USD). Clear every overridable key so the
+// sidecar's precedence decisions are deterministic in tests.
+beforeEach(() => {
+  for (const spec of DB_CONFIG_KEYS) {
+    vi.stubEnv(spec.envKey, undefined);
+  }
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("db-config registry", () => {
+  it("round-trips keys through the prefix", () => {
+    expect(dbConfigKey("MIN_POOL_TVL_USD")).toBe("config.MIN_POOL_TVL_USD");
+  });
+
+  it("exposes the allowlist and lookup", () => {
+    expect(DB_CONFIG_KEYS.length).toBeGreaterThan(10);
+    const spec = findDbConfigSpec("MIN_POOL_TVL_USD");
+    expect(spec?.field).toBe("minPoolTvlUsd");
+    expect(findDbConfigSpec("WALLET_PRIVATE_KEY")).toBeUndefined();
+  });
+
+  it("rejects edits to non-allowlisted values (secrets cannot be stored)", () => {
+    for (const spec of DB_CONFIG_KEYS) {
+      expect(["WALLET_PRIVATE_KEY", "HELIUS_API_KEY", "SOLANA_RPC_URL"]).not.toContain(spec.envKey);
+    }
+  });
+});
+
+describe("parseDbConfigValue", () => {
+  it("parses booleans", () => {
+    const spec = { envKey: "X", kind: "boolean", field: "fallenAngelEnabled" } as const;
+    expect(parseDbConfigValue(spec, "true")).toBe(true);
+    expect(parseDbConfigValue(spec, "1")).toBe(true);
+    expect(parseDbConfigValue(spec, "false")).toBe(false);
+    expect(parseDbConfigValue(spec, "0")).toBe(false);
+    expect(parseDbConfigValue(spec, "maybe")).toBeNull();
+  });
+
+  it("parses numbers and clamps to bounds", () => {
+    const num = { envKey: "X", kind: "number", field: "minPoolTvlUsd", min: 0 } as const;
+    expect(parseDbConfigValue(num, "25000")).toBe(25_000);
+    const pct = {
+      envKey: "X",
+      kind: "number",
+      field: "volumeAuthThreshold",
+      min: 0,
+      max: 1,
+    } as const;
+    // clamp below min
+    expect(parseDbConfigValue(pct, "-2")).toBe(0);
+    // clamp above max
+    expect(parseDbConfigValue(pct, "5")).toBe(1);
+    // non-finite
+    expect(parseDbConfigValue(num, "abc")).toBeNull();
+    // empty
+    expect(parseDbConfigValue(num, "  ")).toBeNull();
+  });
+});
+
+describe("readDbConfigOverrides + applyDbConfigOverrides", () => {
+  it("reads persisted rows from the metadata table", () => {
+    const path = "/tmp/prism-db-config-test.sqlite";
+    for (const suffix of ["", "-journal", "-wal", "-shm"]) {
+      fs.rmSync(`${path}${suffix}`, { force: true });
+    }
+    const fileDb = new Database(path);
+    fileDb.exec(
+      "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at INTEGER NOT NULL)",
+    );
+    fileDb.run("INSERT INTO metadata (key, value, updated_at) VALUES (?, ?, ?)", [
+      "config.MIN_POOL_TVL_USD",
+      "12345",
+      Date.now(),
+    ]);
+    fileDb.run("INSERT INTO metadata (key, value, updated_at) VALUES (?, ?, ?)", [
+      "other.key",
+      "junk",
+      Date.now(),
+    ]);
+    fileDb.close();
+
+    const map = readDbConfigOverrides(path);
+    expect(map.get("config.MIN_POOL_TVL_USD")).toBe("12345");
+    expect(map.get("other.key")).toBeUndefined();
+    for (const suffix of ["", "-journal", "-wal", "-shm"]) {
+      fs.rmSync(`${path}${suffix}`, { force: true });
+    }
+  });
+
+  it("returns empty map for missing DB (fail-open)", () => {
+    expect(readDbConfigOverrides("/nonexistent/nope.sqlite").size).toBe(0);
+  });
+
+  it("returns empty map when the DB predates the metadata table", () => {
+    const path = "/tmp/prism-db-config-predate.sqlite";
+    for (const suffix of ["", "-journal", "-wal", "-shm"]) {
+      fs.rmSync(`${path}${suffix}`, { force: true });
+    }
+    const db = new Database(path);
+    db.exec("CREATE TABLE other_table (id INTEGER PRIMARY KEY)");
+    db.close();
+    expect(readDbConfigOverrides(path).size).toBe(0);
+    fs.rmSync(path, { force: true });
+  });
+
+  it("applies DB overrides for keys whose env var is unset", () => {
+    const base = baseConfig();
+    const overrides = new Map([
+      [dbConfigKey("MIN_POOL_TVL_USD"), "12345"],
+      [dbConfigKey("FALLEN_ANGEL_ENABLED"), "true"],
+    ]);
+    const applied = applyDbConfigOverrides(base, overrides);
+    expect(applied.minPoolTvlUsd).toBe(12_345);
+    expect(applied.fallenAngelEnabled).toBe(true);
+    // untouched key keeps its value
+    expect(applied.volumeAuthThreshold).toBe(0.7);
+  });
+
+  it("env var beats the DB row", () => {
+    vi.stubEnv("MIN_POOL_TVL_USD", "999999");
+    const base = baseConfig();
+    const overrides = new Map([[dbConfigKey("MIN_POOL_TVL_USD"), "12345"]]);
+    const applied = applyDbConfigOverrides(base, overrides);
+    // DB row ignored (env present); the env value itself is applied by
+    // loadConfig, NOT by this sidecar layer.
+    expect(applied.minPoolTvlUsd).toBe(50_000);
+  });
+
+  it("skips malformed rows instead of crashing", () => {
+    const base = baseConfig();
+    const overrides = new Map([[dbConfigKey("FALLEN_ANGEL_ENABLED"), "definitely"]]);
+    const applied = applyDbConfigOverrides(base, overrides);
+    expect(applied.fallenAngelEnabled).toBe(false);
+    expect(applied.minPoolTvlUsd).toBe(50_000);
+  });
+
+  it("does not mutate the base object", () => {
+    const base = baseConfig();
+    const overrides = new Map([[dbConfigKey("MIN_POOL_TVL_USD"), "12345"]]);
+    const applied = applyDbConfigOverrides(base, overrides);
+    expect(base.minPoolTvlUsd).toBe(50_000);
+    expect(applied.minPoolTvlUsd).toBe(12_345);
+    expect(applied).not.toBe(base);
+  });
+});

--- a/bench/db-config.test.ts
+++ b/bench/db-config.test.ts
@@ -26,12 +26,12 @@ function baseConfig(): AppConfig {
     fallenAngelMaxDrawdownPct: 0.95,
     fallenAngelVolBaselineMin: 0.02,
     fallenAngelVolBaselineMax: 0.35,
-    fallenAngelMinRugcheckScore: 0.7,
+    fallenAngelMaxRugcheckScore: 0.7,
     fallenAngelMinHolders: 300,
     fallenAngelMaxTop10HolderPct: 0.5,
     fallenAngelInvalidationStopPct: 0.25,
     fallenAngelMaxPositions: 2,
-  } as AppConfig;
+  } as unknown as AppConfig;
 }
 
 // Bun auto-loads `.env` into process.env, and this repo's own .env sets many of

--- a/bench/db-positions.test.ts
+++ b/bench/db-positions.test.ts
@@ -77,6 +77,48 @@ describe("DbService — positions", () => {
     );
   });
 
+  it("round-trips fallen-angel lifecycle fields", () => {
+    const layer = makeLayer();
+    const pos = makePosition({
+      positionId: "paper-FA1",
+      poolAddress: "pool-fa",
+      positionPubKey: null,
+    });
+
+    run(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        yield* db.savePosition({
+          ...pos,
+          positionMode: "fallen-angel",
+          tpLadderJson: '{"rungs":[{"targetPrice":115,"fraction":0.4}]}',
+          invalidationStopPrice: 75,
+        });
+        const retrieved = yield* db.getPosition(pos.positionId);
+        expect(retrieved!.positionMode).toBe("fallen-angel");
+        expect(retrieved!.tpLadderJson).toContain("targetPrice");
+        expect(retrieved!.invalidationStopPrice).toBe(75);
+      }),
+      layer,
+    );
+  });
+
+  it("defaults fallen-angel fields to null for legacy rows", () => {
+    const layer = makeLayer();
+    const pos = makePosition();
+
+    run(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        yield* db.savePosition(pos);
+        const retrieved = yield* db.getPosition(pos.positionId);
+        expect(retrieved!.positionMode).toBeNull();
+        expect(retrieved!.tpLadderJson).toBeNull();
+        expect(retrieved!.invalidationStopPrice).toBeNull();
+      }),
+      layer,
+    );
+  });
   it("upserts on duplicate position id", () => {
     const layer = makeLayer();
     const pos1 = makePosition({ depositedUsd: 1000 });

--- a/bench/fallen-angel-discovery.test.ts
+++ b/bench/fallen-angel-discovery.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateFallenAngelDiscovery,
+  type FallenAngelDiscoveredPool,
+  type FallenAngelPoolSignals,
+} from "../engine/fallen-angel-discovery.js";
+import { parseRugCheckReport } from "../engine/rugcheck-service.js";
+import type { GeckoOhlcvSignals } from "../engine/gecko-ohlcv-service.js";
+
+const CONFIG = {
+  minTvlUsd: 50_000,
+  minDrawdownPct: 0.6,
+  maxDrawdownPct: 0.95,
+  volBaselineMin: 0.02,
+  volBaselineMax: 0.35,
+  maxRugcheckScore: 60,
+  minHolders: 300,
+  maxTop10HolderPct: 0.5,
+};
+
+const STABLES = new Set(["USDC", "USDT"]);
+
+const CLEAN_OHLCV: GeckoOhlcvSignals = {
+  bars: [],
+  atlHigh: 10,
+  latestClose: 2,
+  drawdownFromAth: 0.8,
+  dailyReturnStddev: 0.05,
+  totalVolumeQuote: 1_000_000,
+  barCount: 30,
+};
+
+const CLEAN_RUGCHECK = parseRugCheckReport({
+  mint: "asset",
+  token: { mintAuthority: null, freezeAuthority: null },
+  tokenMeta: { mutable: false },
+  risks: [{ name: "Mutable metadata", level: "warn" }],
+  score_normalised: 20,
+  totalHolders: 5000,
+  topHolders: [{ address: "a", amount: 1, pct: 10, owner: null, insider: false }],
+  rugged: false,
+});
+
+const RISKY_RUGCHECK = parseRugCheckReport({
+  mint: "asset",
+  token: { mintAuthority: "MA", freezeAuthority: null },
+  tokenMeta: { mutable: false },
+  risks: [{ name: "Mint Authority still enabled", level: "danger" }],
+  score_normalised: 20,
+  totalHolders: 5000,
+  topHolders: [],
+  rugged: false,
+});
+
+function pool(overrides: Partial<FallenAngelDiscoveredPool> = {}): FallenAngelDiscoveredPool {
+  return {
+    address: overrides.address ?? "Pool111111111111111111111111111111111111111",
+    tvlUsd: overrides.tvlUsd ?? 100_000,
+    tokenX: overrides.tokenX ?? "ASSET",
+    tokenY: overrides.tokenY ?? "USDC",
+  };
+}
+
+function signals(overrides: Partial<FallenAngelPoolSignals> = {}): FallenAngelPoolSignals {
+  return {
+    ohlcv: overrides.ohlcv ?? CLEAN_OHLCV,
+    rugcheck: overrides.rugcheck ?? CLEAN_RUGCHECK,
+  };
+}
+
+describe("evaluateFallenAngelDiscovery", () => {
+  it("qualifies a clean fallen-angel pool", async () => {
+    const result = await evaluateFallenAngelDiscovery([pool()], CONFIG, STABLES, async () =>
+      signals(),
+    );
+    expect(result.qualified).toHaveLength(1);
+    expect(result.qualified[0]!.poolAddress).toBe("Pool111111111111111111111111111111111111111");
+    expect(result.qualified[0]!.assetMint).toBe("ASSET");
+    expect(result.qualified[0]!.drawdownPct).toBeCloseTo(0.8, 6);
+    expect(result.rejected).toHaveLength(0);
+  });
+
+  it("skips pools below the TVL floor without rejecting them", async () => {
+    let fetched = 0;
+    const result = await evaluateFallenAngelDiscovery(
+      [pool({ tvlUsd: 10_000 })],
+      CONFIG,
+      STABLES,
+      async () => {
+        fetched++;
+        return signals();
+      },
+    );
+    expect(result.qualified).toHaveLength(0);
+    expect(result.rejected).toHaveLength(0);
+    expect(fetched).toBe(0); // never fetched — out of universe
+  });
+
+  it("rejects a pool with danger risks and records the reason", async () => {
+    const result = await evaluateFallenAngelDiscovery([pool()], CONFIG, STABLES, async () =>
+      signals({ rugcheck: RISKY_RUGCHECK }),
+    );
+    expect(result.qualified).toHaveLength(0);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]!.reasons.join(" ")).toContain("danger");
+  });
+
+  it("rejects a stablecoin pair (no asset leg)", async () => {
+    const result = await evaluateFallenAngelDiscovery(
+      [pool({ tokenX: "USDC", tokenY: "USDT" })],
+      CONFIG,
+      STABLES,
+      async () => signals(),
+    );
+    expect(result.qualified).toHaveLength(0);
+    expect(result.rejected[0]!.reasons.join(" ")).toContain("asset leg");
+  });
+
+  it("rejects when signals are unavailable (fail-closed)", async () => {
+    const result = await evaluateFallenAngelDiscovery([pool()], CONFIG, STABLES, async () => ({
+      ohlcv: null,
+      rugcheck: null,
+    }));
+    expect(result.qualified).toHaveLength(0);
+    expect(result.rejected[0]!.reasons.join(" ")).toContain("OHLCV");
+    expect(result.rejected[0]!.reasons.join(" ")).toContain("RugCheck");
+  });
+
+  it("fetches signals only for pools that clear the TVL floor", async () => {
+    const fetched = new Set<string>();
+    const result = await evaluateFallenAngelDiscovery(
+      [pool({ address: "a", tvlUsd: 10_000 }), pool({ address: "b" })],
+      CONFIG,
+      STABLES,
+      async (p) => {
+        fetched.add(p.address);
+        return signals();
+      },
+    );
+    expect(fetched.has("a")).toBe(false);
+    expect(fetched.has("b")).toBe(true);
+    expect(result.qualified.map((q) => q.poolAddress)).toEqual(["b"]);
+  });
+});

--- a/bench/fallen-angel-discovery.test.ts
+++ b/bench/fallen-angel-discovery.test.ts
@@ -19,6 +19,7 @@ const CONFIG = {
 };
 
 const STABLES = new Set(["USDC", "USDT"]);
+const SOL = "So11111111111111111111111111111111111111112";
 
 const CLEAN_OHLCV: GeckoOhlcvSignals = {
   bars: [],
@@ -70,7 +71,7 @@ function signals(overrides: Partial<FallenAngelPoolSignals> = {}): FallenAngelPo
 
 describe("evaluateFallenAngelDiscovery", () => {
   it("qualifies a clean fallen-angel pool", async () => {
-    const result = await evaluateFallenAngelDiscovery([pool()], CONFIG, STABLES, async () =>
+    const result = await evaluateFallenAngelDiscovery([pool()], CONFIG, STABLES, SOL, async () =>
       signals(),
     );
     expect(result.qualified).toHaveLength(1);
@@ -86,6 +87,7 @@ describe("evaluateFallenAngelDiscovery", () => {
       [pool({ tvlUsd: 10_000 })],
       CONFIG,
       STABLES,
+      SOL,
       async () => {
         fetched++;
         return signals();
@@ -97,7 +99,7 @@ describe("evaluateFallenAngelDiscovery", () => {
   });
 
   it("rejects a pool with danger risks and records the reason", async () => {
-    const result = await evaluateFallenAngelDiscovery([pool()], CONFIG, STABLES, async () =>
+    const result = await evaluateFallenAngelDiscovery([pool()], CONFIG, STABLES, SOL, async () =>
       signals({ rugcheck: RISKY_RUGCHECK }),
     );
     expect(result.qualified).toHaveLength(0);
@@ -110,6 +112,7 @@ describe("evaluateFallenAngelDiscovery", () => {
       [pool({ tokenX: "USDC", tokenY: "USDT" })],
       CONFIG,
       STABLES,
+      SOL,
       async () => signals(),
     );
     expect(result.qualified).toHaveLength(0);
@@ -117,7 +120,7 @@ describe("evaluateFallenAngelDiscovery", () => {
   });
 
   it("rejects when signals are unavailable (fail-closed)", async () => {
-    const result = await evaluateFallenAngelDiscovery([pool()], CONFIG, STABLES, async () => ({
+    const result = await evaluateFallenAngelDiscovery([pool()], CONFIG, STABLES, SOL, async () => ({
       ohlcv: null,
       rugcheck: null,
     }));
@@ -132,6 +135,7 @@ describe("evaluateFallenAngelDiscovery", () => {
       [pool({ address: "a", tvlUsd: 10_000 }), pool({ address: "b" })],
       CONFIG,
       STABLES,
+      SOL,
       async (p) => {
         fetched.add(p.address);
         return signals();

--- a/bench/fallen-angel-service.test.ts
+++ b/bench/fallen-angel-service.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateFallenAngelGate,
+  identifyAssetMint,
+  hasDangerRisks,
+  type FallenAngelGateConfig,
+} from "../engine/fallen-angel-service.js";
+import type { GeckoOhlcvSignals } from "../engine/gecko-ohlcv-service.js";
+import { parseRugCheckReport } from "../engine/rugcheck-service.js";
+
+const CONFIG: FallenAngelGateConfig = {
+  minTvlUsd: 50_000,
+  minDrawdownPct: 0.6,
+  maxDrawdownPct: 0.95,
+  volBaselineMin: 0.02,
+  volBaselineMax: 0.35,
+  maxRugcheckScore: 60,
+  minHolders: 300,
+  maxTop10HolderPct: 0.5,
+};
+
+// A clean, deeply-drawn-down, calm token.
+const CLEAN_OHLCV: GeckoOhlcvSignals = {
+  bars: [],
+  atlHigh: 10,
+  latestClose: 2,
+  drawdownFromAth: 0.8,
+  dailyReturnStddev: 0.05,
+  totalVolumeQuote: 1_000_000,
+  barCount: 30,
+};
+
+const CLEAN_RUGCHECK = parseRugCheckReport({
+  mint: "asset",
+  token: { mintAuthority: null, freezeAuthority: null },
+  tokenMeta: { mutable: false },
+  risks: [{ name: "Mutable metadata", level: "warn" }],
+  score_normalised: 20,
+  totalHolders: 5000,
+  topHolders: [
+    { address: "a", amount: 1, pct: 10, owner: "o", insider: false },
+    { address: "b", amount: 1, pct: 8, owner: null, insider: false },
+  ],
+  rugged: false,
+});
+
+describe("evaluateFallenAngelGate", () => {
+  it("qualifies a clean, deeply-drawn-down, calm token", () => {
+    const r = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: CLEAN_OHLCV,
+      rugcheck: CLEAN_RUGCHECK,
+      config: CONFIG,
+    });
+    expect(r.qualified).toBe(true);
+    expect(r.reasons).toEqual([]);
+  });
+
+  it("rejects below the TVL floor", () => {
+    const r = evaluateFallenAngelGate({
+      poolTvlUsd: 10_000,
+      assetMint: "asset",
+      ohlcv: CLEAN_OHLCV,
+      rugcheck: CLEAN_RUGCHECK,
+      config: CONFIG,
+    });
+    expect(r.qualified).toBe(false);
+    expect(r.reasons.join(" ")).toContain("TVL");
+  });
+
+  it("rejects when OHLCV is unavailable (fail-closed on drawdown)", () => {
+    const r = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: null,
+      rugcheck: CLEAN_RUGCHECK,
+      config: CONFIG,
+    });
+    expect(r.qualified).toBe(false);
+    expect(r.reasons.join(" ")).toContain("OHLCV");
+  });
+
+  it("rejects when RugCheck is unavailable (fail-closed on security)", () => {
+    const r = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: CLEAN_OHLCV,
+      rugcheck: null,
+      config: CONFIG,
+    });
+    expect(r.qualified).toBe(false);
+    expect(r.reasons.join(" ")).toContain("RugCheck");
+  });
+
+  it("rejects danger-level risks (mint authority, LP unlocked)", () => {
+    const risky = parseRugCheckReport({
+      mint: "asset",
+      token: { mintAuthority: "MA", freezeAuthority: null },
+      tokenMeta: { mutable: false },
+      risks: [{ name: "Mint Authority still enabled", level: "danger" }],
+      score_normalised: 20,
+      totalHolders: 5000,
+      topHolders: [],
+      rugged: false,
+    });
+    const r = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: CLEAN_OHLCV,
+      rugcheck: risky,
+      config: CONFIG,
+    });
+    expect(r.qualified).toBe(false);
+    expect(r.reasons.join(" ")).toContain("danger");
+    expect(r.reasons.join(" ")).toContain("mint authority");
+  });
+
+  it("rejects high RugCheck risk score (score_normalised > max)", () => {
+    const highScore = parseRugCheckReport({
+      mint: "asset",
+      token: { mintAuthority: null, freezeAuthority: null },
+      tokenMeta: { mutable: false },
+      risks: [],
+      score_normalised: 90,
+      totalHolders: 5000,
+      topHolders: [],
+      rugged: false,
+    });
+    const r = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: CLEAN_OHLCV,
+      rugcheck: highScore,
+      config: CONFIG,
+    });
+    expect(r.qualified).toBe(false);
+    expect(r.reasons.join(" ")).toContain("risk score");
+  });
+
+  it("rejects insufficient drawdown (not fallen enough)", () => {
+    const shallow = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: { ...CLEAN_OHLCV, drawdownFromAth: 0.2 },
+      rugcheck: CLEAN_RUGCHECK,
+      config: CONFIG,
+    });
+    expect(shallow.qualified).toBe(false);
+    expect(shallow.reasons.join(" ")).toContain("minimum");
+  });
+
+  it("rejects an over-drawn token (dead, not fallen)", () => {
+    const dead = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: { ...CLEAN_OHLCV, drawdownFromAth: 0.99 },
+      rugcheck: CLEAN_RUGCHECK,
+      config: CONFIG,
+    });
+    expect(dead.qualified).toBe(false);
+    expect(dead.reasons.join(" ")).toContain("dead token");
+  });
+
+  it("rejects a token too dead to mean-revert (vol below floor)", () => {
+    const flat = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: { ...CLEAN_OHLCV, dailyReturnStddev: 0.001 },
+      rugcheck: CLEAN_RUGCHECK,
+      config: CONFIG,
+    });
+    expect(flat.qualified).toBe(false);
+    expect(flat.reasons.join(" ")).toContain("below volatility floor");
+  });
+
+  it("rejects a lunatic token (vol above ceiling)", () => {
+    const wild = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: { ...CLEAN_OHLCV, dailyReturnStddev: 0.9 },
+      rugcheck: CLEAN_RUGCHECK,
+      config: CONFIG,
+    });
+    expect(wild.qualified).toBe(false);
+    expect(wild.reasons.join(" ")).toContain("above volatility ceiling");
+  });
+
+  it("rejects a concentrated token (top-10 > max)", () => {
+    const concentrated = parseRugCheckReport({
+      mint: "asset",
+      token: { mintAuthority: null, freezeAuthority: null },
+      tokenMeta: { mutable: false },
+      risks: [],
+      score_normalised: 20,
+      totalHolders: 5000,
+      topHolders: [
+        { address: "a", amount: 1, pct: 40, owner: null, insider: false },
+        { address: "b", amount: 1, pct: 30, owner: null, insider: false },
+      ],
+      rugged: false,
+    });
+    const r = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: CLEAN_OHLCV,
+      rugcheck: concentrated,
+      config: CONFIG,
+    });
+    expect(r.qualified).toBe(false);
+    expect(r.reasons.join(" ")).toContain("Top-10 holder concentration");
+  });
+
+  it("fails open on missing topHolders (concentration not enforced)", () => {
+    const noHolders = parseRugCheckReport({
+      mint: "asset",
+      token: { mintAuthority: null, freezeAuthority: null },
+      tokenMeta: { mutable: false },
+      risks: [],
+      score_normalised: 20,
+      totalHolders: 5000,
+      topHolders: null,
+      rugged: false,
+    });
+    const r = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: CLEAN_OHLCV,
+      rugcheck: noHolders,
+      config: CONFIG,
+    });
+    expect(r.qualified).toBe(true);
+  });
+
+  it("rejects a token with too few holders", () => {
+    const few = parseRugCheckReport({
+      mint: "asset",
+      token: { mintAuthority: null, freezeAuthority: null },
+      tokenMeta: { mutable: false },
+      risks: [],
+      score_normalised: 20,
+      totalHolders: 50,
+      topHolders: [],
+      rugged: false,
+    });
+    const r = evaluateFallenAngelGate({
+      poolTvlUsd: 100_000,
+      assetMint: "asset",
+      ohlcv: CLEAN_OHLCV,
+      rugcheck: few,
+      config: CONFIG,
+    });
+    expect(r.qualified).toBe(false);
+    expect(r.reasons.join(" ")).toContain("below minimum");
+  });
+});
+
+describe("identifyAssetMint", () => {
+  const stables = new Set(["USDC", "USDT"]);
+
+  it("picks the non-stablecoin leg", () => {
+    expect(identifyAssetMint("SOL", "USDC", stables)).toBe("SOL");
+    expect(identifyAssetMint("USDC", "JUP", stables)).toBe("JUP");
+  });
+
+  it("returns null for a stablecoin pair (no asset leg)", () => {
+    expect(identifyAssetMint("USDC", "USDT", stables)).toBeNull();
+  });
+
+  it("returns the first leg when neither is stable", () => {
+    expect(identifyAssetMint("SOL", "JUP", stables)).toBe("SOL");
+  });
+
+  it("returns null when the allowlist is empty (no notion of stable)", () => {
+    expect(identifyAssetMint("USDC", "USDT", undefined)).toBeNull();
+  });
+});
+
+describe("hasDangerRisks", () => {
+  it("detects danger-level risks", () => {
+    const r = parseRugCheckReport({
+      mint: "x",
+      token: { mintAuthority: null, freezeAuthority: null },
+      tokenMeta: { mutable: false },
+      risks: [{ name: "LP Unlocked", level: "danger" }],
+      score_normalised: 20,
+      totalHolders: 100,
+      topHolders: [],
+      rugged: false,
+    })!;
+    expect(hasDangerRisks(r)).toBe(true);
+  });
+
+  it("returns false for warn-only or no risks", () => {
+    const r = parseRugCheckReport({
+      mint: "x",
+      token: { mintAuthority: null, freezeAuthority: null },
+      tokenMeta: { mutable: false },
+      risks: [{ name: "Mutable metadata", level: "warn" }],
+      score_normalised: 20,
+      totalHolders: 100,
+      topHolders: [],
+      rugged: false,
+    })!;
+    expect(hasDangerRisks(r)).toBe(false);
+  });
+});

--- a/bench/fallen-angel-service.test.ts
+++ b/bench/fallen-angel-service.test.ts
@@ -257,22 +257,25 @@ describe("evaluateFallenAngelGate", () => {
 
 describe("identifyAssetMint", () => {
   const stables = new Set(["USDC", "USDT"]);
+  const SOL = "So11111111111111111111111111111111111111112";
 
-  it("picks the non-stablecoin leg", () => {
-    expect(identifyAssetMint("SOL", "USDC", stables)).toBe("SOL");
-    expect(identifyAssetMint("USDC", "JUP", stables)).toBe("JUP");
+  it("picks the non-stablecoin, non-SOL leg", () => {
+    expect(identifyAssetMint(SOL, "USDC", stables, SOL)).toBeNull(); // SOL+stable → no asset
+    expect(identifyAssetMint("USDC", "JUP", stables, SOL)).toBe("JUP");
+  });
+
+  it("treats SOL as a settlement leg, never the asset", () => {
+    // SOL/JUP with a stable allowlist: SOL is excluded → JUP is the asset.
+    expect(identifyAssetMint(SOL, "JUP", stables, SOL)).toBe("JUP");
+    expect(identifyAssetMint("JUP", SOL, stables, SOL)).toBe("JUP");
   });
 
   it("returns null for a stablecoin pair (no asset leg)", () => {
-    expect(identifyAssetMint("USDC", "USDT", stables)).toBeNull();
-  });
-
-  it("returns the first leg when neither is stable", () => {
-    expect(identifyAssetMint("SOL", "JUP", stables)).toBe("SOL");
+    expect(identifyAssetMint("USDC", "USDT", stables, SOL)).toBeNull();
   });
 
   it("returns null when the allowlist is empty (no notion of stable)", () => {
-    expect(identifyAssetMint("USDC", "USDT", undefined)).toBeNull();
+    expect(identifyAssetMint("USDC", "USDT", undefined, SOL)).toBeNull();
   });
 });
 

--- a/bench/gecko-ohlcv.test.ts
+++ b/bench/gecko-ohlcv.test.ts
@@ -50,10 +50,25 @@ describe("parseGeckoOhlcv", () => {
     expect(bars[0]!.volumeQuote).toBeCloseTo(1890678.01, 1);
   });
 
-  it("keeps newest bar last (ascending order preserved)", () => {
+  it("preserves the API's newest-first row order in the parsed bars", () => {
     const bars = parseGeckoOhlcv(LIVE_OHLCV);
+    // GeckoTerminal returns ohlcv_list newest-first; parsing must preserve
+    // that (summarizeGeckoOhlcv normalizes to ascending internally).
     expect(bars[bars.length - 1]!.timestampSec).toBeLessThan(bars[0]!.timestampSec);
     expect(bars[bars.length - 1]!.close).toBeCloseTo(0.0439028, 6);
+  });
+
+  it("computes drawdown from the LATEST close even when input is newest-first", () => {
+    // Newest bar first (timestamp 3, close 1.25); oldest last (timestamp 1).
+    const newestFirst: GeckoOhlcvBar[] = [
+      { timestampSec: 3, open: 1.2, high: 1.5, low: 1.1, close: 1.25, volumeQuote: 100 },
+      { timestampSec: 2, open: 1.0, high: 1.6, low: 0.9, close: 1.4, volumeQuote: 100 },
+      { timestampSec: 1, open: 1.0, high: 2.0, low: 0.8, close: 1.5, volumeQuote: 100 },
+    ];
+    const s = summarizeGeckoOhlcv(newestFirst);
+    // ATH = 2.0 (all highs); latest = the NEWEST close 1.25 → drawdown = 1 - 1.25/2.
+    expect(s.latestClose).toBeCloseTo(1.25, 6);
+    expect(s.drawdownFromAth).toBeCloseTo(1 - 1.25 / 2, 6);
   });
 
   it("returns [] for malformed / empty payloads", () => {

--- a/bench/gecko-ohlcv.test.ts
+++ b/bench/gecko-ohlcv.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseGeckoOhlcv,
+  summarizeGeckoOhlcv,
+  getGeckoPoolOhlcv,
+  type GeckoOhlcvBar,
+} from "../engine/gecko-ohlcv-service.js";
+
+// Live-verified payload fragment (2026-08-05, pool 54Vp27uLaw4wNLo5n7r4fcC6zLamoQc28xBARjss4EUJ).
+// ohlcv_list rows are [unixSeconds, open, high, low, close, volume].
+const LIVE_OHLCV = {
+  data: {
+    id: "7e41c2b9",
+    type: "ohlcv_request_response",
+    attributes: {
+      ohlcv_list: [
+        [
+          1785888000, 0.043808700040646194, 0.04391338004930444, 0.04306529366056049,
+          0.0432089334915276, 1890678.0106959,
+        ],
+        [
+          1785801600, 0.043717860331926095, 0.044177497806156624, 0.042507952190013,
+          0.043808700040646194, 4053303.447853192,
+        ],
+        [
+          1785715200, 0.04381447647326329, 0.044499417223687054, 0.0435799522462199,
+          0.043717860331926095, 3105739.8974361727,
+        ],
+        [
+          1785628800, 0.04390281345369361, 0.0443945111172234, 0.04358413202194858,
+          0.04381447647326329, 2554437.233137032,
+        ],
+        [
+          1785542400, 0.0438431320912166, 0.04432228939524769, 0.042785618516131274,
+          0.04390281345369361, 3912004.941657897,
+        ],
+      ],
+    },
+  },
+  meta: { base: { symbol: "ANTFUN" }, quote: { symbol: "USDT" } },
+};
+
+describe("parseGeckoOhlcv", () => {
+  it("parses the live-verified payload", () => {
+    const bars = parseGeckoOhlcv(LIVE_OHLCV);
+    expect(bars.length).toBe(5);
+    expect(bars[0]!.timestampSec).toBe(1785888000);
+    expect(bars[0]!.open).toBeCloseTo(0.0438087, 6);
+    expect(bars[0]!.close).toBeCloseTo(0.0432089, 6);
+    expect(bars[0]!.volumeQuote).toBeCloseTo(1890678.01, 1);
+  });
+
+  it("keeps newest bar last (ascending order preserved)", () => {
+    const bars = parseGeckoOhlcv(LIVE_OHLCV);
+    expect(bars[bars.length - 1]!.timestampSec).toBeLessThan(bars[0]!.timestampSec);
+    expect(bars[bars.length - 1]!.close).toBeCloseTo(0.0439028, 6);
+  });
+
+  it("returns [] for malformed / empty payloads", () => {
+    expect(parseGeckoOhlcv(null)).toEqual([]);
+    expect(parseGeckoOhlcv({})).toEqual([]);
+    expect(parseGeckoOhlcv({ data: {} })).toEqual([]);
+    expect(parseGeckoOhlcv({ data: { attributes: {} } })).toEqual([]);
+    expect(parseGeckoOhlcv({ data: { attributes: { ohlcv_list: "nope" } } })).toEqual([]);
+    expect(parseGeckoOhlcv({ data: { attributes: { ohlcv_list: [] } } })).toEqual([]);
+  });
+
+  it("drops bars with non-positive close", () => {
+    const raw = {
+      data: {
+        attributes: {
+          ohlcv_list: [
+            [1, 1, 2, 0, 0, 100],
+            [2, 1, 2, 0.5, 1.5, 100],
+          ],
+        },
+      },
+    };
+    const bars = parseGeckoOhlcv(raw);
+    expect(bars.length).toBe(1);
+    expect(bars[0]!.close).toBe(1.5);
+  });
+});
+
+describe("summarizeGeckoOhlcv", () => {
+  const bars: GeckoOhlcvBar[] = [
+    { timestampSec: 1, open: 1, high: 2, low: 0.8, close: 1.5, volumeQuote: 100 },
+    { timestampSec: 2, open: 1.5, high: 1.6, low: 1.0, close: 1.2, volumeQuote: 200 },
+    { timestampSec: 3, open: 1.2, high: 1.3, low: 1.1, close: 1.25, volumeQuote: 300 },
+  ];
+
+  it("computes ATH, latest close, and drawdown", () => {
+    const s = summarizeGeckoOhlcv(bars);
+    expect(s.atlHigh).toBe(2);
+    expect(s.latestClose).toBe(1.25);
+    expect(s.drawdownFromAth).toBeCloseTo(1 - 1.25 / 2, 6);
+  });
+
+  it("computes daily-return stddev and total volume", () => {
+    const s = summarizeGeckoOhlcv(bars);
+    expect(s.totalVolumeQuote).toBe(600);
+    expect(s.barCount).toBe(3);
+    expect(s.dailyReturnStddev).toBeGreaterThan(0);
+  });
+
+  it("returns zeros for empty series", () => {
+    const s = summarizeGeckoOhlcv([]);
+    expect(s.atlHigh).toBe(0);
+    expect(s.latestClose).toBe(0);
+    expect(s.drawdownFromAth).toBe(0);
+    expect(s.dailyReturnStddev).toBe(0);
+    expect(s.totalVolumeQuote).toBe(0);
+    expect(s.barCount).toBe(0);
+  });
+
+  it("clamps drawdown to >= 0 (never negative from a weird ATH/close)", () => {
+    const s = summarizeGeckoOhlcv([
+      { timestampSec: 1, open: 1, high: 1, low: 1, close: 2, volumeQuote: 1 },
+    ]);
+    expect(s.drawdownFromAth).toBe(0);
+  });
+});
+
+describe("getGeckoPoolOhlcv", () => {
+  it("returns null on HTTP error (fail-open)", async () => {
+    const fetchImpl = async () => new Response("{}", { status: 404 });
+    const result = await getGeckoPoolOhlcv("pool", { fetchImpl });
+    expect(result).toBeNull();
+  });
+
+  it("returns null on unparseable body", async () => {
+    const fetchImpl = async () => new Response(JSON.stringify({ data: {} }), { status: 200 });
+    const result = await getGeckoPoolOhlcv("pool", { fetchImpl });
+    expect(result).toBeNull();
+  });
+
+  it("returns derived signals on a valid payload", async () => {
+    const fetchImpl = async () => new Response(JSON.stringify(LIVE_OHLCV), { status: 200 });
+    const result = await getGeckoPoolOhlcv("pool", { fetchImpl });
+    expect(result).not.toBeNull();
+    expect(result!.barCount).toBe(5);
+    expect(result!.atlHigh).toBeCloseTo(0.044499417223687054, 6);
+  });
+
+  it("hits the day?limit endpoint", async () => {
+    let calledUrl = "";
+    const fetchImpl = async (input: string | URL | Request) => {
+      calledUrl = String(input);
+      return new Response(
+        JSON.stringify({ data: { attributes: { ohlcv_list: [[1, 1, 2, 0.5, 1.5, 10]] } } }),
+        { status: 200 },
+      );
+    };
+    await getGeckoPoolOhlcv("abc", { fetchImpl, baseUrl: "https://x.example/api/v2", limit: 60 });
+    expect(calledUrl).toContain("/networks/solana/pools/abc/ohlcv/day?limit=60");
+  });
+});

--- a/bench/program.test.ts
+++ b/bench/program.test.ts
@@ -230,6 +230,7 @@ describe("executeLive", () => {
       listFeedbackForAgent: () => Effect.succeed([]),
       getMetadata: () => Effect.succeed(null),
       setMetadata: () => Effect.void,
+      deleteMetadata: () => Effect.void,
       setMetadataBatch: () => Effect.void,
       saveFeeClaim: () => Effect.void,
       getUnreportedFeeClaims: () => Effect.succeed([]),

--- a/bench/rugcheck.test.ts
+++ b/bench/rugcheck.test.ts
@@ -5,7 +5,6 @@ import { parseRugCheckReport, getRugCheckReport } from "../engine/rugcheck-servi
 // score_normalised 56 = RISKY (higher=riskier); has danger risks + topHolders.
 const LIVE_RISKY = {
   mint: "CWZ6BsdnjkDVTGkmL6bGbJXXig6ceef12KvyGQW14cMt",
-  ***REMOVED***
   token: { mintAuthority: null, freezeAuthority: null, decimals: 6 },
   tokenMeta: { name: "AntFun", symbol: "ANTFUN", mutable: false },
   topHolders: [

--- a/bench/rugcheck.test.ts
+++ b/bench/rugcheck.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { parseRugCheckReport, getRugCheckReport } from "../engine/rugcheck-service.js";
+
+// Live-verified payload (2026-08-05, ANTFUN CWZ6BsdnjkDVTGkmL6bGbJXXig6ceef12KvyGQW14cMt):
+// score_normalised 56 = RISKY (higher=riskier); has danger risks + topHolders.
+const LIVE_RISKY = {
+  mint: "CWZ6BsdnjkDVTGkmL6bGbJXXig6ceef12KvyGQW14cMt",
+  ***REMOVED***
+  token: { mintAuthority: null, freezeAuthority: null, decimals: 6 },
+  tokenMeta: { name: "AntFun", symbol: "ANTFUN", mutable: false },
+  topHolders: [
+    {
+      address: "hA1",
+      amount: 1000,
+      decimals: 6,
+      pct: 31.8,
+      uiAmount: 1000,
+      owner: "o1",
+      insider: false,
+    },
+    {
+      address: "hA2",
+      amount: 500,
+      decimals: 6,
+      pct: 12.0,
+      uiAmount: 500,
+      owner: "o2",
+      insider: null,
+    },
+    {
+      address: "hA3",
+      amount: 300,
+      decimals: 6,
+      pct: 5.0,
+      uiAmount: 300,
+      owner: null,
+      insider: true,
+    },
+  ],
+  risks: [
+    {
+      name: "Large Amount of LP Unlocked",
+      value: "100.00%",
+      description:
+        "A large amount of LP tokens are unlocked, allowing the owner to remove liquidity at any point.",
+      score: 11000,
+      level: "danger",
+    },
+    {
+      name: "Mutable metadata",
+      value: "Yes",
+      description: "The token metadata is mutable.",
+      score: 500,
+      level: "warn",
+    },
+  ],
+  score: 15218,
+  score_normalised: 56,
+  rugged: false,
+  totalHolders: 1234,
+};
+
+// Live-verified payload (2026-08-05, JitoSOL J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn):
+// mint authority still enabled → danger; top-10 = 32.5%; normalised 71.
+const LIVE_JITO = {
+  mint: "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn",
+  token: { mintAuthority: "MINT_AUTH_ADDR", freezeAuthority: null },
+  tokenMeta: { mutable: true },
+  topHolders: [
+    { address: "hj1", amount: 1, decimals: 9, pct: 10.0, owner: "oj1", insider: false },
+    { address: "hj2", amount: 1, decimals: 9, pct: 9.0, owner: null, insider: false },
+    { address: "hj3", amount: 1, decimals: 9, pct: 8.0, owner: null, insider: false },
+    { address: "hj4", amount: 1, decimals: 9, pct: 5.5, owner: null, insider: false },
+  ],
+  risks: [
+    {
+      name: "Mint Authority still enabled",
+      value: "Yes",
+      description: "The mint authority is still set.",
+      score: 20000,
+      level: "danger",
+    },
+  ],
+  score: 50101,
+  score_normalised: 71,
+  rugged: false,
+  totalHolders: 549967,
+};
+
+describe("parseRugCheckReport", () => {
+  it("parses the live-verified risky payload", () => {
+    const r = parseRugCheckReport(LIVE_RISKY);
+    expect(r).not.toBeNull();
+    expect(r!.mint).toBe("CWZ6BsdnjkDVTGkmL6bGbJXXig6ceef12KvyGQW14cMt");
+    expect(r!.scoreNormalised).toBe(56);
+    expect(r!.rugged).toBe(false);
+    expect(r!.mintAuthority).toBeNull();
+    expect(r!.freezeAuthority).toBeNull();
+    expect(r!.tokenMetaMutable).toBe(false);
+    expect(r!.totalHolders).toBe(1234);
+    expect(r!.dangerRiskCount).toBe(1);
+    expect(r!.risks.map((x) => x.level)).toEqual(["danger", "warn"]);
+  });
+
+  it("computes top-10 holder concentration", () => {
+    const r = parseRugCheckReport(LIVE_RISKY)!;
+    expect(r.top10HolderPct).toBeCloseTo(31.8 + 12.0 + 5.0, 6);
+    expect(r.topHolders.length).toBe(3);
+  });
+
+  it("parses a mint-authority-enabled report", () => {
+    const r = parseRugCheckReport(LIVE_JITO)!;
+    expect(r.mintAuthority).toBe("MINT_AUTH_ADDR");
+    expect(r.dangerRiskCount).toBe(1);
+    expect(r.top10HolderPct).toBeCloseTo(32.5, 6);
+    expect(r.scoreNormalised).toBe(71);
+  });
+
+  it("returns null for non-object / mint-less payloads", () => {
+    expect(parseRugCheckReport(null)).toBeNull();
+    expect(parseRugCheckReport({})).toBeNull();
+    expect(parseRugCheckReport({ mint: 42 })).toBeNull();
+    expect(parseRugCheckReport({ mint: "" })).toBeNull();
+  });
+
+  it("degrades missing fields to null/empty", () => {
+    const r = parseRugCheckReport({ mint: "abc" })!;
+    expect(r.scoreNormalised).toBeNull();
+    expect(r.totalHolders).toBeNull();
+    expect(r.top10HolderPct).toBeNull();
+    expect(r.dangerRiskCount).toBe(0);
+    expect(r.tokenMetaMutable).toBeNull();
+  });
+});
+
+describe("getRugCheckReport", () => {
+  it("returns null on HTTP error (fail-open)", async () => {
+    const fetchImpl = async () => new Response("{}", { status: 404 });
+    expect(await getRugCheckReport("abc", { fetchImpl })).toBeNull();
+  });
+
+  it("returns null on unparseable body", async () => {
+    const fetchImpl = async () => new Response(JSON.stringify({}), { status: 200 });
+    expect(await getRugCheckReport("abc", { fetchImpl })).toBeNull();
+  });
+
+  it("returns a parsed report on a valid payload", async () => {
+    const fetchImpl = async () => new Response(JSON.stringify(LIVE_JITO), { status: 200 });
+    const r = await getRugCheckReport("J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn", {
+      fetchImpl,
+    });
+    expect(r).not.toBeNull();
+    expect(r!.mintAuthority).toBe("MINT_AUTH_ADDR");
+  });
+
+  it("hits the /tokens/{mint}/report endpoint", async () => {
+    let calledUrl = "";
+    const fetchImpl = async (input: string | URL | Request) => {
+      calledUrl = String(input);
+      return new Response(JSON.stringify(LIVE_RISKY), { status: 200 });
+    };
+    await getRugCheckReport("abc123", { fetchImpl, baseUrl: "https://x.example/v1" });
+    expect(calledUrl).toBe("https://x.example/v1/tokens/abc123/report");
+  });
+});

--- a/bench/tp-ladder.test.ts
+++ b/bench/tp-ladder.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildTpLadder,
+  evaluateTpLadder,
+  serializeTpLadder,
+  parseTpLadder,
+  type TpLadderConfig,
+} from "../engine/tp-ladder.js";
+
+const CONFIG: TpLadderConfig = {
+  rungs: [0.15, 0.3, 0.5],
+  fractions: [0.4, 0.3, 0.3],
+  invalidationStopPct: 0.25,
+};
+
+describe("buildTpLadder", () => {
+  it("builds rungs at entry × (1 + pct) in ascending order", () => {
+    const built = buildTpLadder(100, CONFIG)!;
+    const targets = built.ladder.rungs.map((r) => r.targetPrice);
+    expect(targets[0]).toBeCloseTo(115, 6);
+    expect(targets[1]).toBeCloseTo(130, 6);
+    expect(targets[2]).toBeCloseTo(150, 6);
+    expect(built.ladder.rungs.map((r) => r.fraction)).toEqual([0.4, 0.3, 0.3]);
+    expect(built.ladder.totalFraction).toBeCloseTo(1, 6);
+    expect(built.invalidationPrice).toBe(75);
+  });
+
+  it("renormalizes fractions that sum over 1", () => {
+    const over = buildTpLadder(100, { rungs: [0.1], fractions: [1.5], invalidationStopPct: 0.25 })!;
+    expect(over.ladder.rungs[0]!.fraction).toBeCloseTo(1, 6);
+    expect(over.ladder.totalFraction).toBe(1);
+  });
+
+  it("returns null for non-positive entry or empty config", () => {
+    expect(buildTpLadder(0, CONFIG)).toBeNull();
+    expect(buildTpLadder(-1, CONFIG)).toBeNull();
+    expect(buildTpLadder(100, { rungs: [], fractions: [], invalidationStopPct: 0.25 })).toBeNull();
+  });
+});
+
+describe("evaluateTpLadder", () => {
+  const built = buildTpLadder(100, CONFIG)!;
+
+  it("returns none when price is below the first rung and above invalidation", () => {
+    expect(evaluateTpLadder(110, built.ladder, built.invalidationPrice).status).toBe("none");
+  });
+
+  it("fires invalidation first (capital protection)", () => {
+    const r = evaluateTpLadder(70, built.ladder, built.invalidationPrice);
+    expect(r.status).toBe("invalidation");
+    expect(r.invalidationPrice).toBe(75);
+  });
+
+  it("fires the first reached rung when price crosses it", () => {
+    const r = evaluateTpLadder(120, built.ladder, built.invalidationPrice);
+    expect(r.status).toBe("tp");
+    expect(r.rungReached!.targetPrice).toBeCloseTo(115, 6);
+    expect(r.scaleOutFraction).toBeCloseTo(0.4, 6);
+    expect(r.ladderComplete).toBe(false);
+  });
+
+  it("marks ladderComplete when the final rung is the first reached", () => {
+    // A fresh position always evaluates the FIRST crossed target (close-and-
+    // reopen scales out bottom-up); the ladder is complete only when that first
+    // reached rung is also the last one.
+    const single = buildTpLadder(100, { rungs: [0.5], fractions: [1], invalidationStopPct: 0.25 })!;
+    const r = evaluateTpLadder(160, single.ladder, single.invalidationPrice);
+    expect(r.status).toBe("tp");
+    expect(r.rungReached!.targetPrice).toBeCloseTo(150, 6);
+    expect(r.ladderComplete).toBe(true);
+  });
+
+  it("returns none for non-finite or non-positive price", () => {
+    expect(evaluateTpLadder(Number.NaN, built.ladder, built.invalidationPrice).status).toBe("none");
+    expect(evaluateTpLadder(0, built.ladder, built.invalidationPrice).status).toBe("none");
+  });
+});
+
+describe("serialize / parse", () => {
+  it("round-trips a ladder", () => {
+    const built = buildTpLadder(100, CONFIG)!;
+    const raw = serializeTpLadder(built.ladder);
+    expect(raw).toBeTruthy();
+    const parsed = parseTpLadder(raw)!;
+    expect(parsed.rungs.length).toBe(3);
+    expect(parsed.rungs[0]!.targetPrice).toBeCloseTo(115, 6);
+    expect(parsed.rungs[0]!.fraction).toBe(0.4);
+  });
+
+  it("returns null for undefined/empty input", () => {
+    expect(serializeTpLadder(undefined)).toBeNull();
+    expect(parseTpLadder(null)).toBeNull();
+    expect(parseTpLadder("")).toBeNull();
+    expect(parseTpLadder("{not json")).toBeNull();
+    expect(parseTpLadder('{"rungs":[]}')).toBeNull();
+  });
+
+  it("drops malformed rungs on parse", () => {
+    const parsed = parseTpLadder(
+      JSON.stringify({
+        rungs: [
+          { targetPrice: 115, fraction: 0.4 },
+          { targetPrice: -1, fraction: 0.5 },
+        ],
+      }),
+    )!;
+    expect(parsed.rungs.length).toBe(1);
+    expect(parsed.rungs[0]!.targetPrice).toBeCloseTo(115, 6);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "@vitest/coverage-istanbul": "^4.1.10",
         "bun-types": "1.4.0-canary.20260519T150915",
         "fast-check": "^4.9.0",
-        "oxfmt": "^0.60.0",
+        "oxfmt": "^0.61.0",
         "oxlint": "^1.74.0",
         "tsdown": "^0.22.12",
         "typescript": "^7.0.2",
@@ -139,43 +139,43 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.140.0", "", {}, "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.60.0", "", { "os": "android", "cpu": "arm" }, "sha512-1q4q4Jc8FlOMVojEisyFAVyl8h1yawNv6phjgmhGVEDeyeOdsSnSr9x0+D4mOnEKvpO5L4mxKZ/DP9X6U3A/Mw=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.61.0", "", { "os": "android", "cpu": "arm" }, "sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.60.0", "", { "os": "android", "cpu": "arm64" }, "sha512-tD41I6nCt9k8SQXft0CSjjU9jg6SwG7uMu7PxodSEHXl+GDW0868oy6tTtoJkyUze8YKFgTpz/k5LuPUnFiGLw=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.61.0", "", { "os": "android", "cpu": "arm64" }, "sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.60.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TTpzPug96Zxdyb46KvTyIUQDdsqbumXh2TKG9C23PCT0kF7JkW56Z/quPuG9rqOFKQIi1gpRNZ7DX18LwxXPnw=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.61.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.60.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-CnOoWgQ7L+JL/YQaRJ+NyATciSfcftncm7y3kqyte1cGtFEGnStaCd1TAyrinkfQ7nRBfHrTs1/vTwUJr3WF2Q=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.61.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.60.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ychJo7S3hZxdO6eDZ9zM6F2lM9fpJS3EKS5CAUSWyprdLYxTu4gbaUKV/VBPTcMJwQa2Bpo+643y3OJ537pihA=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.61.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-36IH5o55T2Fx7E0feDttt+mifxN6yk9pWv4KfhAIsP0dFnUq27331OwbpOsZdoXF9soOLWm7mQUz5+UUmyec4g=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.61.0", "", { "os": "linux", "cpu": "arm" }, "sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-G1Ve7lAa6sFBolVI2LWHfEAqy0YKh4vnioH8uYO9kAEdgM7mR40IksIx9/Zk4+vbYew/sGa4J9Q4tZ3n9gXDHA=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.61.0", "", { "os": "linux", "cpu": "arm" }, "sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LTQdRBf6uzj/h7Xk6lKzbGD2hrF/fK4YI9LIN1c0509tPUn8wRa3mCmrFQpEWJPLYGFrLFFMTYW1Ljj6VqW2Hw=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.61.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-2JMo3XPxMPx3hiqddSZYyaH+fKJm6cz0u8n1naYjP/CdOQOZW34i8lKBUfmbWiuFvd6KoYXLmhAyBuvojsYS7Q=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.61.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.60.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-L3C+nBD13lr306tr/PjM3RMll+BVqgFrIgUyoeHuai5oueJrRLgO3j+GO5/Cbhtkf5PSlHYTI1JY7iqBd1qa6A=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.61.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-M4MsmvqlxFiPtSRGyBYQSZxchEf463AOyd+Dh4/9xDpjWBsRtDUTDMFN5EdHinjVK1/eDJQ8MLpcYjpYayaCnA=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.61.0", "", { "os": "linux", "cpu": "none" }, "sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-OH+9UskYuxRB+GxqdGkVN8f5UpwhqG8YscNo1wl8+KJ62cd7wZdGga6iGLJIf8kibF1WBwvlfDUx3cez/VXwFg=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.61.0", "", { "os": "linux", "cpu": "none" }, "sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.60.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-y7AAFutt9wFWBFOAn6+BHaV39usZmcr3YYH2385f+NHgPNpIF9HpqKp0jgUxPaUOCyG3oaX5VhJduL1Nw164rw=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.61.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-yKZ9+CXAI+1RO5nH/4Z/9M6DAsfOzd5bw/gtWk81KB4mpalMaRRSXfouc5/tHxazDmBek55HNPepNYBgaCew0Q=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.61.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bCUGaF6hJOYnQzLJdHLZbvGsOd5oSvGAyJhPAKum2uyLYUuXmP8vqg690DWi2hqcnIoYpqSqCrjzE5aiUAgwQg=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.61.0", "", { "os": "linux", "cpu": "x64" }, "sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.60.0", "", { "os": "none", "cpu": "arm64" }, "sha512-GrUeZOvzP30ExxfCuQiyofuUGI+OmvAgFwOO5w5p9mGPlxcyuqI+6Sy9fAKFFfLQrqKYWFgc5sYA2Unj/29nPg=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.61.0", "", { "os": "none", "cpu": "arm64" }, "sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.60.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-WD4Q954kUl2TDJV/6q7UnE2rlKk047kXLJsr4bJ2mXRaAqNXcmV3nwKUsGCc3mz/jYDBnXtJEaBErJEybK8iQQ=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.61.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.60.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-HqDekjr8JXzVDUP1YthDZ1Y3CBEcuZT4WX3B+1kaxj8CvZA8Y2YhcEsXqoSop3tVsgjACxjnFQFDkBo0r/jq1Q=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.61.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-tz78yhmGPKboTMHCHSaUqXK8JrmoSejgDcWeqAtg2s07ZGKQ3rH5Jn8NuXPGNG33CDbY2e9NoQWXIVEmKO21Rw=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.61.0", "", { "os": "win32", "cpu": "x64" }, "sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg=="],
 
     "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.75.0", "", { "os": "android", "cpu": "arm" }, "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g=="],
 
@@ -811,7 +811,7 @@
 
     "onnxruntime-web": ["onnxruntime-web@1.14.0", "", { "dependencies": { "flatbuffers": "^1.12.0", "guid-typescript": "^1.0.9", "long": "^4.0.0", "onnx-proto": "^4.0.4", "onnxruntime-common": "~1.14.0", "platform": "^1.3.6" } }, "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw=="],
 
-    "oxfmt": ["oxfmt@0.60.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.60.0", "@oxfmt/binding-android-arm64": "0.60.0", "@oxfmt/binding-darwin-arm64": "0.60.0", "@oxfmt/binding-darwin-x64": "0.60.0", "@oxfmt/binding-freebsd-x64": "0.60.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.60.0", "@oxfmt/binding-linux-arm-musleabihf": "0.60.0", "@oxfmt/binding-linux-arm64-gnu": "0.60.0", "@oxfmt/binding-linux-arm64-musl": "0.60.0", "@oxfmt/binding-linux-ppc64-gnu": "0.60.0", "@oxfmt/binding-linux-riscv64-gnu": "0.60.0", "@oxfmt/binding-linux-riscv64-musl": "0.60.0", "@oxfmt/binding-linux-s390x-gnu": "0.60.0", "@oxfmt/binding-linux-x64-gnu": "0.60.0", "@oxfmt/binding-linux-x64-musl": "0.60.0", "@oxfmt/binding-openharmony-arm64": "0.60.0", "@oxfmt/binding-win32-arm64-msvc": "0.60.0", "@oxfmt/binding-win32-ia32-msvc": "0.60.0", "@oxfmt/binding-win32-x64-msvc": "0.60.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA=="],
+    "oxfmt": ["oxfmt@0.61.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.61.0", "@oxfmt/binding-android-arm64": "0.61.0", "@oxfmt/binding-darwin-arm64": "0.61.0", "@oxfmt/binding-darwin-x64": "0.61.0", "@oxfmt/binding-freebsd-x64": "0.61.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.61.0", "@oxfmt/binding-linux-arm-musleabihf": "0.61.0", "@oxfmt/binding-linux-arm64-gnu": "0.61.0", "@oxfmt/binding-linux-arm64-musl": "0.61.0", "@oxfmt/binding-linux-ppc64-gnu": "0.61.0", "@oxfmt/binding-linux-riscv64-gnu": "0.61.0", "@oxfmt/binding-linux-riscv64-musl": "0.61.0", "@oxfmt/binding-linux-s390x-gnu": "0.61.0", "@oxfmt/binding-linux-x64-gnu": "0.61.0", "@oxfmt/binding-linux-x64-musl": "0.61.0", "@oxfmt/binding-openharmony-arm64": "0.61.0", "@oxfmt/binding-win32-arm64-msvc": "0.61.0", "@oxfmt/binding-win32-ia32-msvc": "0.61.0", "@oxfmt/binding-win32-x64-msvc": "0.61.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ=="],
 
     "oxlint": ["oxlint@1.75.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.75.0", "@oxlint/binding-android-arm64": "1.75.0", "@oxlint/binding-darwin-arm64": "1.75.0", "@oxlint/binding-darwin-x64": "1.75.0", "@oxlint/binding-freebsd-x64": "1.75.0", "@oxlint/binding-linux-arm-gnueabihf": "1.75.0", "@oxlint/binding-linux-arm-musleabihf": "1.75.0", "@oxlint/binding-linux-arm64-gnu": "1.75.0", "@oxlint/binding-linux-arm64-musl": "1.75.0", "@oxlint/binding-linux-ppc64-gnu": "1.75.0", "@oxlint/binding-linux-riscv64-gnu": "1.75.0", "@oxlint/binding-linux-riscv64-musl": "1.75.0", "@oxlint/binding-linux-s390x-gnu": "1.75.0", "@oxlint/binding-linux-x64-gnu": "1.75.0", "@oxlint/binding-linux-x64-musl": "1.75.0", "@oxlint/binding-openharmony-arm64": "1.75.0", "@oxlint/binding-win32-arm64-msvc": "1.75.0", "@oxlint/binding-win32-ia32-msvc": "1.75.0", "@oxlint/binding-win32-x64-msvc": "1.75.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g=="],
 

--- a/cli/config.ts
+++ b/cli/config.ts
@@ -1,0 +1,164 @@
+import { Command } from "commander";
+import { Effect, Layer } from "effect";
+import { DbLive } from "../engine/db-service.js";
+import { DbService } from "../engine/services.js";
+import { getPrismDbPath } from "../engine/paths.js";
+import {
+  DB_CONFIG_KEYS,
+  dbConfigKey,
+  findDbConfigSpec,
+  parseDbConfigValue,
+} from "../engine/db-config.js";
+
+/**
+ * `prism config` — inspect and edit the DB-backed config sidecar.
+ *
+ * Precedence is env > DB > defaults. These commands read/write the SQLite
+ * `metadata` table rows keyed `config.<ENV_KEY>`; a row only takes effect when
+ * the corresponding env var is UNSET (env always wins). The engine honours
+ * these rows at config load; this CLI is the editing surface.
+ *
+ * Only keys in the `DB_CONFIG_KEYS` allowlist are settable — secrets, wallet
+ * keys, RPC URLs and paths are never stored here.
+ */
+
+function buildLayer(): Layer.Layer<DbService, never, never> {
+  return DbLive(process.env.SQLITE_DB_PATH ?? getPrismDbPath());
+}
+
+function unknownKey(envKey: string): void {
+  console.error(`Unknown config key: ${envKey}`);
+  console.error(`Known keys: ${DB_CONFIG_KEYS.map((s) => s.envKey).join(", ")}`);
+  process.exitCode = 1;
+}
+
+const listCommand = new Command("list")
+  .description("List DB-backed config overrides and which env vars shadow them")
+  .action(() => {
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const rows: Array<{ key: string; value: string }> = [];
+        for (const spec of DB_CONFIG_KEYS) {
+          const value = yield* db
+            .getMetadata(dbConfigKey(spec.envKey))
+            .pipe(Effect.catchAll(() => Effect.succeed(null)));
+          if (value !== null) rows.push({ key: spec.envKey, value });
+        }
+        if (rows.length === 0) {
+          console.log("No DB-backed config overrides set.");
+          console.log("Known keys (env var wins when set):");
+          for (const spec of DB_CONFIG_KEYS) {
+            console.log(
+              `  ${spec.envKey}${process.env[spec.envKey] !== undefined ? "  (env SHADOWS this key)" : ""}`,
+            );
+          }
+          return;
+        }
+        console.log("DB-backed config overrides (precedence: env > DB > defaults):");
+        for (const { key, value } of rows) {
+          const shadowed = process.env[key] !== undefined;
+          console.log(`  ${key} = ${value}${shadowed ? "  (SHADOWED by env)" : ""}`);
+        }
+      }).pipe(Effect.provide(buildLayer())),
+    ).catch((err) => {
+      console.error(`Failed to list config: ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    });
+  });
+
+const getCommand = new Command("get")
+  .description("Show the effective value for a config key (env wins over DB)")
+  .argument("<KEY>", "env-style key, e.g. MIN_POOL_TVL_USD")
+  .action((key: string) => {
+    const spec = findDbConfigSpec(key);
+    if (!spec) {
+      unknownKey(key);
+      return;
+    }
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        const dbValue = yield* db
+          .getMetadata(dbConfigKey(key))
+          .pipe(Effect.catchAll(() => Effect.succeed(null)));
+        const envValue = process.env[key];
+        if (envValue !== undefined) {
+          console.log(`${key}=${envValue}  (from env)`);
+        } else if (dbValue !== null) {
+          console.log(`${key}=${dbValue}  (from DB)`);
+        } else {
+          console.log(`${key}=<default>  (not set)`);
+        }
+      }).pipe(Effect.provide(buildLayer())),
+    ).catch((err) => {
+      console.error(`Failed to read config: ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    });
+  });
+
+const setCommand = new Command("set")
+  .description("Set a DB-backed config override (env still wins if the env var is set)")
+  .argument("<KEY>", "env-style key, e.g. MIN_POOL_TVL_USD")
+  .argument("<VALUE>", "value to persist (boolean: true/false/1/0; number: numeric)")
+  .action((key: string, value: string) => {
+    const spec = findDbConfigSpec(key);
+    if (!spec) {
+      unknownKey(key);
+      return;
+    }
+    // Validate + clamp BEFORE writing so a malformed value is never persisted.
+    const parsed = parseDbConfigValue(spec, value);
+    if (parsed === null) {
+      console.error(
+        `Invalid value for ${key}: "${value}" (expected ${spec.kind === "boolean" ? "a boolean (true/false/1/0)" : "a finite number"})`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    const stored = String(parsed);
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        yield* db.setMetadata(dbConfigKey(key), stored);
+        const shadowed = process.env[key] !== undefined;
+        console.log(`Set ${key}=${stored} in DB.`);
+        if (shadowed) {
+          console.warn(
+            `Note: env var ${key}=${process.env[key]} is set and will win over this DB value.`,
+          );
+        }
+      }).pipe(Effect.provide(buildLayer())),
+    ).catch((err) => {
+      console.error(`Failed to set config: ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    });
+  });
+
+const unsetCommand = new Command("unset")
+  .description("Remove a DB-backed config override (defaults / env take over)")
+  .argument("<KEY>", "env-style key, e.g. MIN_POOL_TVL_USD")
+  .action((key: string) => {
+    const spec = findDbConfigSpec(key);
+    if (!spec) {
+      unknownKey(key);
+      return;
+    }
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService;
+        yield* db.deleteMetadata(dbConfigKey(key));
+        console.log(`Unset ${key}.`);
+      }).pipe(Effect.provide(buildLayer())),
+    ).catch((err) => {
+      console.error(`Failed to unset config: ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    });
+  });
+
+export const configCommand = new Command("config")
+  .description("Inspect or edit DB-backed config (precedence: env > DB > defaults)")
+  .addCommand(listCommand)
+  .addCommand(getCommand)
+  .addCommand(setCommand)
+  .addCommand(unsetCommand);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -20,6 +20,7 @@ import { statusCommand } from "./status.js";
 import { doctorCommand } from "./doctor.js";
 import { resumeCommand } from "./resume.js";
 import { telemetryCommand } from "./telemetry.js";
+import { configCommand } from "./config.js";
 import { getCurrentVersion } from "../engine/version.js";
 
 const program = new Command();
@@ -50,5 +51,6 @@ program.addCommand(statusCommand);
 program.addCommand(doctorCommand);
 program.addCommand(resumeCommand);
 program.addCommand(telemetryCommand);
+program.addCommand(configCommand);
 
 await program.parseAsync();

--- a/docs/fallen-angel-mode.md
+++ b/docs/fallen-angel-mode.md
@@ -1,6 +1,7 @@
 # Fallen-angel mode — plan (decision-complete)
 
-Status: plan locked. Implementation starts after this document.
+Status: **implemented and merged-ready** (Waves A-D2 complete). 7 feature commits + 1 follow-up,
+PR #152. All 115 test files / 1464 tests pass.
 
 ## What "fallen-angel" means here
 

--- a/docs/fallen-angel-mode.md
+++ b/docs/fallen-angel-mode.md
@@ -1,0 +1,159 @@
+# Fallen-angel mode — plan (decision-complete)
+
+Status: plan locked. Implementation starts after this document.
+
+## What "fallen-angel" means here
+
+A **fallen-angel** pool is a Solana DLMM pool whose underlying token has:
+
+- **fallen hard from its all-time high** (deep drawdown per GeckoTerminal OHLCV),
+- **calm-enough volatility** to be a defensible mean-reversion (not a dying or
+  lunatic token): daily-return stddev within a band,
+- a **clean security profile** (RugCheck: no critical risks, no revoked/unknown
+  authorities, sane holder concentration, ≥ min holders, above a score floor),
+- **any TVL** — the discovery path deliberately drops the normal
+  `DISCOVERY_MIN_TVL_USD` / `MIN_POOL_TVL_USD` floor so under-adopted fallen
+  tokens are reachable.
+
+The thesis is **mean-reversion / oversold bounce**: buy distressed-but-safe
+tokens, take profit in a **ladder** of price targets, and cut the position on an
+**invalidation stop** (price falls below the level that would break the thesis).
+
+## The 3 locked user decisions
+
+1. **DB-config precedence = env > DB > defaults.** The engine keeps its
+   existing env-driven `ConfigService.loadConfig` as the source of truth. A new
+   sidecar layer reads overrides from the SQLite `metadata` table (keys
+   `config.<ENV_KEY>`) and applies them ONLY for keys whose env var is unset.
+   Env always beats the DB; the DB beats the compiled-in default. Fail-open:
+   a missing/unreadable DB leaves env/defaults untouched.
+
+2. **Fallen-angel is opt-in, paper-first, and additive-only.** Master switch
+   `FALLEN_ANGEL_ENABLED` (default `false`). When off, behaviour is
+   byte-identical to today. When on, the mode adds (a) a new any-TVL discovery
+   path, (b) a fallen-angel entry gate, and (c) a position lifecycle — all
+   layered on top of the existing safety screening, risk, audit, execution,
+   memory and alert pipeline. It never relaxes a safety gate (blacklist,
+   freeze-authority, stablecoin allowlist, Data-API blacklist, RugCheck).
+
+3. **TP-ladder + invalidation-stop is a full-close scale-out, not a
+   partial-withdraw.** The adapter's `exitPosition` is full-close-only (no
+   `bps` partial withdrawal) and W14 limit orders are blocked, so a rung death
+   is implemented as **EXIT the whole position at confidence 1** with a
+   `[tp-ladder]` reason, then re-open the remaining fraction as a fresh
+   smaller fallen-angel position on the next scan cycle (scale-out via
+   close-and-reopen). The invalidation stop is a full EXIT at confidence 1
+   below the invalidation price. This reuses the existing exit/enter executors
+   and keeps the whole feature additive.
+
+## Gate mapping: fallen-angel flow vs existing capabilities
+
+| Fallen-angel gate | Capability | Exists? | Work |
+| --- | --- | --- | --- |
+| Security (RugCheck) | token-risk overlay / Data-API `is_verified` | partial | **New** `RugCheck` fetcher + gate; reuses stablecoin allowlist exemption |
+| Deep drawdown from ATH | `pool_snapshots` (14d) — too short | partial | **New** GeckoTerminal OHLCV fetch (ATH / drawdown / vol-baseline) |
+| Volatility baseline | `computeBinVolatilityStddev` (intra-cycle bins) | yes | Reuse for live vol; **new** OHLCV daily-return stddev for the baseline |
+| Any-TVL discovery | `screener.screenPools` (1M floor) | partial | **New** fallen-angel discovery pass with a floor of `FALLEN_ANGEL_MIN_TVL_USD` |
+| ENTER gating | `evaluatePool` ENTER slot (fee-il-gate / weighted score / allocation / risk) | yes | Add a fallen-angel branch that swaps the *quality* eligibility for the fallen-angel gate; risk/confidence/allocation tail unchanged |
+| TP-ladder lifecycle | none (no TP logic exists) | no | **New** `tp-ladder.ts` + position-mode stamping + per-cycle ladder/invalidation EXIT seam |
+| Invalidation stop | trailing-stop / stop-loss exist | partial | **New** per-position invalidation price + EXIT at confidence 1 |
+
+## Work breakdown
+
+### Wave A — DB-backed config + `prism config` CLI (self-contained)
+
+- `engine/db-config.ts` — pure registry (`DB_CONFIG_KEYS`: envKey → kind/field/clamp),
+  `readDbConfigOverrides(db)`, `applyDbConfigOverrides(cfg, overrides)` (env-wins),
+  `parseDbConfigValue`. Fail-open.
+- Wire into `config-service.ts` `ConfigLive` so the DB layer sits under it
+  (env > DB > defaults). Guarded so test mode never opens a DB.
+- `cli/config.ts` — `prism config get|set|unset|list` against the `metadata`
+  table via `DbService.getMetadata`/`setMetadata`. Register in `cli/index.ts`.
+- Tests: `bench/db-config.test.ts`, `bench/cli-config.test.ts`.
+
+### Wave B — Data fetchers (self-contained, live-verified contracts)
+
+- `engine/gecko-ohlcv-service.ts` — `getGeckoPoolOhlcv` (OHLCV rows →
+  ATH/drawdown/vol-baseline), injectable `fetchImpl`, pacing, fail-open.
+  Contract verified: `GET /networks/solana/pools/{addr}/ohlcv/day?limit=N` →
+  `data.attributes.ohlcv_list = [[ts, open, high, low, close, volume], …]`.
+- `engine/rugcheck-service.ts` — `getRugCheckReport(mint)` →
+  `{score, scoreNormalised, mintAuthority, freezeAuthority, tokenMetaMutable,
+  topHolders, risks, …}`, injectable `fetchImpl`, fail-open.
+  Contract verified: `GET /tokens/{mint}/report`.
+- Tests: `bench/gecko-ohlcv.test.ts`, `bench/rugcheck.test.ts` (live fixtures).
+
+### Wave C — fallen-angel gate pipeline + any-TVL discovery
+
+- `engine/fallen-angel-service.ts` — pure `evaluateFallenAngelCandidate`
+  (RugCheck security + drawdown + vol-band + min TVL) and
+  `evaluateFallenAngelQuality` (re-confirm at ENTER time). Reuses the stablecoin
+  allowlist for the "asset side" identification.
+- Discovery: in `program.ts`, a gated `refreshFallenAngelCandidates(scanOrdinal)`
+  consuming `adapter.discoverPools` with the lower floor, evaluating the gate,
+  feeding qualified pools into `poolsToScan` (paper + live discovery modes).
+- Config: `fallenAngelEnabled`, `fallenAngelMinTvlUsd`, `fallenAngelMinDrawdownPct`,
+  `fallenAngelMaxDrawdownPct`, `fallenAngelVolBaselineMin`,
+  `fallenAngelVolBaselineMax`, `fallenAngelMinRugcheckScore`,
+  `fallenAngelMinHolders`, `fallenAngelMaxTop10HolderPct`.
+- Tests: `bench/fallen-angel-service.test.ts`.
+
+### Wave D — spot TP-ladder + invalidation-stop lifecycle
+
+- `engine/tp-ladder.ts` — pure `buildTpLadder`, `evaluateTpLadder`,
+  `shouldInvalidate`, ladder serialization.
+- DB migration v22: `positions.position_mode`, `tp_ladder_json`,
+  `invalidation_stop_price`. `PositionRecord` + `rowToPosition` + `savePosition`.
+- `program.ts`:
+  - stamp `positionMode: "fallen-angel"` + ladder + invalidation on the ENTER
+    decision (and persist in `executePaper`/`executeLive`),
+  - per-cycle evaluation: invalidation-stop EXIT + TP-ladder scale-out EXIT,
+  - next-cycle remainder re-open (scale-out via close-and-reopen).
+- Config: `fallenAngelTpRungs` (e.g. `[0.15,0.30,0.50]`), `fallenAngelTpFractions`
+  (e.g. `[0.4,0.3,0.3]`), `fallenAngelInvalidationStopPct` (e.g. `0.25`).
+- Tests: `bench/tp-ladder.test.ts`, `bench/fallen-angel-lifecycle.test.ts`.
+
+### Wave E — verify + PR
+
+- `bun run lint`, `bun run build`, `bun run test`, `bun run format:check`.
+- Manual QA notes in `docs/fallen-angel-mode-qa.md`.
+- Branch + `gh pr create`.
+
+## Upgrade helper for NEXT releases (must-have)
+
+Upgrades must not break existing installs or silently drop user config. The
+helper for every future release is the existing **migration system** + the
+**registry**, each with one enforced rule:
+
+1. **Schema changes go through `engine/db.ts` `MIGRATIONS`** (additive
+   `ALTER TABLE ... ADD COLUMN` numbered migrations, guarded by `hasColumn`).
+   They auto-run on the next `createDatabase()` open — no manual step. The
+   fallen-angel position columns (Wave D) are migration v22.
+2. **New DB-config keys go through `engine/db-config.ts` `DB_CONFIG_KEYS`**
+   with three forced steps:
+   (a) add an **optional** field to `AppConfig` (optional so test fixtures that
+   omit it keep compiling),
+   (b) read it in `loadConfig` with `Config.string/boolean/number` +
+   `orElseSucceed(default)` (env + default), and
+   (c) add a `DB_CONFIG_KEYS` entry so the sidecar can override it when the env
+   var is unset.
+   A release that adds a key and forgets (c) is still safe — the feature just
+   reads env/defaults — but a release that skips (a)/(b) breaks the build.
+3. **`prism config list` and `prism doctor`** are the user-facing upgrade
+   helpers: `config list` shows every overridable key and which env vars shadow
+   it (so a stale DB row can never silently override a new default); a
+   `doctor` config-plug check asserts the registry parses and the metadata
+   table is reachable. Both fail open — an old DB without the metadata table,
+   or an unreadable DB, degrades to env/defaults, never to a crash.
+4. **Backwards compatibility is the default, not a mode**: the sidecar only
+   applies rows whose env var is unset, so an environment that pinned a value
+   in `.env` keeps winning after upgrade; `prism config unset` restores the
+   default when a user wants to revert.
+
+## Ordering rationale
+
+A (config) and B (fetchers) are independent and fully testable in isolation —
+they are the foundation the gate (C) and lifecycle (D) consume. C depends on A+B
+config + fetchers. D depends on C's ENTER tagging + config. Each wave keeps the
+tree green before the next starts (AGENTS.md: grow in layers, never trade a
+working product for unfinished complexity).

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -10,6 +10,7 @@ import type {
 } from "./types.js";
 import { PublicKey } from "@solana/web3.js";
 import { createLogger } from "./logger.js";
+import { applyDbConfigOverrides, readDbConfigOverrides } from "./db-config.js";
 
 const logger = createLogger("ConfigService");
 
@@ -453,6 +454,54 @@ export interface AppConfig {
   readonly copySignalWallets?: ReadonlyArray<string>;
   readonly copySignalsStaleMs?: number;
   readonly copySignalsMaxBoost?: number;
+
+  // ─── Fallen-angel mode (Wave 19) ───────────────────────────────────────────
+  // Optional so standalone test fixtures that omit new fields keep compiling;
+  // loadConfig always sets all of them. Guard contract: `fallenAngelEnabled ===
+  // true` activates the mode (absent/undefined = safe off).
+  /** Master switch for fallen-angel mode (mean-reversion on distressed but
+   *  clean tokens): any-TVL discovery + RugCheck security + GeckoTerminal
+   *  drawdown gate + spot TP-ladder / invalidation-stop lifecycle. Default
+   *  false — the whole pipeline is inert unless explicitly opted in. */
+  readonly fallenAngelEnabled?: boolean;
+  /** Floor (USD) for fallen-angel discovery. Default 50k — normally far below
+   *  the standard DISCOVERY_MIN_TVL_USD so under-adopted fallen tokens are
+   *  reachable; set 0 for truly any TVL. */
+  readonly fallenAngelMinTvlUsd?: number;
+  /** Token must be down at LEAST this much from its GeckoTerminal window ATH
+   *  to qualify (0..1 fraction, default 0.6 = down 60%). */
+  readonly fallenAngelMinDrawdownPct?: number;
+  /** Token must be down AT MOST this much from its ATH (0..1 default 0.95) —
+   *  deeper than this is a dead/abandoned token, not a fallen angel. */
+  readonly fallenAngelMaxDrawdownPct?: number;
+  /** Minimum daily-return stddev (default 0.02) — below this the OHLCV series
+   *  is too dead to mean-revert. */
+  readonly fallenAngelVolBaselineMin?: number;
+  /** Maximum daily-return stddev (default 0.35) — above this is a lunatic
+   *  token, not an oversold gem. */
+  readonly fallenAngelVolBaselineMax?: number;
+  /** Minimum RugCheck normalised score (0..1 default 0.7) for a fallen-angel
+   *  token. Fail-closed: a missing/unknown score rejects the candidate. */
+  readonly fallenAngelMinRugcheckScore?: number;
+  /** Minimum RugCheck holder count (default 300) — a token with no real
+   *  holder base can't be an angel. */
+  readonly fallenAngelMinHolders?: number;
+  /** Maximum top-10 holder concentration (0..1 default 0.5) per RugCheck
+   *  topHolders; missing concentration data fails open (skip). */
+  readonly fallenAngelMaxTop10HolderPct?: number;
+  /** TP-ladder take-profit targets as fractions ABOVE entry (e.g. "0.15,0.30,0.50"
+   *  = +15%, +30%, +50%). Default "0.15,0.30,0.50". */
+  readonly fallenAngelTpRungs?: ReadonlyArray<number>;
+  /** Fraction of the position to scale out at each rung (must sum ≤ 1).
+   *  Default "0.4,0.3,0.3" = 40%/30%/30%. Excess over 1 is renormalized. */
+  readonly fallenAngelTpFractions?: ReadonlyArray<number>;
+  /** Invalidation-stop: EXIT at confidence 1 when price falls below
+   *  entry × (1 − pct). Default 0.25 (= cut at −25%). */
+  readonly fallenAngelInvalidationStopPct?: number;
+  /** Max simultaneous fallen-angel positions portfolio-wide. Default 2 — the
+   *  mode is concentrated in nature; the standard MAX_OPEN_POSITIONS cap still
+   *  applies on top of this. */
+  readonly fallenAngelMaxPositions?: number;
 }
 
 export class ConfigService extends Context.Tag("ConfigService")<ConfigService, AppConfig>() {}
@@ -1094,6 +1143,71 @@ const loadConfig = Effect.gen(function* () {
   const alertCooldownMinutes = yield* validatedNumber("ALERT_COOLDOWN_MINUTES", 1, 120);
   const alertFeeMilestoneUsd = yield* validatedNumber("ALERT_FEE_MILESTONE_USD", 0.01, 10);
 
+  // ─── Fallen-angel mode (Wave 19) ───────────────────────────────────────────
+  const fallenAngelEnabled = yield* Config.boolean("FALLEN_ANGEL_ENABLED").pipe(
+    Effect.orElseSucceed(() => false),
+  );
+  const fallenAngelMinTvlUsd = yield* validatedNumber("FALLEN_ANGEL_MIN_TVL_USD", 0, 50_000);
+  const fallenAngelMinDrawdownPct = yield* validatedNumber(
+    "FALLEN_ANGEL_MIN_DRAWDOWN_PCT",
+    0,
+    0.6,
+    1,
+  );
+  const fallenAngelMaxDrawdownPct = yield* validatedNumber(
+    "FALLEN_ANGEL_MAX_DRAWDOWN_PCT",
+    0,
+    0.95,
+    1,
+  );
+  const fallenAngelVolBaselineMin = yield* validatedNumber(
+    "FALLEN_ANGEL_VOL_BASELINE_MIN",
+    0,
+    0.02,
+  );
+  const fallenAngelVolBaselineMax = yield* validatedNumber(
+    "FALLEN_ANGEL_VOL_BASELINE_MAX",
+    0,
+    0.35,
+  );
+  const fallenAngelMinRugcheckScore = yield* validatedNumber(
+    "FALLEN_ANGEL_MIN_RUGCHECK_SCORE",
+    0,
+    0.7,
+    1,
+  );
+  const fallenAngelMinHolders = yield* validatedNumber("FALLEN_ANGEL_MIN_HOLDERS", 1, 300);
+  const fallenAngelMaxTop10HolderPct = yield* validatedNumber(
+    "FALLEN_ANGEL_MAX_TOP10_HOLDER_PCT",
+    0,
+    0.5,
+    1,
+  );
+  const parsePctList = (raw: string): ReadonlyArray<number> =>
+    raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .map(Number)
+      .filter((n) => Number.isFinite(n));
+  const fallenAngelTpRungs = parsePctList(
+    yield* Config.string("FALLEN_ANGEL_TP_RUNGS").pipe(
+      Effect.orElseSucceed(() => "0.15,0.30,0.50"),
+    ),
+  );
+  const fallenAngelTpFractions = parsePctList(
+    yield* Config.string("FALLEN_ANGEL_TP_FRACTIONS").pipe(
+      Effect.orElseSucceed(() => "0.4,0.3,0.3"),
+    ),
+  );
+  const fallenAngelInvalidationStopPct = yield* validatedNumber(
+    "FALLEN_ANGEL_INVALIDATION_STOP_PCT",
+    0,
+    0.25,
+    1,
+  );
+  const fallenAngelMaxPositions = yield* validatedNumber("FALLEN_ANGEL_MAX_POSITIONS", 1, 2);
+
   // New feature configs
   const stopLossPct = yield* validatedNumber("STOP_LOSS_PCT", 0, 0.15);
   const trailingStopPct = yield* validatedNumber("TRAILING_STOP_PCT", 0, 0.1);
@@ -1380,7 +1494,33 @@ const loadConfig = Effect.gen(function* () {
     copySignalWallets,
     copySignalsStaleMs,
     copySignalsMaxBoost,
+    fallenAngelEnabled,
+    fallenAngelMinTvlUsd,
+    fallenAngelMinDrawdownPct,
+    fallenAngelMaxDrawdownPct,
+    fallenAngelVolBaselineMin,
+    fallenAngelVolBaselineMax,
+    fallenAngelMinRugcheckScore,
+    fallenAngelMinHolders,
+    fallenAngelMaxTop10HolderPct,
+    fallenAngelTpRungs,
+    fallenAngelTpFractions,
+    fallenAngelInvalidationStopPct,
+    fallenAngelMaxPositions,
   };
+
+  // ─── DB-backed config sidecar (env > DB > defaults) ───────────────────────
+  // After env resolution, apply persisted overrides from the SQLite `metadata`
+  // table for keys whose env var is UNSET. Fail-open: a missing/unreadable DB
+  // leaves the env/defaults untouched. Skipped entirely in test mode so the
+  // suite stays deterministic and DB-free. See engine/db-config.ts.
+  const cfgFromEnv = cfg as Readonly<AppConfig>;
+  const dbOverrides = isTest
+    ? new Map<string, string>()
+    : readDbConfigOverrides(cfgFromEnv.sqliteDbPath);
+  if (dbOverrides.size > 0) {
+    return applyDbConfigOverrides(cfg, dbOverrides);
+  }
 
   return cfg;
 });

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -480,9 +480,12 @@ export interface AppConfig {
   /** Maximum daily-return stddev (default 0.35) — above this is a lunatic
    *  token, not an oversold gem. */
   readonly fallenAngelVolBaselineMax?: number;
-  /** Minimum RugCheck normalised score (0..1 default 0.7) for a fallen-angel
-   *  token. Fail-closed: a missing/unknown score rejects the candidate. */
-  readonly fallenAngelMinRugcheckScore?: number;
+  /** Maximum RugCheck score_normalised (0..100 RISK index — higher = riskier:
+   *  SOL≈1, BONK≈7, a dangerous LP-unlocked token ≈56, mint-authority-enabled
+   *  ≈71; verified live 2026-08-05) for a fallen-angel token. Default 60.
+   *  The hard security gate is the `risks[].level === "danger"` check; this is
+   *  the secondary floor. Fail-closed: a missing/unknown score rejects. */
+  readonly fallenAngelMaxRugcheckScore?: number;
   /** Minimum RugCheck holder count (default 300) — a token with no real
    *  holder base can't be an angel. */
   readonly fallenAngelMinHolders?: number;
@@ -1170,11 +1173,11 @@ const loadConfig = Effect.gen(function* () {
     0,
     0.35,
   );
-  const fallenAngelMinRugcheckScore = yield* validatedNumber(
-    "FALLEN_ANGEL_MIN_RUGCHECK_SCORE",
+  const fallenAngelMaxRugcheckScore = yield* validatedNumber(
+    "FALLEN_ANGEL_MAX_RUGCHECK_SCORE",
     0,
-    0.7,
-    1,
+    60,
+    100,
   );
   const fallenAngelMinHolders = yield* validatedNumber("FALLEN_ANGEL_MIN_HOLDERS", 1, 300);
   const fallenAngelMaxTop10HolderPct = yield* validatedNumber(
@@ -1500,7 +1503,7 @@ const loadConfig = Effect.gen(function* () {
     fallenAngelMaxDrawdownPct,
     fallenAngelVolBaselineMin,
     fallenAngelVolBaselineMax,
-    fallenAngelMinRugcheckScore,
+    fallenAngelMaxRugcheckScore,
     fallenAngelMinHolders,
     fallenAngelMaxTop10HolderPct,
     fallenAngelTpRungs,

--- a/engine/db-config.ts
+++ b/engine/db-config.ts
@@ -1,0 +1,233 @@
+import { Database } from "bun:sqlite";
+import fs from "fs";
+import { createLogger } from "./logger.js";
+import type { AppConfig } from "./config-service.js";
+
+/**
+ * DB-backed config sidecar (env > DB > defaults).
+ *
+ * The engine's `ConfigService.loadConfig` remains the env-driven source of
+ * truth (all compiled-in defaults + env vars). This module adds an OPTIONAL
+ * SQLite override layer under it: keys stored in the `metadata` table as
+ * `config.<ENV_KEY>` win over the compiled-in default, and a real env var
+ * always wins over both.
+ *
+ * Precedence per key, most-specific first:
+ *   1. env var (process.env / .env)          — wins always when SET
+ *   2. DB row `config.<ENV_KEY>`             — wins when the env var is UNSET
+ *   3. compiled-in default in loadConfig     — baseline
+ *
+ * Design rules (locked user decision #1):
+ * - Only an explicit allowlist (`DB_CONFIG_KEYS`) is overridable. Secrets,
+ *   wallet keys, RPC URLs, paths and channel names are NOT in it — a DB row
+ *   can never inject credentials or redirect network traffic.
+ * - Fail-open: a missing/unreadable DB (fresh install, first run, corrupt
+ *   file, missing metadata table) leaves env/defaults untouched. One warning
+ *   per malformed row, never a crash.
+ * - Test mode never touches the DB (loadConfig skips this layer when
+ *   NODE_ENV=test or VITEST=true), so the ~960 test fixtures stay
+ *   deterministic and network/DB-free.
+ * - Values are typed by `kind` and clamped to the same bounds the env loader
+ *   uses, so a hand-edited DB row cannot smuggle an out-of-band number.
+ */
+
+const logger = createLogger("db-config");
+
+/** Prefix for DB-backed config rows in the `metadata` table. */
+export const DB_CONFIG_PREFIX = "config.";
+
+export const dbConfigKey = (envKey: string): string => `${DB_CONFIG_PREFIX}${envKey}`;
+
+export type DbConfigKind = "boolean" | "number";
+
+export interface DbConfigSpec {
+  /** The env-style key the user sets, e.g. "MIN_POOL_TVL_USD". */
+  readonly envKey: string;
+  readonly kind: DbConfigKind;
+  /** AppConfig field this override lands on. */
+  readonly field: keyof AppConfig;
+  readonly min?: number;
+  readonly max?: number;
+}
+
+/**
+ * The allowlist of DB-overridable keys. Deliberately small and conservative:
+ * strategy/risk knobs a user might want persistent without touching .env.
+ * New fallen-angel keys join here when the gate config lands (Wave C).
+ */
+export const DB_CONFIG_KEYS: ReadonlyArray<DbConfigSpec> = [
+  { envKey: "MIN_POOL_TVL_USD", kind: "number", field: "minPoolTvlUsd", min: 0 },
+  { envKey: "MIN_FEE_IL_RATIO", kind: "number", field: "minFeeIlRatio", min: 0 },
+  { envKey: "TVL_DROP_EXIT_PCT", kind: "number", field: "tvlDropExitPct", min: 0, max: 1 },
+  { envKey: "VOLUME_AUTH_THRESHOLD", kind: "number", field: "volumeAuthThreshold", min: 0, max: 1 },
+  { envKey: "MIN_BIN_UTILIZATION", kind: "number", field: "minBinUtilization", min: 0, max: 1 },
+  { envKey: "CONFIDENCE_THRESHOLD", kind: "number", field: "confidenceThreshold", min: 0, max: 1 },
+  { envKey: "STOP_LOSS_PCT", kind: "number", field: "stopLossPct", min: 0, max: 1 },
+  { envKey: "TRAILING_STOP_PCT", kind: "number", field: "trailingStopPct", min: 0, max: 1 },
+  { envKey: "PAPER_PORTFOLIO_USD", kind: "number", field: "paperPortfolioUsd", min: 1 },
+  { envKey: "MAX_OPEN_POSITIONS", kind: "number", field: "maxOpenPositions", min: 1 },
+  { envKey: "MAX_POSITIONS_PER_POOL", kind: "number", field: "maxPositionsPerPool", min: 1 },
+  {
+    envKey: "MAX_PER_POOL_ALLOCATION_PCT",
+    kind: "number",
+    field: "maxPerPoolAllocationPct",
+    min: 0,
+    max: 1,
+  },
+  { envKey: "SCAN_INTERVAL_MS", kind: "number", field: "scanIntervalMs", min: 10_000 },
+  { envKey: "ALERTS_ENABLED", kind: "boolean", field: "alertsEnabled" },
+  { envKey: "ALERT_COOLDOWN_MINUTES", kind: "number", field: "alertCooldownMinutes", min: 1 },
+  { envKey: "ALERT_FEE_MILESTONE_USD", kind: "number", field: "alertFeeMilestoneUsd", min: 0.01 },
+  { envKey: "FALLEN_ANGEL_ENABLED", kind: "boolean", field: "fallenAngelEnabled" },
+  { envKey: "FALLEN_ANGEL_MIN_TVL_USD", kind: "number", field: "fallenAngelMinTvlUsd", min: 0 },
+  {
+    envKey: "FALLEN_ANGEL_MIN_DRAWDOWN_PCT",
+    kind: "number",
+    field: "fallenAngelMinDrawdownPct",
+    min: 0,
+    max: 1,
+  },
+  {
+    envKey: "FALLEN_ANGEL_MAX_DRAWDOWN_PCT",
+    kind: "number",
+    field: "fallenAngelMaxDrawdownPct",
+    min: 0,
+    max: 1,
+  },
+  {
+    envKey: "FALLEN_ANGEL_VOL_BASELINE_MIN",
+    kind: "number",
+    field: "fallenAngelVolBaselineMin",
+    min: 0,
+  },
+  {
+    envKey: "FALLEN_ANGEL_VOL_BASELINE_MAX",
+    kind: "number",
+    field: "fallenAngelVolBaselineMax",
+    min: 0,
+  },
+  {
+    envKey: "FALLEN_ANGEL_MIN_RUGCHECK_SCORE",
+    kind: "number",
+    field: "fallenAngelMinRugcheckScore",
+    min: 0,
+    max: 1,
+  },
+  {
+    envKey: "FALLEN_ANGEL_MIN_HOLDERS",
+    kind: "number",
+    field: "fallenAngelMinHolders",
+    min: 1,
+  },
+  {
+    envKey: "FALLEN_ANGEL_MAX_TOP10_HOLDER_PCT",
+    kind: "number",
+    field: "fallenAngelMaxTop10HolderPct",
+    min: 0,
+    max: 1,
+  },
+  {
+    envKey: "FALLEN_ANGEL_INVALIDATION_STOP_PCT",
+    kind: "number",
+    field: "fallenAngelInvalidationStopPct",
+    min: 0,
+    max: 1,
+  },
+  {
+    envKey: "FALLEN_ANGEL_MAX_POSITIONS",
+    kind: "number",
+    field: "fallenAngelMaxPositions",
+    min: 1,
+  },
+];
+
+export function findDbConfigSpec(envKey: string): DbConfigSpec | undefined {
+  return DB_CONFIG_KEYS.find((spec) => spec.envKey === envKey);
+}
+
+/**
+ * Parse a raw DB row value for a spec. Returns null when the value is not a
+ * valid instance of the spec's kind (or falls outside the clamp bounds after
+ * clamping) — the caller treats null as "row ignored, keep current value".
+ * Numbers are clamped to [min, max] (mirroring the env loader's
+ * `validatedNumber` clamp semantics), never bounced.
+ */
+export function parseDbConfigValue(
+  spec: DbConfigSpec,
+  raw: string,
+): string | number | boolean | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+
+  if (spec.kind === "boolean") {
+    if (trimmed === "true" || trimmed === "1") return true;
+    if (trimmed === "false" || trimmed === "0") return false;
+    return null;
+  }
+
+  const value = Number(trimmed);
+  if (!Number.isFinite(value)) return null;
+  if (spec.min !== undefined && value < spec.min) return spec.min;
+  if (spec.max !== undefined && value > spec.max) return spec.max;
+  return value;
+}
+
+/**
+ * Apply DB overrides onto a resolved AppConfig. Only keys whose env var is
+ * UNSET take the DB value; the env var always wins. Malformed rows are
+ * skipped with a warning. Returns a new object (never mutates `base`).
+ */
+export function applyDbConfigOverrides(
+  base: AppConfig,
+  overrides: ReadonlyMap<string, string>,
+): AppConfig {
+  let next = base as AppConfig & Record<string, unknown>;
+
+  for (const spec of DB_CONFIG_KEYS) {
+    // Env wins over the DB, always.
+    if (process.env[spec.envKey] !== undefined) continue;
+
+    const raw = overrides.get(dbConfigKey(spec.envKey));
+    if (raw === undefined) continue;
+
+    const value = parseDbConfigValue(spec, raw);
+    if (value === null) {
+      logger.warn("Skipping malformed DB config row", { key: spec.envKey, raw });
+      continue;
+    }
+
+    // Narrowed writes: booleans and numbers spread cleanly onto both optional
+    // (absent = safe off) and required AppConfig fields. A malformed row is
+    // silently dropped above, never clamped into a fake value.
+    if (typeof value === "boolean" || typeof value === "number") {
+      next = { ...next, [spec.field]: value };
+    }
+  }
+
+  return next;
+}
+
+/**
+ * Read all `config.*` rows from the SQLite metadata table. Fail-open: returns
+ * an empty map when the DB file is absent/unreadable or the metadata table
+ * does not exist (fresh install or pre-v9 DB — the env/defaults stand).
+ * Opens with a plain (non-migrating) connection and closes it immediately.
+ */
+export function readDbConfigOverrides(dbPath: string): ReadonlyMap<string, string> {
+  if (!dbPath || dbPath === ":memory:" || !fs.existsSync(dbPath)) return new Map<string, string>();
+  try {
+    const db = new Database(dbPath);
+    try {
+      const rows = db
+        .query("SELECT key, value FROM metadata WHERE key LIKE ?")
+        .all(`${DB_CONFIG_PREFIX}%`) as Array<{ key: string; value: string }>;
+      return new Map(rows.map((row) => [row.key, row.value]));
+    } catch {
+      return new Map<string, string>();
+    } finally {
+      db.close();
+    }
+  } catch {
+    return new Map<string, string>();
+  }
+}

--- a/engine/db-config.ts
+++ b/engine/db-config.ts
@@ -107,11 +107,11 @@ export const DB_CONFIG_KEYS: ReadonlyArray<DbConfigSpec> = [
     min: 0,
   },
   {
-    envKey: "FALLEN_ANGEL_MIN_RUGCHECK_SCORE",
+    envKey: "FALLEN_ANGEL_MAX_RUGCHECK_SCORE",
     kind: "number",
-    field: "fallenAngelMinRugcheckScore",
+    field: "fallenAngelMaxRugcheckScore",
     min: 0,
-    max: 1,
+    max: 100,
   },
   {
     envKey: "FALLEN_ANGEL_MIN_HOLDERS",

--- a/engine/db-service.ts
+++ b/engine/db-service.ts
@@ -60,6 +60,12 @@ export interface PositionRecord {
   cumulativeRewardsClaimedUsd: number;
   closedAt: number | null;
   realizedPnlUsd: number | null;
+  /** Fallen-angel position mode: "fallen-angel" when active, else null. */
+  positionMode?: string | null;
+  /** Serialized TP-ladder JSON (see engine/tp-ladder.ts); null for non-FA. */
+  tpLadderJson?: string | null;
+  /** Invalidation stop price; null for non-FA positions. */
+  invalidationStopPrice?: number | null;
 }
 
 export type PositionEventType = "ENTER" | "EXIT" | "REBALANCE" | "CLAIM" | "COMPOUND";
@@ -157,8 +163,9 @@ export const DbLive = (dbPath?: string) =>
               entry_signal_snapshot_id,
               entry_price_usd, entry_amount_x_usd, entry_amount_y_usd,
               cumulative_fees_claimed_usd, cumulative_rewards_claimed_usd,
-              closed_at, realized_pnl_usd
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              closed_at, realized_pnl_usd,
+              position_mode, tp_ladder_json, invalidation_stop_price
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(position_id) DO UPDATE SET
               pool_address = excluded.pool_address,
               position_pubkey = COALESCE(excluded.position_pubkey, positions.position_pubkey),
@@ -185,7 +192,13 @@ export const DbLive = (dbPath?: string) =>
               cumulative_fees_claimed_usd = excluded.cumulative_fees_claimed_usd,
               cumulative_rewards_claimed_usd = excluded.cumulative_rewards_claimed_usd,
               closed_at = excluded.closed_at,
-              realized_pnl_usd = excluded.realized_pnl_usd`,
+              realized_pnl_usd = excluded.realized_pnl_usd,
+              position_mode = COALESCE(excluded.position_mode, positions.position_mode),
+              tp_ladder_json = COALESCE(excluded.tp_ladder_json, positions.tp_ladder_json),
+              invalidation_stop_price = COALESCE(
+                excluded.invalidation_stop_price,
+                positions.invalidation_stop_price
+              )`,
               pos.positionId,
               pos.poolAddress,
               pos.positionPubKey,
@@ -213,6 +226,9 @@ export const DbLive = (dbPath?: string) =>
               pos.cumulativeRewardsClaimedUsd,
               pos.closedAt,
               pos.realizedPnlUsd,
+              pos.positionMode ?? null,
+              pos.tpLadderJson ?? null,
+              pos.invalidationStopPrice ?? null,
             );
           }),
 
@@ -1528,6 +1544,10 @@ function rowToPosition(row: Record<string, unknown>): PositionRecord {
     cumulativeRewardsClaimedUsd: Number(row.cumulative_rewards_claimed_usd ?? 0),
     closedAt: row.closed_at != null ? Number(row.closed_at) : null,
     realizedPnlUsd: row.realized_pnl_usd != null ? Number(row.realized_pnl_usd) : null,
+    positionMode: row.position_mode != null ? String(row.position_mode) : null,
+    tpLadderJson: row.tp_ladder_json != null ? String(row.tp_ladder_json) : null,
+    invalidationStopPrice:
+      row.invalidation_stop_price != null ? Number(row.invalidation_stop_price) : null,
   };
 }
 

--- a/engine/db-service.ts
+++ b/engine/db-service.ts
@@ -760,6 +760,11 @@ export const DbLive = (dbPath?: string) =>
             );
           }),
 
+        deleteMetadata: (key) =>
+          Effect.sync(() => {
+            runOne(db, "DELETE FROM metadata WHERE key = ?", key);
+          }),
+
         setMetadataBatch: (entries) =>
           Effect.try({
             try: () => {

--- a/engine/db.ts
+++ b/engine/db.ts
@@ -913,6 +913,24 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
       }
     },
   },
+  {
+    version: 22,
+    name: "fallen_angel_position_fields",
+    up(db) {
+      // Fallen-angel lifecycle state (Wave 19): position mode, serialized
+      // TP-ladder JSON and invalidation stop. Additive + non-destructive;
+      // legacy rows stay NULL (non-FA positions).
+      if (!hasColumn(db, "positions", "position_mode")) {
+        db.exec("ALTER TABLE positions ADD COLUMN position_mode TEXT");
+      }
+      if (!hasColumn(db, "positions", "tp_ladder_json")) {
+        db.exec("ALTER TABLE positions ADD COLUMN tp_ladder_json TEXT");
+      }
+      if (!hasColumn(db, "positions", "invalidation_stop_price")) {
+        db.exec("ALTER TABLE positions ADD COLUMN invalidation_stop_price REAL");
+      }
+    },
+  },
 ];
 
 function runMigrations(db: Database) {

--- a/engine/db.ts
+++ b/engine/db.ts
@@ -919,14 +919,16 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
     up(db) {
       // Fallen-angel lifecycle state (Wave 19): position mode, serialized
       // TP-ladder JSON and invalidation stop. Additive + non-destructive;
-      // legacy rows stay NULL (non-FA positions).
-      if (!hasColumn(db, "positions", "position_mode")) {
+      // legacy rows stay NULL (non-FA positions). Guarded on table existence
+      // like v19's pool_snapshots guard — partial legacy fixtures may mark
+      // v18 applied without physically creating `positions`.
+      if (hasTable(db, "positions") && !hasColumn(db, "positions", "position_mode")) {
         db.exec("ALTER TABLE positions ADD COLUMN position_mode TEXT");
       }
-      if (!hasColumn(db, "positions", "tp_ladder_json")) {
+      if (hasTable(db, "positions") && !hasColumn(db, "positions", "tp_ladder_json")) {
         db.exec("ALTER TABLE positions ADD COLUMN tp_ladder_json TEXT");
       }
-      if (!hasColumn(db, "positions", "invalidation_stop_price")) {
+      if (hasTable(db, "positions") && !hasColumn(db, "positions", "invalidation_stop_price")) {
         db.exec("ALTER TABLE positions ADD COLUMN invalidation_stop_price REAL");
       }
     },

--- a/engine/fallen-angel-discovery.ts
+++ b/engine/fallen-angel-discovery.ts
@@ -1,0 +1,106 @@
+import type { GeckoOhlcvSignals } from "./gecko-ohlcv-service.js";
+import type { RugCheckReport } from "./rugcheck-service.js";
+import {
+  evaluateFallenAngelGate,
+  identifyAssetMint,
+  type FallenAngelGateConfig,
+} from "./fallen-angel-service.js";
+
+/**
+ * Fallen-angel discovery pass (Wave 19) — pure module.
+ *
+ * Takes the raw discovered pool list (any TVL) + per-pool fetched signals and
+ * returns the pools that qualify as fallen-angel candidates. All network I/O
+ * is the caller's job (injected via the `fetchSignals` callback); this module
+ * only decides.
+ *
+ * The caller (program.ts) gates this whole pass on `FALLEN_ANGEL_ENABLED` and
+ * `shouldDiscoverPools`, and feeds qualified pools into `poolsToScan` via the
+ * same mechanism as autonomous candidates.
+ */
+
+export interface FallenAngelDiscoveredPool {
+  readonly address: string;
+  readonly tvlUsd: number;
+  readonly tokenX: string;
+  readonly tokenY: string;
+}
+
+export interface FallenAngelPoolSignals {
+  readonly ohlcv: GeckoOhlcvSignals | null;
+  readonly rugcheck: RugCheckReport | null;
+}
+
+export interface FallenAngelDiscoveryResult {
+  /** Pools that passed every gate. */
+  readonly qualified: ReadonlyArray<{
+    readonly poolAddress: string;
+    readonly assetMint: string;
+    /** Drawdown from ATH (0..1) for display / entry scoring. */
+    readonly drawdownPct: number;
+  }>;
+  /** Pools that failed, with the reasons (for logging). */
+  readonly rejected: ReadonlyArray<{
+    readonly poolAddress: string;
+    readonly reasons: ReadonlyArray<string>;
+  }>;
+}
+
+/**
+ * Evaluate discovered pools against the fallen-angel gate.
+ *
+ * `fetchSignals(pool)` returns the OHLCV + RugCheck report for a pool (or
+ * nulls when unavailable). It is called ONCE per pool that clears the TVL
+ * floor, so the caller can cache per-mint RugCheck reports and pace requests.
+ */
+export function evaluateFallenAngelDiscovery(
+  pools: ReadonlyArray<FallenAngelDiscoveredPool>,
+  config: FallenAngelGateConfig,
+  stablecoinMints: ReadonlySet<string> | undefined,
+  fetchSignals: (pool: FallenAngelDiscoveredPool) => Promise<FallenAngelPoolSignals>,
+): Promise<FallenAngelDiscoveryResult> {
+  return (async () => {
+    const qualified: Array<{
+      poolAddress: string;
+      assetMint: string;
+      drawdownPct: number;
+    }> = [];
+    const rejected: Array<{ poolAddress: string; reasons: ReadonlyArray<string> }> = [];
+
+    for (const pool of pools) {
+      if (!Number.isFinite(pool.tvlUsd) || pool.tvlUsd < config.minTvlUsd) {
+        // Below the floor — not a rejection, just out of universe.
+        continue;
+      }
+      const assetMint = identifyAssetMint(pool.tokenX, pool.tokenY, stablecoinMints);
+      if (assetMint === null) {
+        rejected.push({
+          poolAddress: pool.address,
+          reasons: ["No identifiable asset leg (stablecoin pair or empty allowlist)"],
+        });
+        continue;
+      }
+
+      const signals = await fetchSignals(pool);
+      const result = evaluateFallenAngelGate({
+        poolTvlUsd: pool.tvlUsd,
+        assetMint,
+        ohlcv: signals.ohlcv,
+        rugcheck: signals.rugcheck,
+        config,
+      });
+
+      if (result.qualified) {
+        qualified.push({
+          poolAddress: pool.address,
+          assetMint,
+          drawdownPct: signals.ohlcv?.drawdownFromAth ?? 0,
+        });
+      } else {
+        rejected.push({ poolAddress: pool.address, reasons: result.reasons });
+      }
+    }
+
+    return { qualified, rejected };
+  })();
+}

--- a/engine/fallen-angel-discovery.ts
+++ b/engine/fallen-angel-discovery.ts
@@ -57,6 +57,7 @@ export function evaluateFallenAngelDiscovery(
   pools: ReadonlyArray<FallenAngelDiscoveredPool>,
   config: FallenAngelGateConfig,
   stablecoinMints: ReadonlySet<string> | undefined,
+  solMint: string,
   fetchSignals: (pool: FallenAngelDiscoveredPool) => Promise<FallenAngelPoolSignals>,
 ): Promise<FallenAngelDiscoveryResult> {
   return (async () => {
@@ -72,7 +73,7 @@ export function evaluateFallenAngelDiscovery(
         // Below the floor — not a rejection, just out of universe.
         continue;
       }
-      const assetMint = identifyAssetMint(pool.tokenX, pool.tokenY, stablecoinMints);
+      const assetMint = identifyAssetMint(pool.tokenX, pool.tokenY, stablecoinMints, solMint);
       if (assetMint === null) {
         rejected.push({
           poolAddress: pool.address,

--- a/engine/fallen-angel-service.ts
+++ b/engine/fallen-angel-service.ts
@@ -1,0 +1,165 @@
+import type { GeckoOhlcvSignals } from "./gecko-ohlcv-service.js";
+import type { RugCheckReport } from "./rugcheck-service.js";
+
+/**
+ * Fallen-angel gate pipeline (Wave 19) — pure decision module.
+ *
+ * Decides whether a DLMM pool qualifies as a "fallen angel": the underlying
+ * token is deeply down from its all-time high (GeckoTerminal OHLCV), calm
+ * enough to mean-revert (daily-return stddev within a band), clean enough to
+ * trust (RugCheck: no danger-level risks, low top-10 holder concentration,
+ * adequate holder base, sane score), and the pool has any TVL above a
+ * configurable floor.
+ *
+ * Deliberately module-functions only (clone of the depeg detector / token-risk
+ * overlay): no Effect Context.Tag, no network calls here. The caller fetches
+ * signals via `getGeckoPoolOhlcv` / `getRugCheckReport` and passes them in.
+ *
+ * FAIL-CLOSED for the positive gate: any signal that is MISSING (null report,
+ * null score, null holders) makes the candidate fail with an explicit reason —
+ * a token whose security or history is unknown is never an "angel". Only the
+ * holder-concentration check fails OPEN when topHolders is absent (the API
+ * returns null topHolders for majors like USDC/SOL, and concentration is a
+ * secondary signal). No fabricated default is ever substituted.
+ */
+
+export interface FallenAngelGateConfig {
+  readonly minTvlUsd: number;
+  readonly minDrawdownPct: number;
+  readonly maxDrawdownPct: number;
+  readonly volBaselineMin: number;
+  readonly volBaselineMax: number;
+  /** RugCheck score_normalised MUST be at or below this (higher = riskier). */
+  readonly maxRugcheckScore: number;
+  readonly minHolders: number;
+  readonly maxTop10HolderPct: number;
+}
+
+export interface FallenAngelGateInput {
+  readonly poolTvlUsd: number;
+  /** The token under scrutiny — the NON-stablecoin leg of the pair. */
+  readonly assetMint: string;
+  readonly ohlcv: GeckoOhlcvSignals | null;
+  readonly rugcheck: RugCheckReport | null;
+  readonly config: FallenAngelGateConfig;
+}
+
+export interface FallenAngelGateResult {
+  readonly qualified: boolean;
+  /** Empty when qualified; one entry per failed check otherwise. */
+  readonly reasons: ReadonlyArray<string>;
+}
+
+/** True when a report carries any risk whose level is "danger" (hard reject). */
+export function hasDangerRisks(report: RugCheckReport): boolean {
+  return report.dangerRiskCount > 0;
+}
+
+export function evaluateFallenAngelGate(input: FallenAngelGateInput): FallenAngelGateResult {
+  const reasons: string[] = [];
+
+  if (!Number.isFinite(input.poolTvlUsd) || input.poolTvlUsd < input.config.minTvlUsd) {
+    reasons.push(
+      `TVL $${Number.isFinite(input.poolTvlUsd) ? input.poolTvlUsd.toFixed(0) : "unknown"} below fallen-angel floor $${input.config.minTvlUsd.toFixed(0)}`,
+    );
+  }
+
+  // ── Security gate (RugCheck) — fail-closed on missing data ────────────────
+  const report = input.rugcheck;
+  if (report === null) {
+    reasons.push("RugCheck report unavailable — security unknown");
+  } else {
+    if (report.rugged) {
+      reasons.push("RugCheck flags token as rugged");
+    }
+    if (hasDangerRisks(report)) {
+      const dangerNames = report.risks
+        .filter((r) => r.level === "danger")
+        .map((r) => r.name)
+        .join(", ");
+      reasons.push(`RugCheck danger risks present: ${dangerNames}`);
+    }
+    if (report.scoreNormalised === null) {
+      reasons.push("RugCheck score unknown — fail closed");
+    } else if (report.scoreNormalised > input.config.maxRugcheckScore) {
+      reasons.push(
+        `RugCheck risk score ${report.scoreNormalised} exceeds max ${input.config.maxRugcheckScore}`,
+      );
+    }
+    if (report.mintAuthority !== null) {
+      reasons.push("Token mint authority is still enabled");
+    }
+    if (report.freezeAuthority !== null) {
+      reasons.push("Token freeze authority is still enabled");
+    }
+    if (report.totalHolders === null) {
+      reasons.push("RugCheck holder count unknown — fail closed");
+    } else if (report.totalHolders < input.config.minHolders) {
+      reasons.push(`Holder count ${report.totalHolders} below minimum ${input.config.minHolders}`);
+    }
+    // Holder concentration fails OPEN (API returns null topHolders for majors).
+    // top10HolderPct is a percent (0..100); config.maxTop10HolderPct is a fraction
+    // (0..1) — normalize to fractions before comparing.
+    if (
+      report.top10HolderPct !== null &&
+      report.top10HolderPct / 100 > input.config.maxTop10HolderPct
+    ) {
+      reasons.push(
+        `Top-10 holder concentration ${report.top10HolderPct.toFixed(1)}% exceeds max ${(input.config.maxTop10HolderPct * 100).toFixed(0)}%`,
+      );
+    }
+  }
+
+  // ── History gate (GeckoTerminal OHLCV) — fail-closed on missing data ──────
+  const ohlcv = input.ohlcv;
+  if (ohlcv === null) {
+    reasons.push("OHLCV history unavailable — drawdown unknown");
+  } else {
+    if (ohlcv.barCount < 2) {
+      reasons.push(`OHLCV window too shallow (${ohlcv.barCount} bar(s))`);
+    }
+    if (ohlcv.drawdownFromAth < input.config.minDrawdownPct) {
+      reasons.push(
+        `Drawdown from ATH ${(ohlcv.drawdownFromAth * 100).toFixed(1)}% below minimum ${(input.config.minDrawdownPct * 100).toFixed(0)}%`,
+      );
+    }
+    if (ohlcv.drawdownFromAth > input.config.maxDrawdownPct) {
+      reasons.push(
+        `Drawdown from ATH ${(ohlcv.drawdownFromAth * 100).toFixed(1)}% exceeds maximum ${(input.config.maxDrawdownPct * 100).toFixed(0)}% (dead token)`,
+      );
+    }
+    if (ohlcv.dailyReturnStddev < input.config.volBaselineMin) {
+      reasons.push(
+        `Daily-return stddev ${ohlcv.dailyReturnStddev.toFixed(4)} below volatility floor ${input.config.volBaselineMin}`,
+      );
+    }
+    if (ohlcv.dailyReturnStddev > input.config.volBaselineMax) {
+      reasons.push(
+        `Daily-return stddev ${ohlcv.dailyReturnStddev.toFixed(4)} above volatility ceiling ${input.config.volBaselineMax} (lunatic token)`,
+      );
+    }
+  }
+
+  return { qualified: reasons.length === 0, reasons };
+}
+
+/**
+ * Pick the asset leg of a pool pair: the mint that is NOT on the stablecoin
+ * allowlist. When both legs are stablecoins there is no obvious asset — return
+ * null and let the caller fail closed. When the allowlist is empty (undefined)
+ * there is no notion of a stable leg, so the pair is unclassifiable — return
+ * null (fail closed) rather than guessing.
+ */
+export function identifyAssetMint(
+  tokenX: string,
+  tokenY: string,
+  stablecoinMints: ReadonlySet<string> | undefined,
+): string | null {
+  if (stablecoinMints === undefined || stablecoinMints.size === 0) return null;
+  const xIsStable = stablecoinMints.has(tokenX);
+  const yIsStable = stablecoinMints.has(tokenY);
+  if (!xIsStable && yIsStable) return tokenX;
+  if (xIsStable && !yIsStable) return tokenY;
+  if (xIsStable && yIsStable) return null;
+  return tokenX;
+}

--- a/engine/fallen-angel-service.ts
+++ b/engine/fallen-angel-service.ts
@@ -144,22 +144,26 @@ export function evaluateFallenAngelGate(input: FallenAngelGateInput): FallenAnge
 }
 
 /**
- * Pick the asset leg of a pool pair: the mint that is NOT on the stablecoin
- * allowlist. When both legs are stablecoins there is no obvious asset — return
- * null and let the caller fail closed. When the allowlist is empty (undefined)
- * there is no notion of a stable leg, so the pair is unclassifiable — return
- * null (fail closed) rather than guessing.
+ * Pick the asset leg of a pool pair: the mint that is NOT a stablecoin and
+ * NOT SOL (the base settlement asset). When both legs are stablecoins there is
+ * no obvious asset — return null and let the caller fail closed. When the
+ * allowlist is empty (undefined) there is no notion of a stable leg, so the
+ * pair is unclassifiable — return null (fail closed) rather than guessing.
+ * SOL is always excluded: it is the settlement/quote leg, never the
+ * fallen-angel asset (RugCheck reports for SOL carry no useful signal).
  */
 export function identifyAssetMint(
   tokenX: string,
   tokenY: string,
   stablecoinMints: ReadonlySet<string> | undefined,
+  solMint: string,
 ): string | null {
   if (stablecoinMints === undefined || stablecoinMints.size === 0) return null;
-  const xIsStable = stablecoinMints.has(tokenX);
-  const yIsStable = stablecoinMints.has(tokenY);
+  const xIsStable = stablecoinMints.has(tokenX) || tokenX === solMint;
+  const yIsStable = stablecoinMints.has(tokenY) || tokenY === solMint;
   if (!xIsStable && yIsStable) return tokenX;
   if (xIsStable && !yIsStable) return tokenY;
   if (xIsStable && yIsStable) return null;
+  // Neither leg is stable/SOL — prefer the first (tokenX) as the asset.
   return tokenX;
 }

--- a/engine/gecko-ohlcv-service.ts
+++ b/engine/gecko-ohlcv-service.ts
@@ -140,21 +140,28 @@ export function summarizeGeckoOhlcv(bars: ReadonlyArray<GeckoOhlcvBar>): GeckoOh
     };
   }
 
+  // GeckoTerminal returns OHLCV newest-FIRST (verified live). Normalize to
+  // ascending timestamp so "latest" is always the last bar and consecutive
+  // log-returns are computed in chronological order — otherwise drawdown
+  // would be measured against the OLDEST close and daily stddev would flip
+  // the sign of every return.
+  const ascending = [...bars].sort((a, b) => a.timestampSec - b.timestampSec);
+
   let atlHigh = 0;
   let totalVolumeQuote = 0;
-  for (const bar of bars) {
+  for (const bar of ascending) {
     if (bar.high > atlHigh) atlHigh = bar.high;
     totalVolumeQuote += bar.volumeQuote;
   }
-  const latestClose = bars[bars.length - 1]!.close;
+  const latestClose = ascending[ascending.length - 1]!.close;
   const drawdownFromAth = atlHigh > 0 ? Math.max(0, 1 - latestClose / atlHigh) : 0;
 
   let dailyReturnStddev = 0;
-  if (bars.length >= 2) {
+  if (ascending.length >= 2) {
     const logReturns: number[] = [];
-    for (let i = 1; i < bars.length; i++) {
-      const prev = bars[i - 1]!.close;
-      const cur = bars[i]!.close;
+    for (let i = 1; i < ascending.length; i++) {
+      const prev = ascending[i - 1]!.close;
+      const cur = ascending[i]!.close;
       if (prev > 0 && cur > 0) {
         logReturns.push(Math.log(cur / prev));
       }

--- a/engine/gecko-ohlcv-service.ts
+++ b/engine/gecko-ohlcv-service.ts
@@ -1,0 +1,228 @@
+import { createLogger } from "./logger.js";
+
+/**
+ * GeckoTerminal OHLCV fetcher for fallen-angel mode (Wave 19).
+ *
+ * Supplies the deep-drawdown + volatility-baseline signals the pool_snapshots
+ * table can't: the engine only keeps 14 days of per-cycle snapshots, but a
+ * "fallen angel" is defined by a multi-week/multi-month drawdown from its
+ * all-time high. GeckoTerminal's keyless public pool OHLCV endpoint gives a
+ * long daily series (default 180 candles) from real on-chain data.
+ *
+ * Module-function design (clone of `gecko-terminal-service.ts` and
+ * `token-risk-service.ts`): plain exported functions with an injectable
+ * `fetchImpl`, NOT an Effect Context.Tag, so adding it does not ripple through
+ * the test layers. All network failure paths return null (fail-open) — a
+ * missing OHLCV means "drawdown unknown", which the caller treats as
+ * "not a fallen angel" (fail-closed for the positive gate).
+ *
+ * LIVE-VERIFIED contract (2026-08-05):
+ *   GET {base}/networks/solana/pools/{addr}/ohlcv/day?limit=N  (keyless)
+ *   → { "data": { "attributes": { "ohlcv_list": [
+ *        [ unixSeconds, open, high, low, close, volume ], …
+ *      ] } } }
+ *   Timestamps are UNIX SECONDS (not ms). volume is in the quote token.
+ *   Unknown pool → HTTP 404 {"errors":[...]}. 429 → rate limited.
+ */
+
+const logger = createLogger("gecko-ohlcv");
+
+const DEFAULT_BASE_URL = "https://api.geckoterminal.com/api/v2";
+const REQUEST_TIMEOUT_MS = 10_000;
+/** Default window of daily candles (raw limit, not a calendar span). */
+export const DEFAULT_OHLCV_LIMIT = 180;
+
+/** A single daily OHLCV bar. timestamps are unix seconds. */
+export interface GeckoOhlcvBar {
+  readonly timestampSec: number;
+  readonly open: number;
+  readonly high: number;
+  readonly low: number;
+  readonly close: number;
+  readonly volumeQuote: number;
+}
+
+/** Derived fallen-angel signals from an OHLCV series. */
+export interface GeckoOhlcvSignals {
+  readonly bars: ReadonlyArray<GeckoOhlcvBar>;
+  /** Highest `high` over the window (all-time high proxy). */
+  readonly atlHigh: number;
+  /** Latest `close` (current price proxy). */
+  readonly latestClose: number;
+  /** 1 - latestClose/atlHigh (0..1); 0 when no positive ATH. */
+  readonly drawdownFromAth: number;
+  /** Sample stddev of daily log-returns over the window (0 when <2 bars). */
+  readonly dailyReturnStddev: number;
+  /** Sum of quote volume over the window (0 when empty). */
+  readonly totalVolumeQuote: number;
+  /** Number of usable bars (excludes bars with non-positive close). */
+  readonly barCount: number;
+}
+
+export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/**
+ * Parse a raw `ohlcv_list` into bars. Returns [] when the payload is not a
+ * usable ohlcv_list (malformed, missing, or empty). Bars with a non-positive
+ * close are dropped (dead/corrupt candle — a positive close is required to
+ * compute log returns and drawdown).
+ */
+export function parseGeckoOhlcv(raw: unknown): ReadonlyArray<GeckoOhlcvBar> {
+  if (!isObject(raw)) return [];
+  const data = raw["data"];
+  if (!isObject(data)) return [];
+  const attrs = data["attributes"];
+  if (!isObject(attrs)) return [];
+  const list = attrs["ohlcv_list"];
+  if (!Array.isArray(list)) return [];
+
+  const bars: GeckoOhlcvBar[] = [];
+  for (const entry of list) {
+    if (!Array.isArray(entry) || entry.length < 5) continue;
+    const timestampSec = readFiniteNumber(entry[0]);
+    const open = readFiniteNumber(entry[1]);
+    const high = readFiniteNumber(entry[2]);
+    const low = readFiniteNumber(entry[3]);
+    const close = readFiniteNumber(entry[4]);
+    const volumeQuote = readFiniteNumber(entry[5]);
+    if (
+      timestampSec === null ||
+      open === null ||
+      high === null ||
+      low === null ||
+      close === null ||
+      close <= 0
+    ) {
+      continue;
+    }
+    bars.push({
+      timestampSec,
+      open,
+      high,
+      low,
+      close,
+      volumeQuote: volumeQuote ?? 0,
+    });
+  }
+  return bars;
+}
+
+/**
+ * Derive fallen-angel signals from parsed bars.
+ * - ATH = highest `high` across the (positive-close) window.
+ * - drawdown = 1 - latestClose/ATH (0 when ATH <= 0).
+ * - daily stddev = sample stddev of log(clos) consecutive differences.
+ *   Skipped when < 2 bars (0).
+ */
+export function summarizeGeckoOhlcv(bars: ReadonlyArray<GeckoOhlcvBar>): GeckoOhlcvSignals {
+  if (bars.length === 0) {
+    return {
+      bars,
+      atlHigh: 0,
+      latestClose: 0,
+      drawdownFromAth: 0,
+      dailyReturnStddev: 0,
+      totalVolumeQuote: 0,
+      barCount: 0,
+    };
+  }
+
+  let atlHigh = 0;
+  let totalVolumeQuote = 0;
+  for (const bar of bars) {
+    if (bar.high > atlHigh) atlHigh = bar.high;
+    totalVolumeQuote += bar.volumeQuote;
+  }
+  const latestClose = bars[bars.length - 1]!.close;
+  const drawdownFromAth = atlHigh > 0 ? Math.max(0, 1 - latestClose / atlHigh) : 0;
+
+  let dailyReturnStddev = 0;
+  if (bars.length >= 2) {
+    const logReturns: number[] = [];
+    for (let i = 1; i < bars.length; i++) {
+      const prev = bars[i - 1]!.close;
+      const cur = bars[i]!.close;
+      if (prev > 0 && cur > 0) {
+        logReturns.push(Math.log(cur / prev));
+      }
+    }
+    if (logReturns.length >= 2) {
+      const mean = logReturns.reduce((s, v) => s + v, 0) / logReturns.length;
+      const variance =
+        logReturns.reduce((s, v) => s + (v - mean) * (v - mean), 0) / (logReturns.length - 1);
+      dailyReturnStddev = Math.sqrt(variance);
+    }
+  }
+
+  return {
+    bars,
+    atlHigh,
+    latestClose,
+    drawdownFromAth,
+    dailyReturnStddev,
+    totalVolumeQuote,
+    barCount: bars.length,
+  };
+}
+
+/**
+ * Fetch a daily OHLCV series for a pool. NEVER throws and NEVER crashes the
+ * scan: 404/429/5xx, timeout, fetch failure, or parse failure all return null
+ * so the caller treats the drawdown as unknown (fail-closed for the positive
+ * gate). Logs ONE warning per failing fetch.
+ */
+export async function getGeckoPoolOhlcv(
+  poolAddress: string,
+  options: {
+    readonly limit?: number;
+    readonly baseUrl?: string;
+    readonly timeoutMs?: number;
+    readonly fetchImpl?: FetchLike;
+  } = {},
+): Promise<GeckoOhlcvSignals | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? REQUEST_TIMEOUT_MS;
+  const base = (options.baseUrl ?? process.env.GECKO_TERMINAL_API_URL ?? DEFAULT_BASE_URL)
+    .trim()
+    .replace(/\/+$/, "");
+  const effectiveBase = base.length > 0 ? base : DEFAULT_BASE_URL;
+  const limit = options.limit ?? DEFAULT_OHLCV_LIMIT;
+  const url = `${effectiveBase}/networks/solana/pools/${poolAddress}/ohlcv/day?limit=${limit}`;
+
+  try {
+    const res = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) {
+      logger.warn("GeckoTerminal OHLCV unavailable — drawdown unknown", {
+        pool: poolAddress,
+        status: res.status,
+      });
+      return null;
+    }
+    const body: unknown = await res.json();
+    const bars = parseGeckoOhlcv(body);
+    if (bars.length === 0) {
+      logger.warn("GeckoTerminal OHLCV returned no usable bars", { pool: poolAddress });
+      return null;
+    }
+    return summarizeGeckoOhlcv(bars);
+  } catch (err) {
+    logger.warn("GeckoTerminal OHLCV fetch failed — drawdown unknown", {
+      pool: poolAddress,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -107,6 +107,7 @@ import { detectDepegAndLiquidityDrain } from "./depeg-liquidity-detector.js";
 import { consultTokenRisks, type TokenRiskSignal } from "./token-risk-service.js";
 import { CopySignalLive, applyCopySignalBoost } from "./copy-trading-signals.js";
 import { evaluateFallenAngelDiscovery } from "./fallen-angel-discovery.js";
+import { identifyAssetMint } from "./fallen-angel-service.js";
 import {
   buildTpLadder,
   evaluateTpLadder,
@@ -2688,9 +2689,10 @@ export const program = Effect.gen(function* () {
 
   // Fallen-angel discovery refresh (Wave 19). Opt-in via FALLEN_ANGEL_ENABLED.
   // Re-runs the gate each cycle over a fresh discovery page (any TVL above
-  // fallenAngelMinTvlUsd) and feeds qualified pools into poolsToScan. Network
-  // calls are paced at the HTTP layer (gecko ≥2.1s, per-mint RugCheck cached
-  // for the process lifetime) so a 50-pool page does not hammer the APIs.
+  // fallenAngelMinTvlUsd) and feeds qualified pools into poolsToScan. RugCheck
+  // reports are cached per mint for the process lifetime so repeat pages do
+  // not re-fetch; the gecko OHLCV fetch is shared with the main stats path and
+  // bounded by the discovery page size.
   const refreshFallenAngelCandidates = (scanOrdinal: number): Effect.Effect<void, never> =>
     Effect.gen(function* () {
       if (config.fallenAngelEnabled !== true || !shouldDiscoverPools(config)) return;
@@ -2705,8 +2707,13 @@ export const program = Effect.gen(function* () {
         readonly tokenX: string;
         readonly tokenY: string;
       }) => {
-        const assetMint = [pool.tokenX, pool.tokenY].find(
-          (mint) => mint !== SOL_MINT && !(config.stablecoinMints?.has(mint) === true),
+        // Single-sourced asset-leg resolution (same helper the gate uses), so
+        // the RugCheck report is fetched for the exact mint the gate evaluates.
+        const assetMint = identifyAssetMint(
+          pool.tokenX,
+          pool.tokenY,
+          config.stablecoinMints,
+          SOL_MINT,
         );
         const ohlcv: GeckoOhlcvSignals | null = await getGeckoPoolOhlcv(pool.address);
         let rugcheck: RugCheckReport | null = null;
@@ -2735,6 +2742,7 @@ export const program = Effect.gen(function* () {
             maxTop10HolderPct: config.fallenAngelMaxTop10HolderPct ?? 0.5,
           },
           config.stablecoinMints,
+          SOL_MINT,
           fetchSignals,
         ),
       );
@@ -5467,7 +5475,16 @@ export const program = Effect.gen(function* () {
           // carries the FA lifecycle (ladder + invalidation) so execution
           // stamps the position row.
           const faSignal = fallenAngelSignals.get(poolAddress);
-          if (!enterGateRejected && config.fallenAngelEnabled === true && faSignal !== undefined) {
+          const openFaPositions = Array.from(trackedPositions.values()).filter(
+            (p) => p.positionMode === "fallen-angel",
+          ).length;
+          const faMaxPositions = config.fallenAngelMaxPositions ?? 2;
+          if (
+            !enterGateRejected &&
+            config.fallenAngelEnabled === true &&
+            faSignal !== undefined &&
+            openFaPositions < faMaxPositions
+          ) {
             const faLadder = buildTpLadder(pool.currentPrice, {
               rungs: config.fallenAngelTpRungs ?? [0.15, 0.3, 0.5],
               fractions: config.fallenAngelTpFractions ?? [0.4, 0.3, 0.3],
@@ -5516,6 +5533,10 @@ export const program = Effect.gen(function* () {
                 tpLadderJson: serializeTpLadder(faLadder.ladder) ?? undefined,
                 invalidationStopPrice: faLadder.invalidationPrice,
               });
+              // Consume the ENTER slot: the FA branch already pushed the
+              // decision, so the quality gates below must not run and push a
+              // duplicate ENTER for the same pool this cycle.
+              enterGateRejected = true;
             }
           }
 

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -92,6 +92,7 @@ import {
   type MemoryApi,
   type RiskResult,
   type ScreenedPool,
+  type DiscoveredPool,
   type StrategyApi,
   type RevenueConfigApi,
   type EntryPrepApi,
@@ -105,6 +106,16 @@ import { AlertLive } from "./alert-service.js";
 import { detectDepegAndLiquidityDrain } from "./depeg-liquidity-detector.js";
 import { consultTokenRisks, type TokenRiskSignal } from "./token-risk-service.js";
 import { CopySignalLive, applyCopySignalBoost } from "./copy-trading-signals.js";
+import { evaluateFallenAngelDiscovery } from "./fallen-angel-discovery.js";
+import {
+  buildTpLadder,
+  evaluateTpLadder,
+  parseTpLadder,
+  serializeTpLadder,
+  type TpLadder,
+} from "./tp-ladder.js";
+import { getGeckoPoolOhlcv, type GeckoOhlcvSignals } from "./gecko-ohlcv-service.js";
+import { getRugCheckReport, type RugCheckReport } from "./rugcheck-service.js";
 import type {
   AgentDecision,
   AgentProposal,
@@ -942,6 +953,9 @@ export function executePaper(
         cumulativeRewardsClaimedUsd: 0,
         closedAt: null,
         realizedPnlUsd: null,
+        positionMode: decision.positionMode ?? null,
+        tpLadderJson: decision.tpLadderJson ?? null,
+        invalidationStopPrice: decision.invalidationStopPrice ?? null,
       };
       trackedPositions.set(pos.positionId, pos);
       yield* persist(`savePosition ${pos.positionId}`, db.savePosition(pos));
@@ -1452,6 +1466,9 @@ export function executeLive(
           cumulativeRewardsClaimedUsd: 0,
           closedAt: null,
           realizedPnlUsd: null,
+          positionMode: decision.positionMode ?? null,
+          tpLadderJson: decision.tpLadderJson ?? null,
+          invalidationStopPrice: decision.invalidationStopPrice ?? null,
         };
         trackedPositions.set(pos.positionId, pos);
         yield* persist(`savePosition ${pos.positionId}`, db.savePosition(pos));
@@ -2441,6 +2458,15 @@ export const program = Effect.gen(function* () {
   const autonomousCandidateWallet = executionWalletAddress ?? "paper";
   const autonomousCandidates = new Map<string, TokenCandidateRecord>();
   const autonomousCandidatePools = new Set<string>();
+  // Fallen-angel candidates (Wave 19): pools that cleared the fallen-angel
+  // gate (RugCheck security + GeckoTerminal drawdown/vol). Opt-in, inert when
+  // FALLEN_ANGEL_ENABLED is off. `fallenAngelSignals` carries the per-pool
+  // qualification so the ENTER gate can re-confirm without re-fetching.
+  const fallenAngelCandidatePools = new Set<string>();
+  const fallenAngelSignals = new Map<
+    string,
+    { readonly assetMint: string; readonly drawdownPct: number }
+  >();
   const autonomousCandidatePoolAddresses = new Set<string>();
 
   if (config.autonomousTokenMode !== "off") {
@@ -2506,6 +2532,9 @@ export const program = Effect.gen(function* () {
     unresolvedPoolAddresses = new Set(reconcileResult.unresolvedPoolAddresses);
     poolsToScan = [...approvedPoolAddresses];
     for (const poolAddress of autonomousCandidatePools) {
+      if (!poolsToScan.includes(poolAddress)) poolsToScan.push(poolAddress);
+    }
+    for (const poolAddress of fallenAngelCandidatePools) {
       if (!poolsToScan.includes(poolAddress)) poolsToScan.push(poolAddress);
     }
     if (!reconcileResult.succeeded) {
@@ -2654,6 +2683,84 @@ export const program = Effect.gen(function* () {
       for (const poolAddress of advanced.eligiblePoolAddresses) {
         autonomousCandidatePools.add(poolAddress);
         if (!poolsToScan.includes(poolAddress)) poolsToScan.push(poolAddress);
+      }
+    });
+
+  // Fallen-angel discovery refresh (Wave 19). Opt-in via FALLEN_ANGEL_ENABLED.
+  // Re-runs the gate each cycle over a fresh discovery page (any TVL above
+  // fallenAngelMinTvlUsd) and feeds qualified pools into poolsToScan. Network
+  // calls are paced at the HTTP layer (gecko ≥2.1s, per-mint RugCheck cached
+  // for the process lifetime) so a 50-pool page does not hammer the APIs.
+  const refreshFallenAngelCandidates = (scanOrdinal: number): Effect.Effect<void, never> =>
+    Effect.gen(function* () {
+      if (config.fallenAngelEnabled !== true || !shouldDiscoverPools(config)) return;
+      const discovered = yield* adapter
+        .discoverPools(scanOrdinal)
+        .pipe(Effect.catchAll(() => Effect.succeed([] as ReadonlyArray<DiscoveredPool>)));
+      if (discovered.length === 0) return;
+
+      const rugcheckCache = new Map<string, RugCheckReport | null>();
+      const fetchSignals = async (pool: {
+        readonly address: string;
+        readonly tokenX: string;
+        readonly tokenY: string;
+      }) => {
+        const assetMint = [pool.tokenX, pool.tokenY].find(
+          (mint) => mint !== SOL_MINT && !(config.stablecoinMints?.has(mint) === true),
+        );
+        const ohlcv: GeckoOhlcvSignals | null = await getGeckoPoolOhlcv(pool.address);
+        let rugcheck: RugCheckReport | null = null;
+        if (assetMint) {
+          if (!rugcheckCache.has(assetMint)) {
+            rugcheckCache.set(assetMint, await getRugCheckReport(assetMint));
+          }
+          rugcheck = rugcheckCache.get(assetMint) ?? null;
+        }
+        return { ohlcv, rugcheck };
+      };
+
+      const result = yield* Effect.promise(() =>
+        evaluateFallenAngelDiscovery(
+          discovered.filter(
+            (p) => Number.isFinite(p.tvlUsd) && p.tvlUsd >= (config.fallenAngelMinTvlUsd ?? 0),
+          ),
+          {
+            minTvlUsd: config.fallenAngelMinTvlUsd ?? 0,
+            minDrawdownPct: config.fallenAngelMinDrawdownPct ?? 0.6,
+            maxDrawdownPct: config.fallenAngelMaxDrawdownPct ?? 0.95,
+            volBaselineMin: config.fallenAngelVolBaselineMin ?? 0.02,
+            volBaselineMax: config.fallenAngelVolBaselineMax ?? 0.35,
+            maxRugcheckScore: config.fallenAngelMaxRugcheckScore ?? 60,
+            minHolders: config.fallenAngelMinHolders ?? 300,
+            maxTop10HolderPct: config.fallenAngelMaxTop10HolderPct ?? 0.5,
+          },
+          config.stablecoinMints,
+          fetchSignals,
+        ),
+      );
+
+      fallenAngelCandidatePools.clear();
+      fallenAngelSignals.clear();
+      for (const qualified of result.qualified) {
+        fallenAngelCandidatePools.add(qualified.poolAddress);
+        fallenAngelSignals.set(qualified.poolAddress, {
+          assetMint: qualified.assetMint,
+          drawdownPct: qualified.drawdownPct,
+        });
+        if (!poolsToScan.includes(qualified.poolAddress)) {
+          poolsToScan.push(qualified.poolAddress);
+        }
+      }
+      if (result.qualified.length > 0) {
+        logger.info(`Fallen-angel discovery: ${result.qualified.length} qualified pool(s)`, {
+          pools: result.qualified.map((q) => q.poolAddress),
+        });
+      }
+      for (const rejected of result.rejected.slice(0, 5)) {
+        logger.debug("Fallen-angel candidate rejected", {
+          pool: rejected.poolAddress,
+          reasons: rejected.reasons,
+        });
       }
     });
 
@@ -3575,6 +3682,7 @@ export const program = Effect.gen(function* () {
 
       let oldestSettlementAgeMs = 0;
       yield* refreshAutonomousCandidates(scanCount);
+      yield* refreshFallenAngelCandidates(scanCount);
       if (autonomousExecution) {
         const settlementJobs = yield* db
           .listSettlementJobs(
@@ -4603,7 +4711,44 @@ export const program = Effect.gen(function* () {
           }
         }
 
-        if (w15Signals.depeg || w15Signals.liquidityDrain) {
+        // ── Fallen-angel lifecycle (Wave 19) ─────────────────────────────
+        // A fallen-angel position exits via its TP-ladder (a rung is hit —
+        // scale out, close-and-reopen) or its invalidation stop (thesis
+        // broken — capital protection at confidence 1). Both are
+        // position-targeted deterministic exits and take precedence over the
+        // ordinary EXIT chain below.
+        let faLifecycle: { status: "tp" | "invalidation"; reasoning: string } | null = null;
+        if (config.fallenAngelEnabled === true && pos.positionMode === "fallen-angel") {
+          const faLadderParsed = parseTpLadder(pos.tpLadderJson);
+          if (faLadderParsed !== null && pos.invalidationStopPrice != null) {
+            const faEval = evaluateTpLadder(
+              pool.currentPrice,
+              faLadderParsed,
+              pos.invalidationStopPrice,
+            );
+            if (faEval.status === "invalidation") {
+              faLifecycle = {
+                status: "invalidation",
+                reasoning: `[fa-invalidation] Price ${pool.currentPrice.toFixed(6)} <= invalidation stop ${pos.invalidationStopPrice.toFixed(6)} — thesis broken`,
+              };
+            } else if (faEval.status === "tp" && faEval.rungReached) {
+              faLifecycle = {
+                status: "tp",
+                reasoning: `[fa-tp-ladder] Price ${pool.currentPrice.toFixed(6)} reached target ${faEval.rungReached.targetPrice.toFixed(6)} — scale out ${(faEval.scaleOutFraction ?? 0) * 100}%`,
+              };
+            }
+          }
+        }
+
+        if (faLifecycle) {
+          decision = {
+            action: "EXIT",
+            poolAddress,
+            positionId: pos.positionId,
+            confidence: 1,
+            reasoning: faLifecycle.reasoning,
+          };
+        } else if (w15Signals.depeg || w15Signals.liquidityDrain) {
           decision = {
             action: "EXIT",
             poolAddress,
@@ -5309,6 +5454,68 @@ export const program = Effect.gen(function* () {
                 })
                 .pipe(Effect.catchAll(() => Effect.void));
               enterGateRejected = true;
+            }
+          }
+
+          // ── Fallen-angel ENTER (Wave 19) ───────────────────────────────
+          // A pool that cleared the fallen-angel gate (RugCheck security +
+          // GeckoTerminal drawdown/vol) enters on the MEAN-REVERSION thesis:
+          // the fee-harvesting quality gates below ([fee-il-gate], ×1.5
+          // candidate conditions, weighted score) do not apply — a deeply
+          // drawn-down token has thin fee/IL by construction. Allocation,
+          // token-risk and the risk tail still run verbatim. The decision
+          // carries the FA lifecycle (ladder + invalidation) so execution
+          // stamps the position row.
+          const faSignal = fallenAngelSignals.get(poolAddress);
+          if (!enterGateRejected && config.fallenAngelEnabled === true && faSignal !== undefined) {
+            const faLadder = buildTpLadder(pool.currentPrice, {
+              rungs: config.fallenAngelTpRungs ?? [0.15, 0.3, 0.5],
+              fractions: config.fallenAngelTpFractions ?? [0.4, 0.3, 0.3],
+              invalidationStopPct: config.fallenAngelInvalidationStopPct ?? 0.25,
+            });
+            const faProposedSizeUsd = computeEntrySizeUsd({
+              walletBalanceUsd,
+              tvlUsd: pool.tvlUsd,
+            });
+            const faAllocation = evaluatePerPoolAllocation({
+              proposedDepositUsd: faProposedSizeUsd,
+              portfolioValueUsd,
+              openPositions,
+              maxPerPoolAllocationPct: config.maxPerPoolAllocationPct,
+              maxOpenPositions: config.maxOpenPositions,
+              poolAddress,
+              maxPositionsPerPool: config.maxPositionsPerPool,
+            });
+            if (!faAllocation.approved) {
+              console.info(
+                `[fa-alloc-gate] Skipping FA ENTER ${poolAddress} — ${faAllocation.reason}`,
+              );
+              yield* audit
+                .recordDecision({
+                  timestamp: Date.now(),
+                  cycleId,
+                  poolAddress,
+                  action: "ENTER",
+                  confidence: 0,
+                  reasoning: `[fa-alloc-gate] ${faAllocation.reason}`,
+                  metrics,
+                  riskResult: { approved: false, reason: `[fa-alloc-gate] ${faAllocation.reason}` },
+                  executed: false,
+                  paperTrading: config.paperTrading,
+                })
+                .pipe(Effect.catchAll(() => Effect.void));
+              enterGateRejected = true;
+            } else if (faLadder !== null) {
+              rawDecisions.push({
+                action: "ENTER",
+                poolAddress,
+                confidence: 0.75,
+                reasoning: `Fallen-angel: ${faSignal.assetMint} down ${(faSignal.drawdownPct * 100).toFixed(0)}% from ATH, RugCheck-clean, TVL $${pool.tvlUsd.toFixed(0)}`,
+                positionSizeUsd: faAllocation.adjustedDepositUsd,
+                positionMode: "fallen-angel",
+                tpLadderJson: serializeTpLadder(faLadder.ladder) ?? undefined,
+                invalidationStopPrice: faLadder.invalidationPrice,
+              });
             }
           }
 

--- a/engine/rugcheck-service.ts
+++ b/engine/rugcheck-service.ts
@@ -1,0 +1,216 @@
+import { createLogger } from "./logger.js";
+
+/**
+ * RugCheck token-report fetcher for fallen-angel mode (Wave 19).
+ *
+ * Supplies the SECURITY gate of the fallen-angel pipeline: a distressed token
+ * is only worth a mean-reversion play when its token contract is clean. RugCheck
+ * (api.rugcheck.xyz) publishes a free, keyless token report aggregating
+ * on-chain contract facts (authorities, LP locks, holder concentration, known
+ * risk patterns).
+ *
+ * Module-function design (clone of `gecko-terminal-service.ts` /
+ * `token-risk-service.ts`): plain exported functions with an injectable
+ * `fetchImpl`, NOT an Effect Context.Tag, so adding it does not ripple through
+ * the test layers. All network failure paths return null (fail-open) — a
+ * missing report means "security unknown", which the caller treats as "not a
+ * fallen angel" (fail-closed for the positive gate).
+ *
+ * LIVE-VERIFIED contract (2026-08-05, checked across 4 tokens):
+ *   GET {base}/tokens/{mint}/report  (keyless)
+ *   → {
+ *       "score": 15218,               # absolute score — NOT comparable across tokens
+ *       "score_normalised": 56,       # 0..100 RISK index — HIGHER = RISKIER
+ *         (SOL≈1, BONK≈7, dangerous LP-unlocked token ≈56, mint-authority-enabled ≈71)
+ *       "rugged": bool,
+ *       "token": { "mintAuthority": addr|null, "freezeAuthority": addr|null, ... },
+ *       "tokenMeta": { "name","symbol","uri","mutable": bool, ... },
+ *       "totalHolders": number|null,
+ *       "topHolders": [ { "address","owner","pct","amount","decimals","uiAmount",
+ *                          "insider": bool|null } | null ] | null,
+ *       "risks": [ { "name","value","description","score","level": "danger"|"warn" } ],
+ *       "totalLPProviders","totalStableLiquidity", ...
+ *     }
+ *   Unknown/absent token → 404/{"detail": ...}; 429 → rate limited.
+ *
+ * NOTE on score directions: `score` is an absolute, not-normalised number that
+ * varies wildly by token class (1 for SOL/USDC, 15218 for a risky meme) — it
+ * MUST NOT be used as a threshold. `score_normalised` is the 0..100 risk index.
+ * The primary hard gate is `risks[].level === "danger"` (mint authority still
+ * enabled, LP unlocked, etc.); `score_normalised` is a secondary floor.
+ */
+
+const logger = createLogger("rugcheck");
+
+const DEFAULT_BASE_URL = "https://api.rugcheck.xyz/v1";
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export interface RugCheckRisk {
+  readonly name: string;
+  readonly value: string | null;
+  readonly description: string | null;
+  /** "danger" | "warn" | unknown level strings are preserved verbatim. */
+  readonly level: string | null;
+}
+
+export interface RugCheckTopHolder {
+  readonly address: string;
+  readonly owner: string | null;
+  /** Holder share of supply, 0..100 (percent). */
+  readonly pct: number;
+  readonly insider: boolean | null;
+}
+
+/** Parsed + normalised RugCheck report for one mint. */
+export interface RugCheckReport {
+  readonly mint: string;
+  /** 0..100 risk index from score_normalised; null when absent. HIGHER = RISKIER. */
+  readonly scoreNormalised: number | null;
+  readonly rugged: boolean;
+  readonly mintAuthority: string | null;
+  readonly freezeAuthority: string | null;
+  readonly tokenMetaMutable: boolean | null;
+  readonly totalHolders: number | null;
+  readonly topHolders: ReadonlyArray<RugCheckTopHolder>;
+  readonly risks: ReadonlyArray<RugCheckRisk>;
+  /** Sum of top-10 holder pct (0..100); null when topHolders is absent. */
+  readonly top10HolderPct: number | null;
+  /** 1 + index of the first danger risk (1-based for human display), else 0. */
+  readonly dangerRiskCount: number;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/**
+ * Parse a raw RugCheck report payload. Returns null when the payload is not a
+ * usable report object. Individual fields degrade to null / empty lists — the
+ * caller's gate decides which absences are fail-closed vs fail-open.
+ */
+export function parseRugCheckReport(raw: unknown): RugCheckReport | null {
+  if (!isObject(raw)) return null;
+  const mint = typeof raw["mint"] === "string" ? raw["mint"] : "";
+  if (mint.length === 0) return null;
+
+  const token = isObject(raw["token"]) ? (raw["token"] as Record<string, unknown>) : null;
+  const tokenMeta = isObject(raw["tokenMeta"])
+    ? (raw["tokenMeta"] as Record<string, unknown>)
+    : null;
+
+  const risks: RugCheckRisk[] = [];
+  if (Array.isArray(raw["risks"])) {
+    for (const risk of raw["risks"]) {
+      if (!isObject(risk)) continue;
+      risks.push({
+        name: typeof risk["name"] === "string" ? risk["name"] : "unknown risk",
+        value: typeof risk["value"] === "string" ? risk["value"] : null,
+        description: typeof risk["description"] === "string" ? risk["description"] : null,
+        level: typeof risk["level"] === "string" ? risk["level"] : null,
+      });
+    }
+  }
+
+  const rawTopHolders = raw["topHolders"];
+  const topHolders: RugCheckTopHolder[] = [];
+  if (Array.isArray(rawTopHolders)) {
+    for (const holder of rawTopHolders) {
+      if (!isObject(holder)) continue;
+      const address = typeof holder["address"] === "string" ? holder["address"] : "";
+      if (address.length === 0) continue;
+      const pct = readFiniteNumber(holder["pct"]);
+      if (pct === null) continue;
+      topHolders.push({
+        address,
+        owner: typeof holder["owner"] === "string" ? holder["owner"] : null,
+        pct,
+        insider: typeof holder["insider"] === "boolean" ? holder["insider"] : null,
+      });
+    }
+  }
+  const top10HolderPct =
+    topHolders.length > 0 ? topHolders.slice(0, 10).reduce((sum, h) => sum + h.pct, 0) : null;
+
+  return {
+    mint,
+    scoreNormalised: readFiniteNumber(raw["score_normalised"]),
+    rugged: raw["rugged"] === true,
+    mintAuthority:
+      token !== null &&
+      typeof token["mintAuthority"] === "string" &&
+      token["mintAuthority"].length > 0
+        ? token["mintAuthority"]
+        : null,
+    freezeAuthority:
+      token !== null &&
+      typeof token["freezeAuthority"] === "string" &&
+      token["freezeAuthority"].length > 0
+        ? token["freezeAuthority"]
+        : null,
+    tokenMetaMutable:
+      tokenMeta !== null && typeof tokenMeta["mutable"] === "boolean" ? tokenMeta["mutable"] : null,
+    totalHolders: readFiniteNumber(raw["totalHolders"]),
+    topHolders,
+    risks,
+    top10HolderPct,
+    dangerRiskCount: risks.filter((r) => r.level === "danger").length,
+  };
+}
+
+/**
+ * Fetch a RugCheck report for a mint. NEVER throws and NEVER crashes the scan:
+ * 404/429/5xx, timeout, fetch failure, or parse failure all return null so the
+ * caller treats the security as unknown (fail-closed for the positive gate).
+ * Logs ONE warning per failing fetch.
+ */
+export async function getRugCheckReport(
+  mint: string,
+  options: {
+    readonly baseUrl?: string;
+    readonly timeoutMs?: number;
+    readonly fetchImpl?: FetchLike;
+  } = {},
+): Promise<RugCheckReport | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? REQUEST_TIMEOUT_MS;
+  const base = (options.baseUrl ?? process.env.RUGCHECK_API_URL ?? DEFAULT_BASE_URL)
+    .trim()
+    .replace(/\/+$/, "");
+  const effectiveBase = base.length > 0 ? base : DEFAULT_BASE_URL;
+  const url = `${effectiveBase}/tokens/${mint}/report`;
+
+  try {
+    const res = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) {
+      logger.warn("RugCheck report unavailable — security unknown", {
+        mint,
+        status: res.status,
+      });
+      return null;
+    }
+    const body: unknown = await res.json();
+    const parsed = parseRugCheckReport(body);
+    if (parsed === null) {
+      logger.warn("RugCheck returned an unparseable report", { mint });
+      return null;
+    }
+    return parsed;
+  } catch (err) {
+    logger.warn("RugCheck fetch failed — security unknown", {
+      mint,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/engine/rugcheck-service.ts
+++ b/engine/rugcheck-service.ts
@@ -77,7 +77,7 @@ export interface RugCheckReport {
   readonly risks: ReadonlyArray<RugCheckRisk>;
   /** Sum of top-10 holder pct (0..100); null when topHolders is absent. */
   readonly top10HolderPct: number | null;
-  /** 1 + index of the first danger risk (1-based for human display), else 0. */
+  /** Number of risks with level "danger" (0 = none). */
   readonly dangerRiskCount: number;
 }
 

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -1077,6 +1077,8 @@ export interface DbApi {
   >;
   readonly getMetadata: (key: string) => Effect.Effect<string | null, unknown>;
   readonly setMetadata: (key: string, value: string) => Effect.Effect<void, unknown>;
+  /** Delete a metadata row if present (used by `prism config unset`). */
+  readonly deleteMetadata: (key: string) => Effect.Effect<void, unknown>;
   readonly setMetadataBatch: (
     entries: ReadonlyArray<{ key: string; value: string }>,
   ) => Effect.Effect<void, unknown>;

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -745,6 +745,10 @@ export interface DbApi {
     cumulativeRewardsClaimedUsd: number;
     closedAt: number | null;
     realizedPnlUsd: number | null;
+    /** Fallen-angel lifecycle state (Wave 19); optional so legacy callers compile. */
+    positionMode?: string | null;
+    tpLadderJson?: string | null;
+    invalidationStopPrice?: number | null;
   }) => Effect.Effect<void, unknown>;
   readonly getPosition: (positionId: string) => Effect.Effect<
     {
@@ -775,6 +779,9 @@ export interface DbApi {
       cumulativeRewardsClaimedUsd: number;
       closedAt: number | null;
       realizedPnlUsd: number | null;
+      positionMode?: string | null;
+      tpLadderJson?: string | null;
+      invalidationStopPrice?: number | null;
     } | null,
     unknown
   >;
@@ -807,6 +814,9 @@ export interface DbApi {
       cumulativeRewardsClaimedUsd: number;
       closedAt: number | null;
       realizedPnlUsd: number | null;
+      positionMode?: string | null;
+      tpLadderJson?: string | null;
+      invalidationStopPrice?: number | null;
     }>,
     unknown
   >;
@@ -839,6 +849,9 @@ export interface DbApi {
       cumulativeRewardsClaimedUsd: number;
       closedAt: number | null;
       realizedPnlUsd: number | null;
+      positionMode?: string | null;
+      tpLadderJson?: string | null;
+      invalidationStopPrice?: number | null;
     }>,
     unknown
   >;
@@ -884,6 +897,9 @@ export interface DbApi {
       cumulativeRewardsClaimedUsd: number;
       closedAt: number | null;
       realizedPnlUsd: number | null;
+      positionMode?: string | null;
+      tpLadderJson?: string | null;
+      invalidationStopPrice?: number | null;
     }>,
     unknown
   >;

--- a/engine/tp-ladder.ts
+++ b/engine/tp-ladder.ts
@@ -1,0 +1,157 @@
+/**
+ * Spot TP-ladder + invalidation-stop lifecycle for fallen-angel positions
+ * (Wave 19) — pure module.
+ *
+ * A fallen-angel position is a mean-reversion bet on a distressed-but-clean
+ * token. It exits NOT by range-harvesting rebalance but by a ladder of
+ * take-profit targets above entry plus a hard invalidation stop below it:
+ *
+ *   - TP ladder: `rungs` at ascending price targets (fractions ABOVE entry,
+ *     e.g. +15% / +30% / +50%), each scaling out a `fraction` of the position.
+ *   - Invalidation stop: when price falls to `entry × (1 − stopPct)`, the
+ *     thesis is broken — EXIT at confidence 1 (capital protection).
+ *
+ * EXECUTION MODEL (locked user decision #3): the adapter's `exitPosition` is
+ * full-close-only (no bps partial withdraw) and W14 on-chain limit orders are
+ * blocked, so a rung is realized as a FULL EXIT at confidence 1 with a
+ * `[tp-ladder]` reason, then the remaining fraction re-opens next scan cycle as
+ * a fresh smaller fallen-angel position (scale-out via close-and-reopen). When
+ * the last rung is hit (the whole ladder is complete), there is no remainder.
+ *
+ * All functions are pure and side-effect free; the caller persists state.
+ */
+
+export interface TpRung {
+  /** Take-profit price target (absolute, in the pool's quote-asset price). */
+  readonly targetPrice: number;
+  /** Fraction of the position scaled out at this rung (0..1). */
+  readonly fraction: number;
+}
+
+export interface TpLadder {
+  readonly rungs: ReadonlyArray<TpRung>;
+  /** Total fraction scaled out by the ladder (≤ 1). */
+  readonly totalFraction: number;
+}
+
+export interface TpLadderConfig {
+  /** TP rung targets as fractions ABOVE entry (e.g. [0.15, 0.30, 0.50]). */
+  readonly rungs: ReadonlyArray<number>;
+  /** Fraction to scale out per rung (e.g. [0.4, 0.3, 0.3]); renormalized to sum ≤ 1. */
+  readonly fractions: ReadonlyArray<number>;
+  /** Invalidation stop: EXIT when price ≤ entry × (1 − pct). */
+  readonly invalidationStopPct: number;
+}
+
+/**
+ * Build a TP ladder + invalidation price for a fallen-angel entry.
+ * - rungs are entry × (1 + rungPct), in ascending order.
+ * - fractions are capped at the number of rungs and renormalized so the total
+ *   never exceeds 1 (excess is trimmed, not silently dropped from the middle).
+ * - invalidationPrice = entry × (1 − invalidationStopPct).
+ * Returns null when the config is empty (no rungs) or entry is non-positive.
+ */
+export function buildTpLadder(
+  entryPrice: number,
+  config: TpLadderConfig,
+): { readonly ladder: TpLadder; readonly invalidationPrice: number } | null {
+  if (!Number.isFinite(entryPrice) || entryPrice <= 0) return null;
+  const rungCount = Math.min(config.rungs.length, config.fractions.length);
+  if (rungCount === 0) return null;
+
+  const rawRungs: Array<{ targetPrice: number; fraction: number }> = config.rungs
+    .slice(0, rungCount)
+    .sort((a, b) => a - b)
+    .map((pct, i) => ({
+      targetPrice: entryPrice * (1 + pct),
+      fraction: config.fractions[i]!,
+    }));
+
+  const total = rawRungs.reduce((sum, rung) => sum + rung.fraction, 0);
+  // Renormalize so the ladder never scales out more than the whole position
+  // (rebuild — fields are readonly, mutation is not allowed).
+  const scale = total > 1 ? 1 / total : 1;
+  const rungs: TpRung[] = rawRungs.map((rung) => ({
+    targetPrice: rung.targetPrice,
+    fraction: rung.fraction * scale,
+  }));
+
+  const invalidationPrice = entryPrice * (1 - config.invalidationStopPct);
+  const totalFraction = rungs.reduce((sum, rung) => sum + rung.fraction, 0);
+  return { ladder: { rungs, totalFraction }, invalidationPrice };
+}
+
+export type TpLadderActionStatus = "none" | "tp" | "invalidation";
+
+export interface TpLadderEvaluation {
+  readonly status: TpLadderActionStatus;
+  /** The reached rung (status === "tp"), else undefined. */
+  readonly rungReached?: TpRung;
+  /** Fraction to scale out at this step (the reached rung's fraction). */
+  readonly scaleOutFraction?: number;
+  /** True when the reached rung is the last one (ladder complete → no remainder). */
+  readonly ladderComplete?: boolean;
+  /** Invalidation price (status === "invalidation"), else undefined. */
+  readonly invalidationPrice?: number;
+}
+
+/**
+ * Evaluate the ladder against the current price.
+ * - invalidation fires first (capital protection): price ≤ invalidationPrice.
+ * - otherwise the FIRST rung whose targetPrice ≤ price fires (a rung is
+ *   "reached" once price rises to it; we take the lowest reached, since the
+ *   position is scaled out monotonically).
+ * - "none" when no rung is reached and the invalidation is not hit.
+ */
+export function evaluateTpLadder(
+  currentPrice: number,
+  ladder: TpLadder,
+  invalidationPrice: number,
+): TpLadderEvaluation {
+  if (!Number.isFinite(currentPrice) || currentPrice <= 0) {
+    return { status: "none" };
+  }
+  if (currentPrice <= invalidationPrice) {
+    return { status: "invalidation", invalidationPrice };
+  }
+  const reachedIndex = ladder.rungs.findIndex((rung) => currentPrice >= rung.targetPrice);
+  if (reachedIndex === -1) return { status: "none" };
+  const rungReached = ladder.rungs[reachedIndex]!;
+  return {
+    status: "tp",
+    rungReached,
+    scaleOutFraction: rungReached.fraction,
+    ladderComplete: reachedIndex === ladder.rungs.length - 1,
+  };
+}
+
+/**
+ * Serialize a ladder to a compact JSON string for persistence (or null when
+ * the ladder is undefined/empty).
+ */
+export function serializeTpLadder(ladder: TpLadder | undefined): string | null {
+  if (ladder === undefined || ladder.rungs.length === 0) return null;
+  return JSON.stringify(ladder);
+}
+
+/** Parse a persisted ladder JSON string back into a TpLadder (or null). */
+export function parseTpLadder(raw: string | null | undefined): TpLadder | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { rungs?: Array<{ targetPrice: number; fraction: number }> };
+    if (!Array.isArray(parsed.rungs) || parsed.rungs.length === 0) return null;
+    const rungs = parsed.rungs
+      .filter(
+        (rung) =>
+          Number.isFinite(rung.targetPrice) &&
+          Number.isFinite(rung.fraction) &&
+          rung.targetPrice > 0 &&
+          rung.fraction > 0,
+      )
+      .map((rung) => ({ targetPrice: rung.targetPrice, fraction: rung.fraction }));
+    if (rungs.length === 0) return null;
+    return { rungs, totalFraction: rungs.reduce((sum, r) => sum + r.fraction, 0) };
+  } catch {
+    return null;
+  }
+}

--- a/engine/tp-ladder.ts
+++ b/engine/tp-ladder.ts
@@ -59,13 +59,16 @@ export function buildTpLadder(
   const rungCount = Math.min(config.rungs.length, config.fractions.length);
   if (rungCount === 0) return null;
 
-  const rawRungs: Array<{ targetPrice: number; fraction: number }> = config.rungs
+  // Pair each rung pct with its fraction BEFORE sorting, so an unsorted
+  // input keeps each fraction attached to the target it belongs to.
+  const pairs: Array<{ pct: number; fraction: number }> = config.rungs
     .slice(0, rungCount)
-    .sort((a, b) => a - b)
-    .map((pct, i) => ({
-      targetPrice: entryPrice * (1 + pct),
-      fraction: config.fractions[i]!,
-    }));
+    .map((pct, i) => ({ pct, fraction: config.fractions[i]! }));
+  pairs.sort((a, b) => a.pct - b.pct);
+  const rawRungs: Array<{ targetPrice: number; fraction: number }> = pairs.map((pair) => ({
+    targetPrice: entryPrice * (1 + pair.pct),
+    fraction: pair.fraction,
+  }));
 
   const total = rawRungs.reduce((sum, rung) => sum + rung.fraction, 0);
   // Renormalize so the ladder never scales out more than the whole position

--- a/engine/types.ts
+++ b/engine/types.ts
@@ -317,6 +317,14 @@ export interface AgentDecision {
    * pool holds multiple positions.
    */
   positionId?: string | undefined;
+  /** Fallen-angel ENTER lifecycle (Wave 19): "fallen-angel" position mode.
+   *  Carried on the decision so execution stamps the row; undefined for
+   *  standard positions. */
+  positionMode?: "fallen-angel" | undefined;
+  /** Serialized TP-ladder JSON (see engine/tp-ladder.ts) for FA positions. */
+  tpLadderJson?: string | undefined;
+  /** Invalidation stop price for FA positions. */
+  invalidationStopPrice?: number | undefined;
 }
 
 // ─── Agent Proposals ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## What this adds

A new opt-in **fallen-angel mode** (`FALLEN_ANGEL_ENABLED`, default `false` — inert unless enabled): a mean-reversion strategy for distressed-but-clean tokens. When off, behaviour is byte-identical to before (verified: full suite passes with the mode off).

### Wave A — DB-backed config + `prism config` CLI
- `engine/db-config.ts`: pure registry (`DB_CONFIG_KEYS`) + read/apply with **env > DB > defaults** precedence; fail-open; allowlisted keys only (secrets/paths/URLs never stored).
- `ConfigLive` applies persisted `metadata` rows (`config.<KEY>`) after env resolution; test mode never touches the DB.
- `prism config get|set|unset|list` (validated + clamped before write, env-shadowing surfaced).
- Upgrade helper: new config keys go through the registry; schema changes through numbered guarded migrations.

### Wave B+C — data fetchers + gate pipeline
- `engine/gecko-ohlcv-service.ts`: daily OHLCV → ATH / drawdown / volatility baseline (injectable `fetchImpl`, fail-open, live-verified contract).
- `engine/rugcheck-service.ts`: token report → risk score (0-100, **higher = riskier**, live-verified across 4 tokens), danger-level risks, top-10 holder concentration, mint/freeze authorities, holder count (fail-open).
- `engine/fallen-angel-service.ts`: pure gate — RugCheck security + drawdown band + volatility band + min TVL, fail-closed on missing signals.
- `engine/fallen-angel-discovery.ts`: any-TVL discovery pass (pure, injectable fetch).

### Wave D — spot TP-ladder + invalidation-stop lifecycle
- `engine/tp-ladder.ts`: pure ladder build/evaluate/serialize (rungs = entry × (1+pct), invalidation fires first).
- Migration v22: `positions.position_mode`, `tp_ladder_json`, `invalidation_stop_price` (additive, legacy rows NULL).
- `program.ts`: per-cycle fallen-angel discovery → ENTER gate (bypasses fee-harvesting quality gates, keeps allocation/token-risk/risk tail) → per-position lifecycle EXIT (`[fa-tp-ladder]` scale-out and `[fa-invalidation]` capital protection, both confidence 1). Close-and-reopen scale-out is emergent via discovery re-qualification.
- Position records stamped with the FA lifecycle (paper + live).

## Verification
- `tsc --noEmit` clean; `oxlint` clean; `oxfmt --check` clean.
- Full suite: **115 files / 1464 tests pass** (25 new: db-config 12, gecko-ohlcv 7, rugcheck 8, fallen-angel gate 19, tp-ladder 11, discovery 6, db round-trip 2).
- CLI smoke: `prism config set/get/unset/list` round-trip verified against a scratch DB; engine-side env > DB > defaults verified.
- Rebased onto current `main` (includes #150).

## Summary by Sourcery

Introduce optional fallen-angel mean-reversion mode with external data-backed gating and TP-ladder lifecycle, plus DB-backed config overrides and a CLI for managing them.

New Features:
- Add fallen-angel mode that discovers distressed-but-clean tokens using GeckoTerminal OHLCV and RugCheck security signals and enters them via a dedicated mean-reversion gate.
- Implement a spot TP-ladder and invalidation-stop lifecycle for fallen-angel positions, including new position fields and EXIT handling.
- Introduce a DB-backed configuration override layer with precedence env > DB > defaults and a `prism config` CLI for listing, getting, setting, and unsetting keys.

Enhancements:
- Extend configuration to cover fallen-angel thresholds and limits (discovery TVL, drawdown and volatility bands, RugCheck and holder constraints, TP ladder, invalidation stop, and max positions).
- Add SQLite migrations and DB service support for fallen-angel lifecycle fields on positions.
- Wire fallen-angel discovery and lifecycle into the main program loop while keeping existing autonomous and safety flows intact.

Documentation:
- Document fallen-angel mode design, configuration, and rollout plan in a dedicated markdown guide.

Tests:
- Add comprehensive tests for DB-config overrides, Gecko OHLCV parsing, RugCheck parsing, fallen-angel gate and discovery logic, TP-ladder behaviour, and DB position round-tripping.