### PR TITLE
fix(trailing-stop): require consecutive confirmed cycles before EXIT

### DIFF
--- a/bench/agent-service.test.ts
+++ b/bench/agent-service.test.ts
@@ -50,6 +50,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     watchlistPools: [],
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
+    trailingStopConfirmCycles: 2,
     oorGracePeriodCycles: 3,
     feeClaimIntervalMs: 86_400_000,
     enablePoolDiscovery: false,

--- a/bench/auto-update.test.ts
+++ b/bench/auto-update.test.ts
@@ -38,6 +38,7 @@ function buildLayer(
     watchlistPools: [],
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
+    trailingStopConfirmCycles: 2,
     oorGracePeriodCycles: 3,
     feeClaimIntervalMs: 86_400_000,
     enablePoolDiscovery: false,

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -57,6 +57,7 @@ function buildLayer(
     watchlistPools: [],
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
+    trailingStopConfirmCycles: 2,
     oorGracePeriodCycles: 3,
     feeClaimIntervalMs: 86_400_000,
     enablePoolDiscovery: false,

--- a/bench/helpers.ts
+++ b/bench/helpers.ts
@@ -126,6 +126,7 @@ export function defaultAppConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     watchlistPools: [],
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
+    trailingStopConfirmCycles: 2,
     oorGracePeriodCycles: 3,
     feeClaimIntervalMs: 86_400_000,
     enablePoolDiscovery: false,

--- a/bench/http-status-server.test.ts
+++ b/bench/http-status-server.test.ts
@@ -28,6 +28,7 @@ function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     watchlistPools: [],
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
+    trailingStopConfirmCycles: 2,
     oorGracePeriodCycles: 3,
     feeClaimIntervalMs: 86_400_000,
     enablePoolDiscovery: false,

--- a/bench/mcp-server.test.ts
+++ b/bench/mcp-server.test.ts
@@ -27,6 +27,7 @@ function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     watchlistPools: [],
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
+    trailingStopConfirmCycles: 2,
     oorGracePeriodCycles: 3,
     feeClaimIntervalMs: 86_400_000,
     enablePoolDiscovery: false,

--- a/bench/multi-position.test.ts
+++ b/bench/multi-position.test.ts
@@ -1485,6 +1485,9 @@ describe("program — multiple positions per pool", () => {
         watchlistPools: [POOL],
         maxPositionsPerPool: 2,
         maxOpenPositions: 5,
+        // Single-cycle trailing-stop EXIT assertion — the #153 debounce is
+        // exercised in cycle-evaluate-pool/program tests, not here.
+        trailingStopConfirmCycles: 1,
         // Exactly one scan cycle: the long interval never fires inside the
         // test window, so no replacement ENTER can happen after A exits.
         scanIntervalMs: 600_000,
@@ -1523,7 +1526,10 @@ describe("program — multiple positions per pool", () => {
     // A was far out of range (range [4900,4910] vs active bin 5000): its value
     // estimate collapsed past the trailing stop and it exited. B is in range
     // and untouched.
-    expect(active.map((p) => p.positionId)).toEqual(["seeded-B"]);
+    // Later cycles may ENTER a fresh paper position on the strong pool,
+    // so assert only the seeded identities: B survives, A exited.
+    expect(active.map((p) => p.positionId)).toContain("seeded-B");
+    expect(active.map((p) => p.positionId)).not.toContain("seeded-A");
     expect(closed.map((p) => p.positionId)).toEqual(["seeded-A"]);
 
     const closedA = closed[0]!;
@@ -1556,6 +1562,108 @@ describe("program — multiple positions per pool", () => {
 
     const executedExits = decisions.filter((d) => d.action === "EXIT" && d.executed);
     expect(executedExits.length).toBeGreaterThanOrEqual(1);
+  }, 15_000);
+
+  it("does NOT exit on a single-cycle trailing-stop breach (#153 confirmation)", async () => {
+    const seededA = makePos({
+      positionId: "seeded-A",
+      lowerBinId: 4900,
+      upperBinId: 4910,
+      depositedUsd: 1000,
+      currentValueUsd: 1000,
+    });
+    const seededB = makePos({ positionId: "seeded-B" });
+
+    const layer = makeProgramLayer({
+      adapter: makeProgramAdapter({ [POOL]: makePool({ address: POOL }) }),
+      datapi: { getPoolData: () => Effect.succeed(makeDatapiStats()) },
+      configOverrides: {
+        watchlistPools: [POOL],
+        maxPositionsPerPool: 2,
+        maxOpenPositions: 5,
+        // Default TRAILING_STOP_CONFIRM_CYCLES = 2; long interval so exactly
+        // one scan cycle runs inside the test window.
+        scanIntervalMs: 600_000,
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(seededA);
+      yield* db.savePosition(seededB);
+      yield* Effect.raceFirst(program, Effect.sleep(1_500));
+      const active = yield* db.getAllPositions();
+      const closed = yield* db.getClosedPositions();
+      const audit = yield* AuditService;
+      const decisions = yield* audit.getRecentDecisions(200);
+      return { active, closed, decisions };
+    });
+    const { active, closed, decisions } = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<
+        {
+          active: ReadonlyArray<PositionRecord>;
+          closed: ReadonlyArray<PositionRecord>;
+          decisions: ReadonlyArray<{ action: string }>;
+        },
+        unknown,
+        never
+      >,
+    );
+
+    // A's estimate collapsed (~50% drawdown) on cycle 1, but the breach must
+    // persist for 2 consecutive cycles — one noisy snapshot cannot fire EXIT.
+    expect(active.map((p) => p.positionId)).toEqual(["seeded-A", "seeded-B"]);
+    expect(closed).toHaveLength(0);
+    expect(decisions.filter((d) => d.action === "EXIT")).toHaveLength(0);
+  }, 15_000);
+
+  it("exits only after the trailing-stop breach persists across cycles (#153)", async () => {
+    const seededA = makePos({
+      positionId: "seeded-A",
+      lowerBinId: 4900,
+      upperBinId: 4910,
+      depositedUsd: 1000,
+      currentValueUsd: 1000,
+    });
+    const seededB = makePos({ positionId: "seeded-B" });
+
+    const layer = makeProgramLayer({
+      adapter: makeProgramAdapter({ [POOL]: makePool({ address: POOL }) }),
+      datapi: { getPoolData: () => Effect.succeed(makeDatapiStats()) },
+      configOverrides: {
+        watchlistPools: [POOL],
+        maxPositionsPerPool: 2,
+        maxOpenPositions: 5,
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(seededA);
+      yield* db.savePosition(seededB);
+      // Default 1s scan interval: the persisted breach (A stays out of range
+      // with the active bin fixed at 5000) spans 2+ cycles, so EXIT fires.
+      yield* Effect.raceFirst(program, Effect.sleep(2_500));
+      const active = yield* db.getAllPositions();
+      const closed = yield* db.getClosedPositions();
+      return { active, closed };
+    });
+    const { active, closed } = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<
+        {
+          active: ReadonlyArray<PositionRecord>;
+          closed: ReadonlyArray<PositionRecord>;
+        },
+        unknown,
+        never
+      >,
+    );
+
+    // Later cycles may ENTER a fresh paper position on the strong pool,
+    // so assert only the seeded identities: B survives, A exited.
+    expect(active.map((p) => p.positionId)).toContain("seeded-B");
+    expect(active.map((p) => p.positionId)).not.toContain("seeded-A");
+    expect(closed.map((p) => p.positionId)).toEqual(["seeded-A"]);
   }, 15_000);
 });
 

--- a/bench/revenue-split.test.ts
+++ b/bench/revenue-split.test.ts
@@ -31,6 +31,7 @@ function buildLayer() {
     watchlistPools: [],
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
+    trailingStopConfirmCycles: 2,
     oorGracePeriodCycles: 3,
     feeClaimIntervalMs: 86_400_000,
     enablePoolDiscovery: false,

--- a/bench/risk-service.test.ts
+++ b/bench/risk-service.test.ts
@@ -48,6 +48,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     watchlistPools: [],
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
+    trailingStopConfirmCycles: 2,
     oorGracePeriodCycles: 3,
     feeClaimIntervalMs: 86_400_000,
     enablePoolDiscovery: false,

--- a/bench/screener-discover.test.ts
+++ b/bench/screener-discover.test.ts
@@ -41,6 +41,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     watchlistPools: [],
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
+    trailingStopConfirmCycles: 2,
     oorGracePeriodCycles: 3,
     feeClaimIntervalMs: 86_400_000,
     enablePoolDiscovery: true,

--- a/bench/update-check.test.ts
+++ b/bench/update-check.test.ts
@@ -40,6 +40,7 @@ function buildLayer(
     watchlistPools: [],
     stopLossPct: 0.15,
     trailingStopPct: 0.1,
+    trailingStopConfirmCycles: 2,
     oorGracePeriodCycles: 3,
     feeClaimIntervalMs: 86_400_000,
     enablePoolDiscovery: false,

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -139,6 +139,8 @@ export interface AppConfig {
   // New features
   readonly stopLossPct: number;
   readonly trailingStopPct: number;
+  /** Consecutive cycles the trailing-stop drawdown must persist before EXIT (anti-phantom). */
+  readonly trailingStopConfirmCycles: number;
   readonly oorGracePeriodCycles: number;
   readonly feeClaimIntervalMs: number;
   readonly enablePoolDiscovery: boolean;
@@ -1214,6 +1216,12 @@ const loadConfig = Effect.gen(function* () {
   // New feature configs
   const stopLossPct = yield* validatedNumber("STOP_LOSS_PCT", 0, 0.15);
   const trailingStopPct = yield* validatedNumber("TRAILING_STOP_PCT", 0, 0.1);
+  const trailingStopConfirmCycles = yield* validatedNumber(
+    "TRAILING_STOP_CONFIRM_CYCLES",
+    1,
+    2,
+    10,
+  );
   const oorGracePeriodCycles = yield* validatedNumber("OOR_GRACE_PERIOD_CYCLES", 0, 3);
   const feeClaimIntervalMs = yield* validatedNumber(
     "FEE_CLAIM_INTERVAL_MS",
@@ -1370,6 +1378,7 @@ const loadConfig = Effect.gen(function* () {
     watchlistPools,
     stopLossPct,
     trailingStopPct,
+    trailingStopConfirmCycles,
     oorGracePeriodCycles,
     feeClaimIntervalMs,
     enablePoolDiscovery,

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -4878,7 +4878,10 @@ export const program = Effect.gen(function* () {
               `Trailing stop triggered on ${pool.tokenXSymbol}/${pool.tokenYSymbol}: value dropped ${(drawdown * 100).toFixed(1)}% from peak $${highest.toFixed(2)} (confirmed ${breaches} cycles)`,
               { pool, metrics, position: pos },
             );
-          } else {
+          } else if (!breached) {
+            // Only a genuinely non-breaching cycle emits the large-pnl warning;
+            // a breached-but-unconfirmed cycle is on the path to a trailing-stop
+            // EXIT and the confirmed critical alert — no warning spam first.
             const pnlPct =
               pos.depositedUsd > 0 ? (estimatedValue - pos.depositedUsd) / pos.depositedUsd : 0;
             if (pnlPct < -0.15) {

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -2529,6 +2529,11 @@ export const program = Effect.gen(function* () {
   // Session-local (no schema change) so a restart re-establishes the first
   // cycle as the baseline; downtime catch-up is capped at 2× scan interval.
   const paperFeeAccrualAt = new Map<string, number>();
+  // Trailing-stop phantom-EXIT guard (#153): consecutive cycles the drawdown
+  // has breached the stop. EXIT fires only after the breach persists for
+  // TRAILING_STOP_CONFIRM_CYCLES cycles, so a single noisy snapshot read
+  // (unstable tracked-peak / value) cannot trigger EXIT churn. Session-local.
+  const trailingStopBreachCount = new Map<string, number>();
   const refreshPoolsToScan = (reconcileResult: PositionReconcileResult) => {
     unresolvedPoolAddresses = new Set(reconcileResult.unresolvedPoolAddresses);
     poolsToScan = [...approvedPoolAddresses];
@@ -4852,18 +4857,25 @@ export const program = Effect.gen(function* () {
           const estimatedValue = pos.currentValueUsd;
           const highest = pos.highestValueUsd ?? pos.depositedUsd;
           const drawdown = highest > 0 ? (highest - estimatedValue) / highest : 0;
-          if (drawdown > config.trailingStopPct) {
+          const breached = drawdown > config.trailingStopPct;
+          const breaches = breached ? (trailingStopBreachCount.get(pos.positionId) ?? 0) + 1 : 0;
+          if (breached) trailingStopBreachCount.set(pos.positionId, breaches);
+          else trailingStopBreachCount.delete(pos.positionId);
+          // #153: a single noisy snapshot (unstable tracked-peak/value) must
+          // not fire EXIT — require the breach to persist across consecutive
+          // cycles so phantom triggers churn into nothing instead of EXITs.
+          if (breached && breaches >= config.trailingStopConfirmCycles) {
             decision = {
               action: "EXIT",
               poolAddress,
               positionId: pos.positionId,
               confidence: 0.8,
-              reasoning: `Trailing stop: value dropped ${(drawdown * 100).toFixed(1)}% from peak $${highest.toFixed(2)}`,
+              reasoning: `Trailing stop: value dropped ${(drawdown * 100).toFixed(1)}% from peak $${highest.toFixed(2)} (${breaches}/${config.trailingStopConfirmCycles} cycles)`,
             };
             yield* sendAgentAlert(
               "critical",
               "trailing_stop",
-              `Trailing stop triggered on ${pool.tokenXSymbol}/${pool.tokenYSymbol}: value dropped ${(drawdown * 100).toFixed(1)}% from peak $${highest.toFixed(2)}`,
+              `Trailing stop triggered on ${pool.tokenXSymbol}/${pool.tokenYSymbol}: value dropped ${(drawdown * 100).toFixed(1)}% from peak $${highest.toFixed(2)} (confirmed ${breaches} cycles)`,
               { pool, metrics, position: pos },
             );
           } else {


### PR DESCRIPTION
## What

The trailing-stop fired **false EXITs** because its reference is unstable: on v0.1.4 a live deployment saw **215 EXIT→HOLD overrides in ~24h** as the stop triggered against a phantom tracked-peak that rocks between extreme values ($41 → $0.27 → $41) each cycle. With the agent veto off or slow, those would execute and close positions prematurely.

## Changes

- **Confirmation debounce** (`engine/program.ts`): EXIT fires only after the drawdown breach persists for `TRAILING_STOP_CONFIRM_CYCLES` **consecutive** cycles (new config, default `2`, min `1`, max `10`).
  - A single noisy snapshot increments a per-position counter; any non-breach cycle resets it. A phantom value that rocks breach/no-breach never reaches the threshold.
  - Session-local counter (no schema change): a restart re-establishes the streak — the fail-safe direction, since a genuine drawdown re-confirms within ≤2 cycles (~20 min) while a phantom spike never persists.
- **Auditability**: the EXIT reasoning and critical alert now carry the confirmation count (`(2/2) cycles`), so a false trigger is distinguishable from a confirmed stop.
- **Config** (`engine/config-service.ts`): `TRAILING_STOP_CONFIRM_CYCLES` validated 1–10, default 2. Existing single-cycle tests pin `1` explicitly.

## Tests

- 2 new program-level tests: single-cycle breach does NOT exit; a persistent breach exits only after 2 cycles.
- `bench/helpers.ts` + 9 fixtures updated with the new required config field.

Closes #153

## Summary by Sourcery

Debounce trailing-stop EXITs by requiring a configurable number of consecutive drawdown breaches and update tests and config to support the new confirmation behavior.

New Features:
- Add configurable TRAILING_STOP_CONFIRM_CYCLES setting to control how many consecutive cycles a trailing-stop breach must persist before triggering an EXIT.

Enhancements:
- Track per-position trailing-stop breach streaks in the program to suppress phantom EXITs from noisy value snapshots.
- Include confirmation cycle counts in trailing-stop reasoning messages and critical alerts for improved auditability.

Tests:
- Add program-level tests to verify that a single-cycle trailing-stop breach does not exit and that exits occur only after persistent multi-cycle breaches.
- Update bench helpers and multiple bench tests to provide the new trailingStopConfirmCycles config field and align assertions with potential additional positions being opened.