### PR TITLE
fix(engine): real position mark + dust guards — stop the exit churn

### DIFF
--- a/bench/adapter-position-value.test.ts
+++ b/bench/adapter-position-value.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Effect, Layer } from "effect";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { BN } from "@coral-xyz/anchor";
+import bs58 from "bs58";
+import { AdapterService, type AdapterApi } from "../engine/services.js";
+import { AdapterLive } from "../engine/adapter-service.js";
+import { ConfigService } from "../engine/config-service.js";
+import { AuditLive } from "../engine/audit-service.js";
+import { DbLive } from "../engine/db-service.js";
+import { defaultAppConfig, mockFetch } from "./helpers.js";
+
+// ─── Mocked Meteora DLMM SDK ─────────────────────────────────────────────────
+// getPositionValueUsd must price the position's REAL on-chain X/Y holdings at
+// LIVE token prices (no static fallbacks), fail open to null when a leg is
+// unpriced, and never serve a pre-mutation mark after a position mutation
+// (rebalance preserves positionPubKey, so the shared invalidation path must
+// clear the mark cache too).
+
+const POOL_ADDRESS = Keypair.generate().publicKey.toBase58();
+const POSITION_ADDRESS = Keypair.generate().publicKey.toBase58();
+const TOKEN_X = new PublicKey("So11111111111111111111111111111111111111112");
+const TOKEN_Y = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+const ACTIVE_BIN_ID = 5000;
+const BIN_STEP = 10;
+const BIN_ARRAY_FEE_SOL = 0.07143744;
+const BITMAP_FEE_SOL = 0.01180416;
+
+function makeIx(): TransactionInstruction {
+  return new TransactionInstruction({
+    keys: [],
+    programId: Keypair.generate().publicKey,
+    data: Buffer.from([1]),
+  });
+}
+
+interface FakePositionData {
+  totalXAmount: string;
+  totalYAmount: string;
+  lowerBinId: number;
+  upperBinId: number;
+  feeX: BN;
+  feeY: BN;
+}
+
+function makePositionData(overrides: Partial<FakePositionData> = {}): FakePositionData {
+  return {
+    totalXAmount: "2000000000", // 2 SOL (9 decimals)
+    totalYAmount: "300000000", // 300 USDC (6 decimals)
+    lowerBinId: 4960,
+    upperBinId: 4980,
+    feeX: new BN(0),
+    feeY: new BN(0),
+    ...overrides,
+  };
+}
+
+function makeFakeDlmm(opts: { positionData: FakePositionData }) {
+  return {
+    lbPair: {
+      activeId: ACTIVE_BIN_ID,
+      binStep: BIN_STEP,
+      tokenXMint: TOKEN_X,
+      tokenYMint: TOKEN_Y,
+      reserveX: Keypair.generate().publicKey,
+      reserveY: Keypair.generate().publicKey,
+    },
+    tokenX: { publicKey: TOKEN_X, mint: { decimals: 9 } },
+    tokenY: { publicKey: TOKEN_Y, mint: { decimals: 6 } },
+    refetchStates: vi.fn(async () => {}),
+    getPosition: vi.fn(async (pubkey: PublicKey) => ({
+      publicKey: pubkey,
+      positionData: opts.positionData,
+    })),
+    simulateRebalancePosition: vi.fn(async () => ({
+      rebalancePosition: { address: new PublicKey(POSITION_ADDRESS) },
+      simulationResult: { actualAmountXDeposited: new BN(0) },
+      binArrayCost: 2 * BIN_ARRAY_FEE_SOL,
+      binArrayCount: 2,
+      binArrayExistence: new Set<string>(),
+      bitmapExtensionCost: BITMAP_FEE_SOL,
+    })),
+    rebalancePosition: vi.fn(async () => ({
+      initBinArrayInstructions: [makeIx()],
+      rebalancePositionInstruction: [makeIx(), makeIx()],
+    })),
+    removeLiquidity: vi.fn(async () => {
+      throw new Error("removeLiquidity must not be called");
+    }),
+    initializePositionAndAddLiquidityByStrategy: vi.fn(async () => {
+      throw new Error("initializePositionAndAddLiquidityByStrategy must not be called");
+    }),
+  };
+}
+
+const dlmmState = vi.hoisted(() => ({
+  current: null as ReturnType<typeof makeFakeDlmm> | null,
+}));
+
+vi.mock("@meteora-ag/dlmm", async (importActual) => {
+  const actual = await importActual<typeof import("@meteora-ag/dlmm")>();
+  class FakeDLMM {
+    static async create() {
+      if (!dlmmState.current) throw new Error("fake DLMM instance not set");
+      return dlmmState.current;
+    }
+  }
+  return { ...actual, default: FakeDLMM };
+});
+
+// ─── Adapter layer wiring (mirrors bench/adapter-rebalance.test.ts) ─────────
+
+const walletKeypair = Keypair.generate();
+const walletPrivateKey = bs58.encode(walletKeypair.secretKey);
+
+function makeAdapterLayer(
+  overrides: Parameters<typeof defaultAppConfig>[0] = {},
+): Layer.Layer<AdapterService, never, never> {
+  const configLayer = Layer.succeed(
+    ConfigService,
+    defaultAppConfig({
+      walletPrivateKey,
+      solanaRpcUrl: "https://example.com",
+      solanaRpcFallbackUrl: "",
+      sqliteDbPath: ":memory:",
+      autoUpdate: false,
+      paperTrading: false,
+      solPriceUsd: 150, // static fallback price — must NEVER be used by the mark
+      ...overrides,
+    }),
+  );
+  const auditLayer = Layer.provide(AuditLive, DbLive(":memory:"));
+  return Layer.provide(AdapterLive, Layer.merge(configLayer, auditLayer)) as Layer.Layer<
+    AdapterService,
+    never,
+    never
+  >;
+}
+
+async function runWithAdapter<A, E>(effect: Effect.Effect<A, E, AdapterService>): Promise<A> {
+  return Effect.runPromise(
+    Effect.provide(effect, makeAdapterLayer()) as Effect.Effect<A, E, never>,
+  );
+}
+
+// getPositionValueUsd is optional in the service contract (program.ts guards
+// it too); the adapter under test always provides it.
+function readPositionValueUsd(
+  adapter: AdapterApi,
+  poolAddress: string,
+  positionPubKey: string,
+): Effect.Effect<number | null, never, never> {
+  const read = adapter.getPositionValueUsd;
+  if (read == null) return Effect.succeed(null);
+  return read(poolAddress, positionPubKey);
+}
+
+function mockTokenPrices(prices: Record<string, number>): () => void {
+  return mockFetch((async (url: string | URL | Request) => {
+    const u = url.toString();
+    if (u.includes("api.jup.ag/price/v3")) {
+      const body: Record<string, { usdPrice: number }> = {};
+      for (const [mint, price] of Object.entries(prices)) body[mint] = { usdPrice: price };
+      return new Response(JSON.stringify(body), { status: 200 });
+    }
+    return new Response("unexpected", { status: 500 });
+  }) as unknown as typeof fetch);
+}
+
+function mockRpcSendPipeline(): void {
+  vi.spyOn(Connection.prototype, "getLatestBlockhash").mockResolvedValue({
+    blockhash: bs58.encode(new Uint8Array(32).fill(7)),
+    lastValidBlockHeight: 1_000_000,
+  });
+  let n = 0;
+  vi.spyOn(Connection.prototype, "sendRawTransaction").mockImplementation((raw) => {
+    void raw;
+    n += 1;
+    return Promise.resolve(`mock-sig-${n}`);
+  });
+  vi.spyOn(Connection.prototype, "confirmTransaction").mockImplementation(() =>
+    Promise.resolve(undefined as unknown as never),
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  dlmmState.current = null;
+});
+
+// ─── Real on-chain position mark ─────────────────────────────────────────────
+
+describe("adapter.getPositionValueUsd (real on-chain mark)", () => {
+  it("prices the position's on-chain X/Y holdings at live token prices", async () => {
+    const positionData = makePositionData(); // 2 SOL + 300 USDC
+    dlmmState.current = makeFakeDlmm({ positionData });
+    const restore = mockTokenPrices({ [TOKEN_X.toBase58()]: 200, [TOKEN_Y.toBase58()]: 1 });
+
+    try {
+      const value = await runWithAdapter(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          return yield* readPositionValueUsd(adapter, POOL_ADDRESS, POSITION_ADDRESS);
+        }),
+      );
+      // 2 SOL × $200 + 300 USDC × $1 = $700
+      expect(value).toBeCloseTo(700, 5);
+    } finally {
+      restore();
+    }
+  });
+
+  it("serves the cached mark within the TTL without re-reading the position", async () => {
+    const positionData = makePositionData();
+    const fake = makeFakeDlmm({ positionData });
+    dlmmState.current = fake;
+    const restore = mockTokenPrices({ [TOKEN_X.toBase58()]: 200, [TOKEN_Y.toBase58()]: 1 });
+
+    try {
+      const [first, second] = await runWithAdapter(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          const a = yield* readPositionValueUsd(adapter, POOL_ADDRESS, POSITION_ADDRESS);
+          const b = yield* readPositionValueUsd(adapter, POOL_ADDRESS, POSITION_ADDRESS);
+          return [a, b] as const;
+        }),
+      );
+      expect(first).toBeCloseTo(700, 5);
+      expect(second).toBeCloseTo(700, 5);
+      expect(fake.getPosition).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns null when a leg's live price is unavailable — never a static fallback mark", async () => {
+    // Jupiter prices only USDC; SOL has no live price. The config carries a
+    // static solPriceUsd=150 fallback — if the mark used fallback prices it
+    // would fabricate 2×150 + 300×1 = $600 and skip the HODL-anchored
+    // fallback. Fail-open null is the only correct answer.
+    const positionData = makePositionData();
+    dlmmState.current = makeFakeDlmm({ positionData });
+    const restore = mockTokenPrices({ [TOKEN_Y.toBase58()]: 1 });
+
+    try {
+      const value = await runWithAdapter(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          return yield* readPositionValueUsd(adapter, POOL_ADDRESS, POSITION_ADDRESS);
+        }),
+      );
+      expect(value).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns null when a leg's live price is non-positive", async () => {
+    const positionData = makePositionData();
+    dlmmState.current = makeFakeDlmm({ positionData });
+    // Jupiter reports a 0 price for SOL — treat as unpriced, fail open.
+    const restore = mockTokenPrices({ [TOKEN_X.toBase58()]: 0, [TOKEN_Y.toBase58()]: 1 });
+
+    try {
+      const value = await runWithAdapter(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          return yield* readPositionValueUsd(adapter, POOL_ADDRESS, POSITION_ADDRESS);
+        }),
+      );
+      expect(value).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  it("clears the mark cache on the shared invalidation path after a position mutation", async () => {
+    // A rebalance preserves positionPubKey; without cache invalidation the
+    // next valuation would serve the pre-rebalance mark for up to 60s.
+    const positionData = makePositionData(); // 2 SOL + 300 USDC → $700
+    const fake = makeFakeDlmm({ positionData });
+    dlmmState.current = fake;
+    mockRpcSendPipeline();
+    const restore = mockTokenPrices({ [TOKEN_X.toBase58()]: 200, [TOKEN_Y.toBase58()]: 1 });
+
+    try {
+      const first = await runWithAdapter(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          return yield* readPositionValueUsd(adapter, POOL_ADDRESS, POSITION_ADDRESS);
+        }),
+      );
+      expect(first).toBeCloseTo(700, 5);
+
+      // Mutate the position's on-chain holdings (what a rebalance would do).
+      positionData.totalXAmount = "1000000000"; // 1 SOL + 300 USDC → $500
+      positionData.totalYAmount = "300000000";
+
+      const result = await runWithAdapter(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          return yield* adapter.rebalancePosition(POOL_ADDRESS, POSITION_ADDRESS, 4990, 5030);
+        }),
+      );
+      expect(result.positionPubKey).toBe(POSITION_ADDRESS);
+      expect(fake.removeLiquidity).not.toHaveBeenCalled();
+      expect(fake.initializePositionAndAddLiquidityByStrategy).not.toHaveBeenCalled();
+
+      // The mark after the mutation must be the FRESH read ($500), not the
+      // stale pre-rebalance $700.
+      const second = await runWithAdapter(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          return yield* readPositionValueUsd(adapter, POOL_ADDRESS, POSITION_ADDRESS);
+        }),
+      );
+      expect(second).toBeCloseTo(500, 5);
+      // 1 initial read + 1 rebalance read + 1 post-rebalance read — the last
+      // read must NOT have hit the cache.
+      expect(fake.getPosition).toHaveBeenCalledTimes(3);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/bench/config-service.test.ts
+++ b/bench/config-service.test.ts
@@ -151,6 +151,15 @@ describe("ConfigService freeze screening + IL protection flags", () => {
     const clamped = await loadConfig();
     expect(clamped.ilDominanceMinUsd).toBe(0);
   });
