### PR TITLE
fix(gecko-ohlcv): cache last-good OHLCV per pool + backoff failed fetches

### DIFF
--- a/bench/gecko-ohlcv.test.ts
+++ b/bench/gecko-ohlcv.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import {
   parseGeckoOhlcv,
   summarizeGeckoOhlcv,
   getGeckoPoolOhlcv,
+  resetGeckoOhlcvCache,
   type GeckoOhlcvBar,
 } from "../engine/gecko-ohlcv-service.js";
 
+beforeEach(() => resetGeckoOhlcvCache());
 // Live-verified payload fragment (2026-08-05, pool 54Vp27uLaw4wNLo5n7r4fcC6zLamoQc28xBARjss4EUJ).
 // ohlcv_list rows are [unixSeconds, open, high, low, close, volume].
 const LIVE_OHLCV = {
@@ -168,5 +170,41 @@ describe("getGeckoPoolOhlcv", () => {
     };
     await getGeckoPoolOhlcv("abc", { fetchImpl, baseUrl: "https://x.example/api/v2", limit: 60 });
     expect(calledUrl).toContain("/networks/solana/pools/abc/ohlcv/day?limit=60");
+  });
+
+  it("serves a fresh last-good series from cache without re-fetching", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      return new Response(JSON.stringify(LIVE_OHLCV), { status: 200 });
+    };
+    await getGeckoPoolOhlcv("cached-pool", { fetchImpl });
+    const second = await getGeckoPoolOhlcv("cached-pool", { fetchImpl });
+    expect(second).not.toBeNull();
+    expect(calls).toBe(1);
+  });
+
+  it("reuses the stale last-good series when a later fetch fails (#154)", async () => {
+    const ok = async () => new Response(JSON.stringify(LIVE_OHLCV), { status: 200 });
+    await getGeckoPoolOhlcv("stale-pool", { fetchImpl: ok });
+    const failing = async () => new Response("{}", { status: 429 });
+    const result = await getGeckoPoolOhlcv("stale-pool", {
+      fetchImpl: failing,
+      cacheTtlMs: 0, // force the cached series stale so the fetch runs
+    });
+    expect(result).not.toBeNull();
+    expect(result!.barCount).toBe(5);
+  });
+
+  it("does not re-fetch a pool inside its backoff window", async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      return new Response("{}", { status: 500 });
+    };
+    await getGeckoPoolOhlcv("backoff-pool", { fetchImpl });
+    const second = await getGeckoPoolOhlcv("backoff-pool", { fetchImpl });
+    expect(second).toBeNull();
+    expect(calls).toBe(1);
   });
 });

--- a/engine/gecko-ohlcv-service.ts
+++ b/engine/gecko-ohlcv-service.ts
@@ -40,6 +40,14 @@ const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 /** Exponential backoff for failing pools: base 5 min, cap 1 h. */
 const BACKOFF_BASE_MS = 5 * 60 * 1000;
 const BACKOFF_MAX_MS = 60 * 60 * 1000;