+
+  it("defaults DUST_EXIT_USD to 5 and clamps below the minimum of 0 (0 disables)", async () => {
+    const cfg = await loadConfig();
+    expect(cfg.dustExitUsd).toBe(5);
+
+    vi.stubEnv("DUST_EXIT_USD", "-1");
+    const clamped = await loadConfig();
+    expect(clamped.dustExitUsd).toBe(0);
+  });
 });
 
 describe("ConfigService fee-density cooldown floor guards", () => {

--- a/bench/helpers.ts
+++ b/bench/helpers.ts
@@ -161,6 +161,7 @@ export function defaultAppConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     ilProtectionEnabled: false,
     ilDominanceExitFactor: 2,
     ilDominanceMinUsd: 5,
+    dustExitUsd: 5,
     // Pinned false (production default is true) so the token-risk overlay never
     // fires for the existing ~80 test files; feature tests enable it explicitly.
     jupiterTokenRiskEnabled: false,

--- a/bench/il-protection.test.ts
+++ b/bench/il-protection.test.ts
@@ -296,21 +296,23 @@ describe("IL protection — ENTER fee/IL floor gate (Task 3a)", () => {
 });
 
 describe("IL protection — IL-dominance fast EXIT (Task 3b)", () => {
-  // Pool price doubled since entry (100 → 200); the OOR position's heuristic
-  // value collapses while the HODL benchmark climbs, so IL dominates fees.
+  // Pool price doubled since entry (100 → 200); the OOR position's REAL
+  // on-chain mark (mock getPositionValueUsd → 500, the collapsed single-sided
+  // holdings of an out-of-range position) sits far below the HODL benchmark,
+  // so IL dominates fees.
   function ilPool() {
     return makePool({ address: POOL, currentPrice: 200, activeBinId: 5000 });
   }
 
-  // makePosition hardcodes lowerBinId/upperBinId/outOfRangeSince (it does not
-  // read them from overrides), so the OOR shape is applied via spread AFTER the
-  // helper. Active bin 5000 sits far outside [4900, 4950]: heuristic value →
-  // 1000*(1-1*0.5) = 500; HODL → 500*(200/100)+500 = 1500; IL = 1000, which is
-  // > 10 fees × 2 and > $5 floor → IL-dominance EXIT.
+  // A LIVE position (positionPubKey set) so the value loop takes the real
+  // on-chain mark: 500 (mocked) vs HODL 500*(200/100)+500 = 1500; IL = 1000,
+  // which is > 10 fees × 2 and > $5 floor → IL-dominance EXIT.
   function ilDominantPosition() {
     return {
       ...makePosition({
         poolAddress: POOL,
+        positionId: "il-pos-live",
+        positionPubKey: "il-pos-live",
         depositedUsd: 1000,
         currentValueUsd: 1000,
         entryPriceUsd: 100,
@@ -327,7 +329,10 @@ describe("IL protection — IL-dominance fast EXIT (Task 3b)", () => {
   it("exits an IL-dominant out-of-range position with positionId and IL reasoning", async () => {
     const position = ilDominantPosition();
     const layer = makeTestLayer({
-      adapter: makeAdapter({ [POOL]: ilPool() }),
+      adapter: makeAdapter(
+        { [POOL]: ilPool() },
+        { getPositionValueUsd: () => Effect.succeed(500) },
+      ),
       configOverrides: { watchlistPools: [POOL], ilProtectionEnabled: true },
     });
 
@@ -406,7 +411,10 @@ describe("IL protection — IL-dominance fast EXIT (Task 3b)", () => {
     const position = ilDominantPosition();
     const capturedAlerts: EngineAlert[] = [];
     const layer = makeTestLayer({
-      adapter: makeAdapter({ [POOL]: ilPool() }),
+      adapter: makeAdapter(
+        { [POOL]: ilPool() },
+        { getPositionValueUsd: () => Effect.succeed(500) },
+      ),
       configOverrides: { watchlistPools: [POOL], ilProtectionEnabled: true },
       alertCapture: capturedAlerts,
     });

--- a/bench/multi-position.test.ts
+++ b/bench/multi-position.test.ts
@@ -46,6 +46,7 @@ import {
 import type { AgentDecision, PoolState, Position } from "../engine/types.js";
 import { defaultAppConfig, makePool, makeBinArray, mockFetch, run } from "./helpers.js";
 import { randomUUID } from "crypto";
+import { stringifySafe } from "../engine/bigint-json.js";
 
 // ─── Shared fixtures ─────────────────────────────────────────────────────────
 
@@ -1757,6 +1758,70 @@ describe("program — multiple positions per pool", () => {
       (d) => d.action === "EXIT" && (d.reasoning ?? "").includes("[dust-cleanup]"),
     );
     expect(dustExits.length).toBeGreaterThanOrEqual(1);
+  }, 15_000);
+
+  it("honors a genuine 0 on-chain mark instead of falling back to the HODL estimate", async () => {
+    // The value loop must use an explicit null check (`realMark !== null`),
+    // not `??`: a 0 mark from getPositionValueUsd is REAL data (a genuinely
+    // worthless position → dust), not "unavailable". `??` would treat 0 as
+    // nullish and silently replace it with the HODL-anchored estimate —
+    // 500×(100/100)+500 = 1000 at the unchanged pool price — keeping a
+    // zero-valued position alive instead of dust-cleaning it.
+    const seeded = makePos({
+      positionId: "zero-mark-live",
+      positionPubKey: "zero-mark-live",
+      depositedUsd: 1000,
+      currentValueUsd: 1000,
+      entryPriceUsd: 100,
+      entryAmountXUsd: 500,
+      entryAmountYUsd: 500,
+      lowerBinId: 4980,
+      upperBinId: 5020,
+    });
+
+    const layer = makeProgramLayer({
+      adapter: makeProgramAdapter(
+        { [POOL]: makePool({ address: POOL, currentPrice: 100 }) },
+        { getPositionValueUsd: () => Effect.succeed(0) },
+      ),
+      datapi: { getPoolData: () => Effect.succeed(makeDatapiStats()) },
+      configOverrides: { watchlistPools: [POOL] },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(seeded);
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const persisted = yield* db.getPosition("zero-mark-live");
+      const audit = yield* AuditService;
+      const decisions = yield* audit.getRecentDecisions(200);
+      return { persisted, decisions };
+    });
+    const { persisted, decisions } = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<
+        {
+          persisted: PositionRecord | null;
+          decisions: ReadonlyArray<{ action: string; reasoning: string | null }>;
+        },
+        unknown,
+        never
+      >,
+    );
+
+    // The real 0 mark is honored: any non-zero persisted value would mean the
+    // fallback swallowed the genuine mark.
+    expect(persisted?.currentValueUsd).toBe(0);
+    // The 0 mark lands below the dust threshold → deterministic [dust-cleanup]
+    // EXIT (the HODL fallback of 1000 would never exit).
+    const dustExits = decisions.filter(
+      (d) => d.action === "EXIT" && (d.reasoning ?? "").includes("[dust-cleanup]"),
+    );
+    expect(
+      dustExits,
+      `expected a [dust-cleanup] EXIT on the 0 mark, got: ${stringifySafe(decisions)}`,
+    ).not.toHaveLength(0);
+    // The dust EXIT reasoned from the REAL 0 mark ($0.00), not a fallback.
+    expect(dustExits[0]?.reasoning).toContain("$0.00");
   }, 15_000);
 });
 

--- a/bench/multi-position.test.ts
+++ b/bench/multi-position.test.ts
@@ -1460,12 +1460,19 @@ describe("program — multiple positions per pool", () => {
   }, 15_000);
 
   it("runs an independent lifecycle per position: OOR + trailing-stop EXIT on A leaves B intact", async () => {
+    // Pool price halves to $75: with the price-anchored HODL mark (the old
+    // bin-drift heuristic is gone), A's value genuinely collapses (400 X-leg
+    // at 150 → 200 at 75, plus 400 Y = 600 → 40% drawdown) while B's
+    // Y-heavy mix (100 X + 700 Y) only dips 6.25% (750 vs 800) — no breach.
     const seededA = makePos({
       positionId: "seeded-A",
       lowerBinId: 4900,
       upperBinId: 4910,
       depositedUsd: 1000,
       currentValueUsd: 1000,
+      entryPriceUsd: 150,
+      entryAmountXUsd: 400,
+      entryAmountYUsd: 400,
     });
     const seededB = makePos({
       positionId: "seeded-B",
@@ -1474,12 +1481,12 @@ describe("program — multiple positions per pool", () => {
       depositedUsd: 800,
       currentValueUsd: 800,
       entryPriceUsd: 150,
-      entryAmountXUsd: 400,
-      entryAmountYUsd: 400,
+      entryAmountXUsd: 100,
+      entryAmountYUsd: 700,
     });
 
     const layer = makeProgramLayer({
-      adapter: makeProgramAdapter({ [POOL]: makePool({ address: POOL }) }),
+      adapter: makeProgramAdapter({ [POOL]: makePool({ address: POOL, currentPrice: 75 }) }),
       datapi: { getPoolData: () => Effect.succeed(makeDatapiStats()) },
       configOverrides: {
         watchlistPools: [POOL],
@@ -1523,8 +1530,7 @@ describe("program — multiple positions per pool", () => {
       >,
     );
 
-    // A was far out of range (range [4900,4910] vs active bin 5000): its value
-    // estimate collapsed past the trailing stop and it exited. B is in range
+    // A's value collapsed past the trailing stop and it exited. B is in range
     // and untouched.
     // Later cycles may ENTER a fresh paper position on the strong pool,
     // so assert only the seeded identities: B survives, A exited.
@@ -1534,11 +1540,11 @@ describe("program — multiple positions per pool", () => {
 
     const closedA = closed[0]!;
     expect(closedA.closedAt).not.toBeNull();
-    // Realized PnL = final value (500 after the 50% IL-drift estimate) − basis.
-    // A4 paper fee accrual is active for this pool (fees24h 300 > 0) but A is
-    // OUT of range (inRange = 0) so it accrued nothing — this −500 realized pin
-    // is unaffected by the accrual.
-    expect(closedA.realizedPnlUsd).toBeCloseTo(-500, 0);
+    // Realized PnL = final value (600: the HODL mark after the price halved
+    // the X leg) − basis. A4 paper fee accrual is active for this pool
+    // (fees24h 300 > 0) but A is OUT of range (inRange = 0) so it accrued
+    // nothing — this −400 realized pin is unaffected by the accrual.
+    expect(closedA.realizedPnlUsd).toBeCloseTo(-400, 0);
     // A's OOR cycles accumulated independently; B never left range.
     expect(closedA.oorCycleCount).toBeGreaterThanOrEqual(1);
     expect(active[0]!.oorCycleCount).toBe(0);
@@ -1546,8 +1552,8 @@ describe("program — multiple positions per pool", () => {
     // B's entry accounting survived A's exit byte-for-byte.
     expect(active[0]!.depositedUsd).toBe(800);
     expect(active[0]!.entryPriceUsd).toBe(150);
-    expect(active[0]!.entryAmountXUsd).toBe(400);
-    expect(active[0]!.entryAmountYUsd).toBe(400);
+    expect(active[0]!.entryAmountXUsd).toBe(100);
+    expect(active[0]!.entryAmountYUsd).toBe(700);
 
     // The EXIT event targets A's identity. B is in range with fees24h 300 > 0,
     // so the A4 paper notional-fee accrual booked exactly one CLAIM (kind
@@ -1565,17 +1571,27 @@ describe("program — multiple positions per pool", () => {
   }, 15_000);
 
   it("does NOT exit on a single-cycle trailing-stop breach (#153 confirmation)", async () => {
+    // A breaches hard (400 X-leg at 150 → 200 at $75 pool price → 40%
+    // drawdown); B's Y-heavy mix (100 X + 900 Y) only dips 5% — no breach.
     const seededA = makePos({
       positionId: "seeded-A",
       lowerBinId: 4900,
       upperBinId: 4910,
       depositedUsd: 1000,
       currentValueUsd: 1000,
+      entryPriceUsd: 150,
+      entryAmountXUsd: 400,
+      entryAmountYUsd: 400,
     });
-    const seededB = makePos({ positionId: "seeded-B" });
+    const seededB = makePos({
+      positionId: "seeded-B",
+      entryPriceUsd: 150,
+      entryAmountXUsd: 100,
+      entryAmountYUsd: 900,
+    });
 
     const layer = makeProgramLayer({
-      adapter: makeProgramAdapter({ [POOL]: makePool({ address: POOL }) }),
+      adapter: makeProgramAdapter({ [POOL]: makePool({ address: POOL, currentPrice: 75 }) }),
       datapi: { getPoolData: () => Effect.succeed(makeDatapiStats()) },
       configOverrides: {
         watchlistPools: [POOL],
@@ -1618,17 +1634,26 @@ describe("program — multiple positions per pool", () => {
   }, 15_000);
 
   it("exits only after the trailing-stop breach persists across cycles (#153)", async () => {
+    // Same seeds as the single-cycle test: A breaches 40%, B stays at −5%.
     const seededA = makePos({
       positionId: "seeded-A",
       lowerBinId: 4900,
       upperBinId: 4910,
       depositedUsd: 1000,
       currentValueUsd: 1000,
+      entryPriceUsd: 150,
+      entryAmountXUsd: 400,
+      entryAmountYUsd: 400,
     });
-    const seededB = makePos({ positionId: "seeded-B" });
+    const seededB = makePos({
+      positionId: "seeded-B",
+      entryPriceUsd: 150,
+      entryAmountXUsd: 100,
+      entryAmountYUsd: 900,
+    });
 
     const layer = makeProgramLayer({
-      adapter: makeProgramAdapter({ [POOL]: makePool({ address: POOL }) }),
+      adapter: makeProgramAdapter({ [POOL]: makePool({ address: POOL, currentPrice: 75 }) }),
       datapi: { getPoolData: () => Effect.succeed(makeDatapiStats()) },
       configOverrides: {
         watchlistPools: [POOL],
@@ -1664,6 +1689,74 @@ describe("program — multiple positions per pool", () => {
     expect(active.map((p) => p.positionId)).toContain("seeded-B");
     expect(active.map((p) => p.positionId)).not.toContain("seeded-A");
     expect(closed.map((p) => p.positionId)).toEqual(["seeded-A"]);
+  }, 15_000);
+
+  it("closes dust positions below DUST_EXIT_USD with a [dust-cleanup] EXIT", async () => {
+    // The $0.26 residual entries older builds created by clamping entry size
+    // to leftover per-pool headroom: no entry legs, mark = cost basis (0.26)
+    // < dust threshold (5) → deterministic cleanup EXIT at confidence 1,
+    // reclaiming the per-pool slot.
+    // The $0.26 residual entries older builds created by clamping entry size
+    // to leftover per-pool headroom: real 50/50 legs, so the HODL mark is
+    // 0.13 + 0.13 = 0.26 at the unchanged pool price — below the dust
+    // threshold.
+    const dustPos = makePos({
+      positionId: "seeded-dust",
+      depositedUsd: 0.26,
+      currentValueUsd: 0.26,
+      entryPriceUsd: 150,
+      entryAmountXUsd: 0.13,
+      entryAmountYUsd: 0.13,
+    });
+    const healthyPos = makePos({
+      positionId: "seeded-healthy",
+      depositedUsd: 1000,
+      currentValueUsd: 1000,
+      entryPriceUsd: 150,
+      entryAmountXUsd: 500,
+      entryAmountYUsd: 500,
+    });
+
+    const layer = makeProgramLayer({
+      adapter: makeProgramAdapter({ [POOL]: makePool({ address: POOL }) }),
+      datapi: { getPoolData: () => Effect.succeed(makeDatapiStats()) },
+      configOverrides: {
+        watchlistPools: [POOL],
+        maxPositionsPerPool: 2,
+        maxOpenPositions: 5,
+        scanIntervalMs: 600_000,
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(dustPos);
+      yield* db.savePosition(healthyPos);
+      yield* Effect.raceFirst(program, Effect.sleep(1_500));
+      const active = yield* db.getAllPositions();
+      const closed = yield* db.getClosedPositions();
+      const audit = yield* AuditService;
+      const decisions = yield* audit.getRecentDecisions(200);
+      return { active, closed, decisions };
+    });
+    const { active, closed, decisions } = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<
+        {
+          active: ReadonlyArray<PositionRecord>;
+          closed: ReadonlyArray<PositionRecord>;
+          decisions: ReadonlyArray<{ action: string; reasoning: string | null }>;
+        },
+        unknown,
+        never
+      >,
+    );
+
+    expect(active.map((p) => p.positionId)).toEqual(["seeded-healthy"]);
+    expect(closed.map((p) => p.positionId)).toEqual(["seeded-dust"]);
+    const dustExits = decisions.filter(
+      (d) => d.action === "EXIT" && (d.reasoning ?? "").includes("[dust-cleanup]"),
+    );
+    expect(dustExits.length).toBeGreaterThanOrEqual(1);
   }, 15_000);
 });
 

--- a/bench/pnl-equity.test.ts
+++ b/bench/pnl-equity.test.ts
@@ -19,8 +19,8 @@ describe("computePortfolioEquity (issue #149)", () => {
     expect(result.totalEquityUsd).toBeCloseTo(154.18, 2);
   });
 
-  it("computes equity-based unrealized P&L against total deposits", () => {
-    // wallet 54.18 + positions 36.82 = 91.00 equity; deposits 41.89 → up.
+  it("computes positions-only unrealized P&L; the wallet stays in equity", () => {
+    // wallet 54.18 + positions 36.82 = 91.00 equity; deposits 41.89.
     const result = computePortfolioEquity({
       walletBalanceUsd: 54.18,
       positions: [
@@ -33,12 +33,14 @@ describe("computePortfolioEquity (issue #149)", () => {
       ],
     });
     expect(result.totalEquityUsd).toBeCloseTo(91.0, 2);
-    // The issue's real numbers: wallet ≈ $91 vs $41.89 deposited → POSITIVE.
-    expect(result.unrealizedPnlUsd).toBeGreaterThan(0);
+    // The idle wallet balance is NOT unrealized gain (the "+127% on a $54
+    // wallet" artifact): unrealized = 36.82 − 41.89 = −5.07.
+    expect(result.unrealizedPnlUsd).toBeCloseTo(-5.07, 2);
+    expect(result.unrealizedPnlPct).toBeCloseTo(-12.1, 1);
     expect(result.walletKnown).toBe(true);
   });
 
-  it("includes claimed fees and rewards in unrealized P&L", () => {
+  it("includes claimed fees and rewards in unrealized P&L (wallet excluded)", () => {
     const result = computePortfolioEquity({
       walletBalanceUsd: 10,
       positions: [
@@ -50,9 +52,11 @@ describe("computePortfolioEquity (issue #149)", () => {
         },
       ],
     });
-    // equity 110 + fees 4 + rewards 2 − deposits 100 = 16
-    expect(result.unrealizedPnlUsd).toBeCloseTo(16, 6);
-    expect(result.unrealizedPnlPct).toBeCloseTo(16, 6);
+    // positions 100 + fees 4 + rewards 2 − deposits 100 = 6 (wallet 10 is
+    // equity, not P&L).
+    expect(result.unrealizedPnlUsd).toBeCloseTo(6, 6);
+    expect(result.unrealizedPnlPct).toBeCloseTo(6, 6);
+    expect(result.totalEquityUsd).toBeCloseTo(110, 6);
   });
 
   it("falls back to positions-only equity when the wallet is unknown (no fabrication)", () => {
@@ -100,7 +104,8 @@ describe("computePortfolioEquity (issue #149)", () => {
     const result = computePortfolioEquity({ walletBalanceUsd: 100, positions: [] });
     expect(result.totalEquityUsd).toBe(100);
     expect(result.positionsValueUsd).toBe(0);
-    expect(result.unrealizedPnlUsd).toBe(100); // 100 + 0 − 0
+    // No positions → no unrealized P&L; the wallet is equity, not gain.
+    expect(result.unrealizedPnlUsd).toBe(0);
     expect(result.unrealizedPnlPct).toBe(0);
     expect(result.walletKnown).toBe(true);
   });

--- a/bench/program.test.ts
+++ b/bench/program.test.ts
@@ -555,18 +555,25 @@ describe("executePaper paper/live parity", () => {
 });
 
 describe("estimatePositionValue", () => {
-  function makePos(lowerBinId: number, upperBinId: number, depositedUsd: number) {
+  function makePos(
+    overrides: Partial<{
+      depositedUsd: number;
+      entryPriceUsd: number | null;
+      entryAmountXUsd: number | null;
+      entryAmountYUsd: number | null;
+    }> = {},
+  ) {
     return {
       positionId: "paper-pool1",
       poolAddress: "pool1",
       positionPubKey: null,
-      depositedUsd,
-      currentValueUsd: depositedUsd,
+      depositedUsd: overrides.depositedUsd ?? 1000,
+      currentValueUsd: overrides.depositedUsd ?? 1000,
       tokenXSymbol: "SOL",
       tokenYSymbol: "USDC",
       activeBinId: 5000,
-      lowerBinId,
-      upperBinId,
+      lowerBinId: 4980,
+      upperBinId: 5020,
       timestamp: Date.now(),
       outOfRangeSince: null,
       oorCycleCount: 0,
@@ -577,9 +584,9 @@ describe("estimatePositionValue", () => {
       paperExitedAt: null,
       entrySignalTimestamp: null,
       entrySignalSnapshotId: null,
-      entryPriceUsd: null,
-      entryAmountXUsd: null,
-      entryAmountYUsd: null,
+      entryPriceUsd: overrides.entryPriceUsd === undefined ? 150 : overrides.entryPriceUsd,
+      entryAmountXUsd: overrides.entryAmountXUsd === undefined ? 500 : overrides.entryAmountXUsd,
+      entryAmountYUsd: overrides.entryAmountYUsd === undefined ? 500 : overrides.entryAmountYUsd,
       cumulativeFeesClaimedUsd: 0,
       cumulativeRewardsClaimedUsd: 0,
       closedAt: null,
@@ -587,7 +594,7 @@ describe("estimatePositionValue", () => {
     };
   }
 
-  function makePool(activeBinId: number) {
+  function makePool(currentPrice: number) {
     return {
       address: "pool1",
       tokenX: "SOL",
@@ -598,38 +605,41 @@ describe("estimatePositionValue", () => {
       volume24hUsd: 30_000,
       fees24hUsd: 300,
       apr: 60,
-      activeBinId,
+      activeBinId: 5000,
       binStep: 10,
-      currentPrice: 150,
+      currentPrice,
       timestamp: Date.now(),
     };
   }
 
-  it("returns deposited value when active bin is at center", () => {
-    const pos = makePos(4980, 5020, 1000);
-    const pool = makePool(5000);
-    expect(estimatePositionValue(pos, pool)).toBe(1000);
+  it("revalues the entry legs at the current price (HODL mark)", () => {
+    // 500 X-leg at entry price 150; price unchanged → 500 + 500 = 1000.
+    expect(estimatePositionValue(makePos(), makePool(150))).toBe(1000);
+    // Price +10% → X leg 550 + Y leg 500 = 1050.
+    expect(estimatePositionValue(makePos(), makePool(165))).toBe(1050);
+    // Price −10% → X leg 450 + Y leg 500 = 950.
+    expect(estimatePositionValue(makePos(), makePool(135))).toBe(950);
   });
 
-  it("decreases value as active bin drifts toward edge", () => {
-    const pos = makePos(4980, 5020, 1000);
-    const poolCenter = makePool(5000);
-    const poolEdge = makePool(5020);
-    const centerValue = estimatePositionValue(pos, poolCenter);
-    const edgeValue = estimatePositionValue(pos, poolEdge);
-    expect(edgeValue).toBeLessThan(centerValue);
+  it("falls back to the cost basis when entry legs are unknown", () => {
+    // Pre-v16 rows have NULL entry legs: never fabricate a drawdown.
+    const pos = makePos({ entryPriceUsd: null, entryAmountXUsd: null, entryAmountYUsd: null });
+    expect(estimatePositionValue(pos, makePool(120))).toBe(1000);
   });
 
-  it("reaches minimum value at far edge", () => {
-    const pos = makePos(4980, 5020, 1000);
-    const pool = makePool(5040);
-    expect(estimatePositionValue(pos, pool)).toBe(500);
+  it("falls back to the cost basis when the price is not positive", () => {
+    expect(estimatePositionValue(makePos(), makePool(0))).toBe(1000);
+    expect(estimatePositionValue(makePos(), makePool(Number.NaN))).toBe(1000);
   });
 
-  it("handles narrow ranges", () => {
-    const pos = makePos(4995, 5005, 1000);
-    const pool = makePool(5005);
-    expect(estimatePositionValue(pos, pool)).toBe(500);
+  it("never drops below the cost basis via bin drift (no phantom drawdown)", () => {
+    // The old drift heuristic returned 500 here ("value halved") even though
+    // the pool price barely moved; the HODL mark only moves with price.
+    const pos = makePos({ depositedUsd: 41.63, entryAmountXUsd: 20.82, entryAmountYUsd: 20.82 });
+    expect(estimatePositionValue(pos, makePool(149.5))).toBeCloseTo(41.57, 2);
+    // Unchanged price → the HODL mark equals the entry legs (20.82 + 20.82).
+    expect(estimatePositionValue(pos, makePool(150))).toBeCloseTo(41.64, 2);
+    expect(estimatePositionValue(pos, makePool(150.5))).toBeCloseTo(41.71, 2);
   });
 });
 

--- a/bench/risk.test.ts
+++ b/bench/risk.test.ts
@@ -122,6 +122,41 @@ describe("RiskEngine", () => {
       expect(result.adjustedSizeUsd).toBe(2500);
       expect(result.reason).toContain("25%");
     });
+
+    it("rejects ENTER below the minimum entry size outright", () => {
+      const decision = makeDecision({ action: "ENTER", confidence: 0.8, positionSizeUsd: 2 });
+      const result = evaluateRisk(riskConfig, decision, makeContext({ portfolioValueUsd: 10_000 }));
+      expect(result.approved).toBe(false);
+      expect(result.reason).toContain("minimum entry size");
+    });
+
+    it("rejects a headroom clamp below the minimum entry size (no dust entries)", () => {
+      // Existing pool exposure fills the cap so tightly that the remaining
+      // headroom is $5 — the old code approved a $5 deposit here; the floor
+      // must reject it instead.
+      const position: Position = {
+        id: "pos-1",
+        poolAddress: "TestPool111111111111111111111111111111111111",
+        poolName: "Test",
+        lowerBinId: 4990,
+        upperBinId: 5010,
+        liquidityShares: 1000n,
+        depositedUsd: 2995,
+        currentValueUsd: 2995,
+        unrealizedPnlUsd: 0,
+        feesEarnedUsd: 0,
+        openedAt: Date.now(),
+      };
+      const decision = makeDecision({ action: "ENTER", confidence: 0.85, positionSizeUsd: 29 });
+      const result = evaluateRisk(
+        riskConfig,
+        decision,
+        makeContext({ portfolioValueUsd: 10_000, openPositions: [position] }),
+      );
+      expect(result.approved).toBe(false);
+      expect(result.reason).toContain("below the");
+      expect(result.reason).toContain("minimum entry size");
+    });
   });
 
   describe("stop-loss", () => {

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -1203,6 +1203,11 @@ export const AdapterLive = Layer.effect(
     const invalidateBalanceCaches = Effect.sync(() => {
       tokenBalanceCache.clear();
       nativeSolBalanceCache = undefined;
+      // Position marks read the same on-chain accounts a mutation rewrites:
+      // a rebalance preserves positionPubKey, so without clearing this cache
+      // the next valuation would serve a pre-mutation mark (up to 60s) into
+      // trailing-stop / IL / dust decisions.
+      positionValueCache.clear();
     }).pipe(Effect.zipRight(invalidateWalletSnapshot));
 
     const quotedByRawPayload = new WeakMap<Record<string, unknown>, SwapQuote>();
@@ -2073,15 +2078,22 @@ export const AdapterLive = Layer.effect(
           const positionData = position.positionData;
           const tokenXMint = dlmm.lbPair.tokenXMint.toBase58();
           const tokenYMint = dlmm.lbPair.tokenYMint.toBase58();
-          const prices = yield* fetchTokenPrices([tokenXMint, tokenYMint]);
+          // No static fallback prices: a fabricated mark would skip the
+          // HODL-anchored fallback in the decision loop and could drive
+          // trailing-stop / IL / dust decisions on made-up numbers. Live
+          // prices only; any missing or non-positive leg fails open to null.
+          const prices = yield* fetchTokenPrices([tokenXMint, tokenYMint], {
+            useFallback: false,
+          });
+          const priceX = prices[tokenXMint];
+          const priceY = prices[tokenYMint];
+          if (priceX === undefined || priceX <= 0 || priceY === undefined || priceY <= 0) {
+            return null;
+          }
           const decimalsX = dlmm.tokenX.mint.decimals;
           const decimalsY = dlmm.tokenY.mint.decimals;
-          const xUsd =
-            (Number(positionData.totalXAmount.toString()) / 10 ** decimalsX) *
-            (prices[tokenXMint] ?? 0);
-          const yUsd =
-            (Number(positionData.totalYAmount.toString()) / 10 ** decimalsY) *
-            (prices[tokenYMint] ?? 0);
+          const xUsd = (Number(positionData.totalXAmount.toString()) / 10 ** decimalsX) * priceX;
+          const yUsd = (Number(positionData.totalYAmount.toString()) / 10 ** decimalsY) * priceY;
           const valueUsd = xUsd + yUsd;
           if (!Number.isFinite(valueUsd) || valueUsd <= 0) return null;
           positionValueCache.set(cacheKey, { fetchedAt: Date.now(), value: valueUsd });

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -1029,6 +1029,11 @@ export const AdapterLive = Layer.effect(
     const tokenBalanceCache = new Map<string, { value: bigint; expiresAt: number }>();
     let nativeSolBalanceCache: { value: bigint; expiresAt: number } | undefined;
 
+    // Real position mark cache (getPositionValueUsd): short TTL so the
+    // per-cycle value loop and the claim path share one position read.
+    const POSITION_VALUE_CACHE_TTL_MS = 60_000;
+    const positionValueCache = new Map<string, { value: number; fetchedAt: number }>();
+
     function readTokenBalance(mintAddress: string): Effect.Effect<bigint, unknown> {
       return Effect.gen(function* () {
         const activeWallet = wallet;
@@ -2043,6 +2048,50 @@ export const AdapterLive = Layer.effect(
             };
           });
         }),
+
+      // Real on-chain position mark (trailing-stop / PnL source of truth).
+      // Reads the position account's actual X/Y holdings and prices them at
+      // the pool's token mints. This is what replaced the bin-drift heuristic
+      // (`deposited × (1 − 0.5 × driftPct)`) whose phantom drawdowns — a
+      // 5-bin drift is a 10% "loss" on a binStep-10 pool, i.e. a 0.5% price
+      // move — fired the trailing stop every cycle and churned positions.
+      // Deliberately fail-open: null on any read/pricing problem so the
+      // decision loop falls back to the HODL-anchored mark and never fails
+      // the cycle. Cached ~60s so the per-cycle value loop and the claim
+      // path share one read.
+      getPositionValueUsd: (poolAddress, positionPubKey) => {
+        const cacheKey = `posval:${poolAddress}:${positionPubKey}`;
+        const cached = positionValueCache.get(cacheKey);
+        if (cached !== undefined && Date.now() - cached.fetchedAt < POSITION_VALUE_CACHE_TTL_MS) {
+          return Effect.succeed(cached.value);
+        }
+        return Effect.gen(function* () {
+          const dlmm = yield* getDlmm(poolAddress);
+          const position = yield* Effect.tryPromise(() =>
+            dlmm.getPosition(new PublicKey(positionPubKey)),
+          );
+          const positionData = position.positionData;
+          const tokenXMint = dlmm.lbPair.tokenXMint.toBase58();
+          const tokenYMint = dlmm.lbPair.tokenYMint.toBase58();
+          const prices = yield* fetchTokenPrices([tokenXMint, tokenYMint]);
+          const decimalsX = dlmm.tokenX.mint.decimals;
+          const decimalsY = dlmm.tokenY.mint.decimals;
+          const xUsd =
+            (Number(positionData.totalXAmount.toString()) / 10 ** decimalsX) *
+            (prices[tokenXMint] ?? 0);
+          const yUsd =
+            (Number(positionData.totalYAmount.toString()) / 10 ** decimalsY) *
+            (prices[tokenYMint] ?? 0);
+          const valueUsd = xUsd + yUsd;
+          if (!Number.isFinite(valueUsd) || valueUsd <= 0) return null;
+          positionValueCache.set(cacheKey, { fetchedAt: Date.now(), value: valueUsd });
+          return valueUsd;
+        }).pipe(
+          Effect.catchAll(() => {
+            return Effect.succeed(null);
+          }),
+        );
+      },
 
       getAllWalletPositions: (walletAddress) =>
         Effect.gen(function* () {

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -194,6 +194,10 @@ export interface AppConfig {
   readonly ilDominanceExitFactor?: number;
   /** Minimum IL (USD) before the IL-dominance fast EXIT may fire. Default 5. */
   readonly ilDominanceMinUsd?: number;
+  /** A position whose real mark falls below this USD value is closed as dust
+   *  (`[dust-cleanup]` EXIT, confidence 1) — it occupies a per-pool slot and
+   *  risk budget but can never pay its way. Default 5; 0 disables the rule. */
+  readonly dustExitUsd?: number;
 
   // ─── Token-risk overlay (Wave 18) ───────────────────────────────────────────
   // Optional so standalone test fixtures that omit new fields keep compiling;
@@ -738,6 +742,7 @@ const loadConfig = Effect.gen(function* () {
   );
   const ilDominanceExitFactor = yield* validatedNumber("IL_DOMINANCE_EXIT_FACTOR", 1, 2);
   const ilDominanceMinUsd = yield* validatedNumber("IL_DOMINANCE_MIN_USD", 0, 5);
+  const dustExitUsd = yield* validatedNumber("DUST_EXIT_USD", 0, 5);
 
   const jupiterTokenRiskEnabled = yield* Config.boolean("JUPITER_TOKEN_RISK_ENABLED").pipe(
     Effect.orElseSucceed(() => true),
@@ -1412,6 +1417,7 @@ const loadConfig = Effect.gen(function* () {
     ilProtectionEnabled,
     ilDominanceExitFactor,
     ilDominanceMinUsd,
+    dustExitUsd,
     jupiterTokenRiskEnabled,
     jupiterTokenRiskCacheTtlMin,
     geckoTerminalEnabled,

--- a/engine/pnl.ts
+++ b/engine/pnl.ts
@@ -278,8 +278,13 @@ export function computePortfolioEquity(input: PortfolioEquityInput): PortfolioEq
       : 0;
   const walletKnown = input.walletBalanceUsd !== null && Number.isFinite(input.walletBalanceUsd);
   const totalEquityUsd = positionsValueUsd + walletBalanceUsd;
+  // Unrealized P&L is POSITIONS-ONLY: equity minus deposits would count the
+  // idle wallet balance (e.g. residual SOL/USDC that was never deposited) as
+  // "gain", which produced the misleading "+127%" status on live wallets
+  // (issue #151 follow-up). The wallet is its own line (totalEquityUsd /
+  // walletBalanceUsd); it is not P&L.
   const unrealizedPnlUsd =
-    totalEquityUsd + totalFeesClaimedUsd + totalRewardsClaimedUsd - totalDepositedUsd;
+    positionsValueUsd + totalFeesClaimedUsd + totalRewardsClaimedUsd - totalDepositedUsd;
   const unrealizedPnlPct = totalDepositedUsd > 0 ? (unrealizedPnlUsd / totalDepositedUsd) * 100 : 0;
 
   return {

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -435,15 +435,41 @@ export function hasSyncProposalTransport(status: { readonly transport: string | 
   return status.transport !== null && status.transport !== "alert-only";
 }
 
-// ─── Position value estimation (rough heuristic) ───────────────
+// ─── Position value estimation (fallback mark) ─────────────────
+//
+// The PRIMARY live mark is the real on-chain position value from the
+// adapter (`getPositionValueUsd`: actual X/Y bin holdings priced at the
+// token mints — captures genuine IL). This function is the FAIL-OPEN
+// fallback used when the position account cannot be read, a leg is
+// unpriceable, or the position is paper (no on-chain account). It is
+// deliberately price-anchored (the HODL revaluation of the recorded entry
+// legs) and NEVER the old bin-drift heuristic (`deposited ×
+// (1 − 0.5 × driftPct)`), which fabricated 10-40% "drawdowns" from
+// sub-1% price moves and fired the trailing stop every cycle. A fallback
+// that cannot price simply returns the cost basis — a flat mark never
+// invents a loss.
 
 export function estimatePositionValue(pos: PositionRecord, pool: PoolState): number {
-  const centerBinId = (pos.lowerBinId + pos.upperBinId) / 2;
-  const maxDrift = Math.max(pos.upperBinId - centerBinId, 1);
-  const drift = Math.abs(pool.activeBinId - centerBinId);
-  const driftPct = Math.min(drift / maxDrift, 1);
-  const ilFactor = 1 - driftPct * 0.5;
-  return pos.depositedUsd * ilFactor;
+  const entryPriceUsd = pos.entryPriceUsd;
+  if (
+    entryPriceUsd != null &&
+    entryPriceUsd > 0 &&
+    pos.entryAmountXUsd != null &&
+    pos.entryAmountYUsd != null &&
+    Number.isFinite(pos.entryAmountXUsd) &&
+    Number.isFinite(pos.entryAmountYUsd) &&
+    Number.isFinite(pool.currentPrice) &&
+    pool.currentPrice > 0
+  ) {
+    const hodl = computeHodlValueUsd(
+      pos.entryAmountXUsd,
+      pos.entryAmountYUsd,
+      entryPriceUsd,
+      pool.currentPrice,
+    );
+    if (hodl !== null && Number.isFinite(hodl) && hodl > 0) return hodl;
+  }
+  return pos.depositedUsd;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -4605,8 +4631,25 @@ export const program = Effect.gen(function* () {
 
       // Value estimation per position (feeds the trailing stop and the
       // REBALANCE gas gate); OOR counters above are persisted by the same save.
+      //
+      // PRIMARY mark: the real on-chain position value (adapter reads the
+      // position's actual X/Y bin holdings and prices them — captures genuine
+      // IL). FALLBACK: the HODL-anchored mark (price revaluation of the
+      // recorded entry legs) or, when entry legs are unknown, the cost basis.
+      // The old bin-drift heuristic is gone: it fabricated 10-40% drawdowns
+      // from sub-1% price moves, so the trailing stop fired every cycle and
+      // churned positions open/closed with ~zero realized P&L (live
+      // deployments saw 340+ positions in 2.5 weeks and −$218 of churn).
+      // getPositionValueUsd is optional in the service contract (test mocks)
+      // and never fails — null falls through to the price-anchored mark.
       for (const pos of poolPositions) {
-        const estimatedValue = estimatePositionValue(pos, pool);
+        const realMark =
+          pos.positionPubKey != null && adapter.getPositionValueUsd != null
+            ? yield* adapter
+                .getPositionValueUsd(poolAddress, pos.positionPubKey)
+                .pipe(Effect.catchAll(() => Effect.succeed(null)))
+            : null;
+        const estimatedValue = realMark ?? estimatePositionValue(pos, pool);
         pos.currentValueUsd = estimatedValue;
         const highest = pos.highestValueUsd ?? pos.depositedUsd;
         if (estimatedValue > highest) {
@@ -4794,6 +4837,31 @@ export const program = Effect.gen(function* () {
             confidence: 1,
             reasoning: `IL dominance: $${ilDominance.ilUsd.toFixed(2)} IL exceeds ${config.ilDominanceExitFactor ?? 2}× cumulative fees ($${ilDominance.feesClaimedUsd.toFixed(2)}) while out of range`,
           };
+        } else if (
+          (config.dustExitUsd ?? 0) > 0 &&
+          pos.currentValueUsd < (config.dustExitUsd ?? 0)
+        ) {
+          // Dust cleanup: a position whose REAL mark fell below the dust
+          // threshold is dead capital — it still occupies a per-pool position
+          // slot and a risk/allocation budget, but can never pay its way
+          // (fees scale with deposited value). Deterministic, position-
+          // targeted, confidence 1: reclaim the slot for a real position.
+          // Also auto-clears legacy dust positions (e.g. the $0.26 residual
+          // entries older builds created by clamping entry size to leftover
+          // per-pool headroom). Shadow mode records it; live mode closes it.
+          decision = {
+            action: "EXIT",
+            poolAddress,
+            positionId: pos.positionId,
+            confidence: 1,
+            reasoning: `[dust-cleanup] Position value $${pos.currentValueUsd.toFixed(2)} below $${(config.dustExitUsd ?? 0).toFixed(2)} dust threshold — reclaiming slot`,
+          };
+          yield* sendAgentAlert(
+            "warning",
+            "risk_rejected",
+            `Dust position closed on ${pool.tokenXSymbol}/${pool.tokenYSymbol}: value $${pos.currentValueUsd.toFixed(2)} below $${(config.dustExitUsd ?? 0).toFixed(2)}`,
+            { pool, metrics, position: pos },
+          );
         } else if (tvlVelocity < -config.tvlDropExitPct) {
           decision = {
             action: "EXIT",

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -4649,7 +4649,11 @@ export const program = Effect.gen(function* () {
                 .getPositionValueUsd(poolAddress, pos.positionPubKey)
                 .pipe(Effect.catchAll(() => Effect.succeed(null)))
             : null;
-        const estimatedValue = realMark ?? estimatePositionValue(pos, pool);
+        // Explicit null check (not `??`): the adapter contract returns null
+        // when the mark is unavailable, never 0 — a genuine 0-valued position
+        // is real data (dust) and must not silently fall back to the
+        // price-anchored mark.
+        const estimatedValue = realMark !== null ? realMark : estimatePositionValue(pos, pool);
         pos.currentValueUsd = estimatedValue;
         const highest = pos.highestValueUsd ?? pos.depositedUsd;
         if (estimatedValue > highest) {

--- a/engine/risk-service.ts
+++ b/engine/risk-service.ts
@@ -9,6 +9,7 @@ import type {
   RebalanceParams,
 } from "./types.js";
 import { shouldHoldForRecovery } from "./strategy-service.js";
+import { ENTRY_SIZE_FLOOR_USD } from "./entry-sizing.js";
 
 export interface RiskConfig {
   readonly confidenceThreshold: number;
@@ -108,6 +109,17 @@ export function evaluateRisk(
   // allocation (single source of truth: MAX_PER_POOL_ALLOCATION_PCT) minus
   // the pool's existing aggregate exposure across all its positions.
   if (decision.action === "ENTER" && decision.positionSizeUsd !== undefined) {
+    // Absolute floor first: any ENTER below the minimum entry size is dust
+    // (covers agent proposals and any future sizing path, not just the
+    // headroom clamp below).
+    if (decision.positionSizeUsd < ENTRY_SIZE_FLOOR_USD) {
+      return {
+        approved: false,
+        reason:
+          `Entry size $${decision.positionSizeUsd.toFixed(2)} is below the ` +
+          `$${ENTRY_SIZE_FLOOR_USD.toFixed(0)} minimum entry size`,
+      };
+    }
     const capPct = riskConfig.maxPerPoolAllocationPct;
     const existingPoolExposureUsd = ctx.openPositions
       .filter((p) => p.poolAddress === decision.poolAddress)
@@ -133,6 +145,19 @@ export function evaluateRisk(
         };
       }
       const adjustedSizeUsd = maxSize;
+      // A clamped-to-headroom size below the entry floor is dust, not an
+      // entry: approving it creates a position that can never pay its way
+      // (and previously produced $0.26 residual positions that churned the
+      // trailing stop and occupied per-pool slots). Reject instead of
+      // approving a sub-floor clamp.
+      if (adjustedSizeUsd < ENTRY_SIZE_FLOOR_USD) {
+        return {
+          approved: false,
+          reason:
+            `Remaining per-pool headroom $${adjustedSizeUsd.toFixed(2)} is below the ` +
+            `$${ENTRY_SIZE_FLOOR_USD.toFixed(0)} minimum entry size — skipping dust entry`,
+        };
+      }
       return {
         approved: true,
         reason: `Size capped to ${(capPct * 100).toFixed(0)}% of portfolio ($${adjustedSizeUsd.toFixed(0)})`,

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -146,6 +146,23 @@ export interface AdapterApi {
     unknown
   >;
   /**
+   * Real USD value of a live on-chain position (principal only — pending
+   * swap fees and LM rewards are accounted by the claim paths, never by the
+   * mark). Computed from the position's ACTUAL bin holdings
+   * (`totalXAmount`/`totalYAmount`) priced at the pool's token mints, so it
+   * captures genuine impermanent loss (an out-of-range position holds mostly
+   * one side) instead of the old bin-drift heuristic that fabricated ±20-40%
+   * "drawdowns" from sub-1% price moves — the root cause of the trailing-stop
+   * exit churn seen on live deployments. Never fails the caller: a
+   * position/price read problem logs nothing and returns null (fail-open),
+   * and the caller falls back to the HODL-anchored mark. Optional so loop
+   * test mocks that do not care about marks compile unchanged.
+   */
+  readonly getPositionValueUsd?: (
+    poolAddress: string,
+    positionPubKey: string,
+  ) => Effect.Effect<number | null, never>;
+  /**
    * Estimate the benefit of rebalancing `positionPubKey` into a new range.
    * Live mode runs the Meteora SDK's atomic-rebalance simulation against the
    * real on-chain position: `estimatedFeesUsd` is the position's real


### PR DESCRIPTION
## What

Fixes the position-exit churn that made the live deployment unprofitable. The DB told the story: **344 positions opened in 2.5 weeks, realized P&L −$217.80, total fees earned $2.51** — the engine was mostly burning gas on open/close cycles, not earning.

## Root cause (1 of 4): the position mark fabricated drawdowns

`estimatePositionValue` was a bin-drift heuristic:

```
value = depositedUsd × (1 − 0.5 × driftPct)
```

On a binStep-10 pool, 25 bins = 2.5% price width, so a **5-bin drift — a 0.5% price move — reads as a 10% "drawdown"**. The trailing stop (10%) fired on phantom losses every cycle ("value dropped 24% from peak $41.63" while the pool moved <1%), and the OpenClaw veto overlay spent Aug 4 overriding those EXITs, explicitly reasoning *"the trailing stop is firing on broken reference data"*.

**Fix:** live positions now mark from the real on-chain position account (`adapter.getPositionValueUsd` — `totalXAmount`/`totalYAmount` priced at the token mints, which captures genuine IL). Fallbacks are price-anchored: HODL revaluation of the recorded entry legs, then the cost basis. No fallback ever fabricates a drawdown. The drift heuristic is deleted.

## Root cause (2 of 4): dust entries

Risk gate 6 clamped ENTER size to remaining per-pool headroom and approved **$0.26 deposits** (the "phantom peak of $0.26" positions). Both an absolute floor and the clamped-headroom path now reject below `ENTRY_SIZE_FLOOR_USD` ($10).

## Root cause (3 of 4): dust positions occupy slots forever

New `DUST_EXIT_USD` (default 5, 0 disables): a position whose real mark falls below the threshold gets a deterministic confidence-1 `[dust-cleanup]` EXIT — reclaiming the per-pool slot (and auto-clearing the legacy $0.26 residuals).

## Root cause (4 of 4): status counted the idle wallet as "gain"

`computePortfolioEquity` computed `unrealized = equity + fees − deposits`, so a $54 wallet with $42 deployed showed **"+127% unrealized"** (the idle SOL counted as profit). Unrealized P&L is now positions-only; equity still includes the wallet.

## Config knobs (deployment-side)

- `DUST_EXIT_USD` (new, default 5)
- Recommended for fine-binStep pools: `ENTRY_RANGE_HALF_WIDTH_BINS=50`, `MAX_REBALANCE_RANGE_BINS=150`, `VOLATILITY_EXIT_STDDEV=8` (wider ranges + higher vol-gate bar → fewer OOR exits; rebalance handles normal drift)

## Tests

- `estimatePositionValue` rewritten for the HODL-fallback semantics (never drops via bin drift; falls back to basis on unknown legs/non-positive price)
- IL-dominance tests now exercise the **real-mark path** (`getPositionValueUsd` mock) — live position with collapsed on-chain mark → IL EXIT
- #153 trailing-stop debounce tests use genuine price-driven drawdowns
- Risk tests cover both dust-entry floors; new dust-cleanup EXIT test; equity tests updated to positions-only P&L

1482 tests pass; lint, format, engine build and CLI bundle build clean.

## Summary by Sourcery

Replace heuristic bin-drift position marking with real on-chain valuation and price-anchored fallbacks, add dust entry/exit protections, and fix portfolio unrealized P&L to exclude idle wallet balances.

New Features:
- Introduce a real on-chain position value mark via adapter.getPositionValueUsd as the primary source for trailing stops and P&L.
- Add a configurable DUST_EXIT_USD threshold that automatically closes tiny positions and frees per-pool slots.

Bug Fixes:
- Eliminate the bin-drift position value heuristic that fabricated large drawdowns from small price moves and caused excessive trailing-stop exit churn.
- Prevent new ENTER decisions and headroom-clamped entries below a minimum USD size to avoid dust positions.
- Compute unrealized P&L from positions-only while keeping the wallet solely in total equity, removing inflated gain reporting from idle balances.

Enhancements:
- Define a HODL-based fallback mark for positions when on-chain valuation is unavailable, ensuring marks never fall below cost basis due to drift.
- Extend risk and IL-protection tests to cover real position marks, dust cleanup exits, and the revised trailing-stop debounce behavior.
- Expose and wire a new dustExitUsd config knob with sane defaults and validation, and add caching for real position value reads in the adapter.

Tests:
- Update and expand test suites for position valuation, multi-position lifecycles, IL-dominance exits, risk entry sizing floors, config loading, and portfolio equity calculations to reflect the new marking and dust-handling rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup for positions valued below the configurable dust threshold, with an alert explaining the exit.
  * Added support for more accurate live position valuation using current on-chain holdings and token prices.
  * Added a configurable `DUST_EXIT_USD` setting, defaulting to $5; set it to zero to disable cleanup.

* **Bug Fixes**
  * Improved portfolio equity and unrealized P&L calculations by separating wallet balances from position performance.
  * Prevented entries that fall below the minimum supported position size.
  * Improved valuation accuracy across changing pool prices and incomplete position data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->