+/**
+ * Max age of a cached/backoff entry before it is pruned (24h). Bounds the
+ * in-process maps to ~a day of active pools so a long-lived process scanning
+ * many/rotating pools does not grow memory without bound.
+ */
+const MAX_RETENTION_MS = 24 * 60 * 60 * 1000;
+/** Hard size cap on both maps as an absolute bound regardless of age. */
+const MAX_CACHE_ENTRIES = 1000;
 /** A single daily OHLCV bar. timestamps are unix seconds. */
 export interface GeckoOhlcvBar {
   readonly timestampSec: number;
@@ -211,6 +219,29 @@ export function resetGeckoOhlcvCache(): void {
 }
 
 /**
+ * Opportunistic eviction (called on every fetch): drop entries older than
+ * MAX_RETENTION_MS, then enforce the hard size cap via insertion-order
+ * eviction so the maps stay bounded even under sustained pool rotation.
+ */
+function pruneOhlcvState(nowMs: number): void {
+  for (const [pool, entry] of lastGoodCache) {
+    if (nowMs - entry.fetchedAt > MAX_RETENTION_MS) lastGoodCache.delete(pool);
+  }
+  for (const [pool, entry] of backoff) {
+    if (nowMs - entry.nextAttemptAt > MAX_RETENTION_MS) backoff.delete(pool);
+  }
+  while (lastGoodCache.size >= MAX_CACHE_ENTRIES) {
+    const oldest = lastGoodCache.keys().next().value;
+    if (oldest === undefined) break;
+    lastGoodCache.delete(oldest);
+  }
+  while (backoff.size >= MAX_CACHE_ENTRIES) {
+    const oldest = backoff.keys().next().value;
+    if (oldest === undefined) break;
+    backoff.delete(oldest);
+  }
+}
+/**
  * Fetch a daily OHLCV series for a pool. NEVER throws and NEVER crashes the
  * scan: 404/429/5xx, timeout, fetch failure, or parse failure all return null
  * so the caller treats the drawdown as unknown (fail-closed for the positive
@@ -241,6 +272,7 @@ export async function getGeckoPoolOhlcv(
   const effectiveBase = base.length > 0 ? base : DEFAULT_BASE_URL;
   const limit = options.limit ?? DEFAULT_OHLCV_LIMIT;
   const url = `${effectiveBase}/networks/solana/pools/${poolAddress}/ohlcv/day?limit=${limit}`;
+  pruneOhlcvState(Date.now());
 
   const cached = lastGoodCache.get(poolAddress);
   if (cached && Date.now() - cached.fetchedAt < (options.cacheTtlMs ?? CACHE_TTL_MS)) {
@@ -271,7 +303,7 @@ export async function getGeckoPoolOhlcv(
   try {
     const res = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
     if (!res.ok) {
-      logger.warn("GeckoTerminal OHLCV unavailable — drawdown unknown", {
+      logger.warn("GeckoTerminal OHLCV request failed", {
         pool: poolAddress,
         status: res.status,
       });
@@ -288,7 +320,7 @@ export async function getGeckoPoolOhlcv(
     backoff.delete(poolAddress);
     return signals;
   } catch (err) {
-    logger.warn("GeckoTerminal OHLCV fetch failed — drawdown unknown", {
+    logger.warn("GeckoTerminal OHLCV fetch threw", {
       pool: poolAddress,
       error: err instanceof Error ? err.message : String(err),
     });

--- a/engine/gecko-ohlcv-service.ts
+++ b/engine/gecko-ohlcv-service.ts
@@ -31,7 +31,15 @@ const DEFAULT_BASE_URL = "https://api.geckoterminal.com/api/v2";
 const REQUEST_TIMEOUT_MS = 10_000;
 /** Default window of daily candles (raw limit, not a calendar span). */
 export const DEFAULT_OHLCV_LIMIT = 180;
-
+/**
+ * How long a last-good OHLCV series is served without re-fetching (#154).
+ * Daily candles move at most once a day, so 6h is a safe reuse window and it
+ * slashes repeated fetches + failure warnings across discovery cycles.
+ */
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+/** Exponential backoff for failing pools: base 5 min, cap 1 h. */
+const BACKOFF_BASE_MS = 5 * 60 * 1000;
+const BACKOFF_MAX_MS = 60 * 60 * 1000;
 /** A single daily OHLCV bar. timestamps are unix seconds. */
 export interface GeckoOhlcvBar {
   readonly timestampSec: number;
@@ -186,10 +194,34 @@ export function summarizeGeckoOhlcv(bars: ReadonlyArray<GeckoOhlcvBar>): GeckoOh
 }
 
 /**
+ * Last-good OHLCV per pool (issue #154): a transient GeckoTerminal outage
+ * must not re-classify a pool that had data as "unknown".
+ */
+const lastGoodCache = new Map<
+  string,
+  { readonly signals: GeckoOhlcvSignals; readonly fetchedAt: number }
+>();
+/** Exponential backoff per failing pool so a dead endpoint is not re-hit every cycle. */
+const backoff = new Map<string, { readonly nextAttemptAt: number; readonly failures: number }>();
+
+/** Clear the in-process OHLCV cache + backoff state (test helper). */
+export function resetGeckoOhlcvCache(): void {
+  lastGoodCache.clear();
+  backoff.clear();
+}
+
+/**
  * Fetch a daily OHLCV series for a pool. NEVER throws and NEVER crashes the
  * scan: 404/429/5xx, timeout, fetch failure, or parse failure all return null
  * so the caller treats the drawdown as unknown (fail-closed for the positive
- * gate). Logs ONE warning per failing fetch.
+ * gate).
+ *
+ * Resilience (#154):
+ * - a fresh last-good series is served from cache (daily candles move ~1/day);
+ * - a failing pool enters exponential backoff (5 min → 1 h) instead of being
+ *   re-fetched + re-warned every cycle;
+ * - during a failure or backoff window, the STALE last-good series is reused
+ *   (debug) — only a pool with NO history is treated as unknown (warn).
  */
 export async function getGeckoPoolOhlcv(
   poolAddress: string,
@@ -197,6 +229,7 @@ export async function getGeckoPoolOhlcv(
     readonly limit?: number;
     readonly baseUrl?: string;
     readonly timeoutMs?: number;
+    readonly cacheTtlMs?: number;
     readonly fetchImpl?: FetchLike;
   } = {},
 ): Promise<GeckoOhlcvSignals | null> {
@@ -209,6 +242,32 @@ export async function getGeckoPoolOhlcv(
   const limit = options.limit ?? DEFAULT_OHLCV_LIMIT;
   const url = `${effectiveBase}/networks/solana/pools/${poolAddress}/ohlcv/day?limit=${limit}`;
 
+  const cached = lastGoodCache.get(poolAddress);
+  if (cached && Date.now() - cached.fetchedAt < (options.cacheTtlMs ?? CACHE_TTL_MS)) {
+    return cached.signals;
+  }
+
+  const pendingBackoff = backoff.get(poolAddress);
+  if (pendingBackoff && Date.now() < pendingBackoff.nextAttemptAt) {
+    return cached?.signals ?? null;
+  }
+
+  const serveFailure = (): GeckoOhlcvSignals | null => {
+    const failures = (backoff.get(poolAddress)?.failures ?? 0) + 1;
+    backoff.set(poolAddress, {
+      nextAttemptAt: Date.now() + Math.min(BACKOFF_BASE_MS * 2 ** (failures - 1), BACKOFF_MAX_MS),
+      failures,
+    });
+    if (cached) {
+      logger.debug("GeckoTerminal OHLCV fetch failed — reusing last-good series", {
+        pool: poolAddress,
+        ageMs: Date.now() - cached.fetchedAt,
+      });
+      return cached.signals;
+    }
+    return null;
+  };
+
   try {
     const res = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
     if (!res.ok) {
@@ -216,20 +275,23 @@ export async function getGeckoPoolOhlcv(
         pool: poolAddress,
         status: res.status,
       });
-      return null;
+      return serveFailure();
     }
     const body: unknown = await res.json();
     const bars = parseGeckoOhlcv(body);
     if (bars.length === 0) {
       logger.warn("GeckoTerminal OHLCV returned no usable bars", { pool: poolAddress });
-      return null;
+      return serveFailure();
     }
-    return summarizeGeckoOhlcv(bars);
+    const signals = summarizeGeckoOhlcv(bars);
+    lastGoodCache.set(poolAddress, { signals, fetchedAt: Date.now() });
+    backoff.delete(poolAddress);
+    return signals;
   } catch (err) {
     logger.warn("GeckoTerminal OHLCV fetch failed — drawdown unknown", {
       pool: poolAddress,
       error: err instanceof Error ? err.message : String(err),
     });
-    return null;
+    return serveFailure();
   }
 }


### PR DESCRIPTION
## What

Fallen-angel discovery was starved of drawdown/vol signals whenever a GeckoTerminal OHLCV fetch failed: the gate is fail-closed on missing signals, so any pool fetched during an outage was excluded — and every cycle re-fetched and re-warned (17 warnings in ~1h on v0.1.5).

## Changes (`engine/gecko-ohlcv-service.ts`)

- **Last-good cache**: OHLCV per pool cached for 6h TTL (daily candles move ~1/day) — healthy pools stop re-fetching every cycle entirely.
- **Exponential backoff**: failing pools are not re-hit for 5 min → 1 h (doubling), instead of every 10-min cycle.
- **No-data-yet vs failed-fetch**: on failure/backoff the stale last-good series is reused (debug log); only a pool with NO history is treated as unknown (warn). A pool that had data yesterday is never re-classified unknown by one transient failure.
- `resetGeckoOhlcvCache()` test helper + 3 new tests (cache hit, stale reuse on failure, backoff window).

Closes #154

## Summary by Sourcery

Cache last-known GeckoTerminal OHLCV signals per pool and add backoff to reduce failed fetch impact on discovery.

Bug Fixes:
- Ensure pools that previously had OHLCV data are not marked unknown due to transient GeckoTerminal outages.
- Prevent repeated OHLCV fetch attempts and warnings for failing pools across discovery cycles.

Enhancements:
- Serve recent OHLCV signals from an in-memory per-pool cache with a bounded TTL to avoid unnecessary refetching.
- Apply exponential backoff for failing pool fetches, reusing stale cached signals when available instead of failing hard.

Tests:
- Add tests covering cache hits, stale cache reuse on fetch failure, and adherence to backoff windows, plus a cache reset helper for isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added caching for pool OHLCV data to improve response speed and reduce unnecessary refreshes.
  - Added stale-data fallback when refresh attempts fail.
  - Added automatic retry backoff for repeated failures, increasing up to one hour.
  - Added an optional cache duration setting for OHLCV requests.

- **Bug Fixes**
  - Prevented repeated requests during temporary service failures.
  - Preserved previously retrieved data when newer refreshes are unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->