### PR TITLE
chore(ops): merge-preserving setup, DB-tunable market config, doctor config check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,6 +147,32 @@ DISCOVERY_MIN_TVL_USD=1000000
 # Minimum fee ratio for auto-discovered pools
 DISCOVERY_MIN_FEE_RATIO=1.5
 
+# ── Market-scan mode (universe-driven trading) ─────────────
+# When enabled, WATCHLIST_POOLS becomes OPTIONAL: the engine continuously
+# scans the top pages of the Meteora universe, re-runs the market gate on a
+# refresh cadence, and trades the top-ranked pools through the normal gates
+# (safety screening, metrics, fee/IL, risk). Pools that stop qualifying drop
+# out of the active set; held positions always stay scanned so exits never
+# stall. See AGENTS.md → Market-scan mode.
+MARKET_SCAN_ENABLED=false
+# How often the universe gate re-runs and the active set is rebuilt (min 60 s)
+MARKET_SCAN_REFRESH_INTERVAL_MS=1800000
+# Top-N pages (1000 pools each) of the TVL-ranked universe per refresh (1-10)
+MARKET_SCAN_UNIVERSE_PAGES=3
+# Minimum TVL (USD) for the market gate
+MARKET_SCAN_MIN_TVL_USD=250000
+# Minimum annualized fee/TVL percent (fees24h x 365 / tvl x 100)
+MARKET_SCAN_MIN_FEE_APR=25
+# How many top-ranked market pools are actively scanned each cycle (1-200)
+MARKET_SCAN_TOP_K=30
+# Hard cap on market-scan pools in the active scan set
+MARKET_SCAN_MAX_POOLS=60
+# Minimum holders for a non-stable, non-SOL leg to pass the gate pre-filter
+MARKET_SCAN_MIN_HOLDERS=1000
+# Skip finer bins (ultra-fine bins churn) / wider bins (fee dilution)
+MARKET_SCAN_MIN_BIN_STEP=2
+MARKET_SCAN_MAX_BIN_STEP=200
+
 # Dump full pool state snapshots to DB every cycle (paper only)
 ENABLE_SNAPSHOT_CAPTURE=false
 # Stablecoin mints trusted by depeg detection + freeze screening (allowlist).
@@ -171,6 +197,14 @@ IL_PROTECTION_ENABLED=true
 IL_DOMINANCE_EXIT_FACTOR=2
 # Minimum IL (USD) before the IL-dominance fast EXIT may fire. Default: 5.
 IL_DOMINANCE_MIN_USD=5
+
+# A position whose real mark falls below this USD value is closed as dust
+# ([dust-cleanup] EXIT, confidence 1) — reclaims the per-pool slot. 0 disables.
+DUST_EXIT_USD=5
+
+# Consecutive cycles the trailing-stop drawdown must persist before EXIT
+# (anti-phantom guard; default 2)
+TRAILING_STOP_CONFIRM_CYCLES=2
 
 # Token-risk overlay (Jupiter Tokens API V2 + Meteora Data API is_verified):
 # smart freeze-authority/scam screening that admits verified freeze-authority

--- a/.env.example
+++ b/.env.example
@@ -155,23 +155,24 @@ DISCOVERY_MIN_FEE_RATIO=1.5
 # out of the active set; held positions always stay scanned so exits never
 # stall. See AGENTS.md → Market-scan mode.
 MARKET_SCAN_ENABLED=false
-# How often the universe gate re-runs and the active set is rebuilt (min 60 s)
-MARKET_SCAN_REFRESH_INTERVAL_MS=1800000
-# Top-N pages (1000 pools each) of the TVL-ranked universe per refresh (1-10)
-MARKET_SCAN_UNIVERSE_PAGES=3
-# Minimum TVL (USD) for the market gate
-MARKET_SCAN_MIN_TVL_USD=250000
-# Minimum annualized fee/TVL percent (fees24h x 365 / tvl x 100)
-MARKET_SCAN_MIN_FEE_APR=25
-# How many top-ranked market pools are actively scanned each cycle (1-200)
-MARKET_SCAN_TOP_K=30
+# Skip wider bins (fee dilution); supported 1-2000
+MARKET_SCAN_MAX_BIN_STEP=200
 # Hard cap on market-scan pools in the active scan set
 MARKET_SCAN_MAX_POOLS=60
+# Skip finer bins (ultra-fine bins churn); supported 0-100
+MARKET_SCAN_MIN_BIN_STEP=2
+# Minimum annualized fee/TVL percent (fees24h x 365 / tvl x 100)
+MARKET_SCAN_MIN_FEE_APR=25
 # Minimum holders for a non-stable, non-SOL leg to pass the gate pre-filter
 MARKET_SCAN_MIN_HOLDERS=1000
-# Skip finer bins (ultra-fine bins churn) / wider bins (fee dilution)
-MARKET_SCAN_MIN_BIN_STEP=2
-MARKET_SCAN_MAX_BIN_STEP=200
+# Minimum TVL (USD) for the market gate
+MARKET_SCAN_MIN_TVL_USD=250000
+# How often the universe gate re-runs and the active set is rebuilt (min 60 s)
+MARKET_SCAN_REFRESH_INTERVAL_MS=1800000
+# How many top-ranked market pools are actively scanned each cycle (1-200)
+MARKET_SCAN_TOP_K=30
+# Top-N pages (1000 pools each) of the TVL-ranked universe per refresh (1-10)
+MARKET_SCAN_UNIVERSE_PAGES=3
 
 # Dump full pool state snapshots to DB every cycle (paper only)
 ENABLE_SNAPSHOT_CAPTURE=false

--- a/bench/db-config.test.ts
+++ b/bench/db-config.test.ts
@@ -8,10 +8,11 @@ import {
   parseDbConfigValue,
   readDbConfigOverrides,
   applyDbConfigOverrides,
+  isKnownConfigField,
 } from "../engine/db-config.js";
 import type { AppConfig } from "../engine/config-service.js";
 
-/** Minimal AppConfig-shaped base for override tests. */
+/** AppConfig-shaped base carrying every DB-tunable declared field (so the typo guard sees a realistic resolved config). */
 function baseConfig(): AppConfig {
   return {
     minPoolTvlUsd: 50_000,
@@ -31,6 +32,28 @@ function baseConfig(): AppConfig {
     fallenAngelMaxTop10HolderPct: 0.5,
     fallenAngelInvalidationStopPct: 0.25,
     fallenAngelMaxPositions: 2,
+    minBinUtilization: 0.05,
+    confidenceThreshold: 0.65,
+    stopLossPct: 0.15,
+    trailingStopPct: 0.1,
+    paperPortfolioUsd: 10_000,
+    maxPositionsPerPool: 2,
+    scanIntervalMs: 600_000,
+    alertsEnabled: true,
+    alertCooldownMinutes: 120,
+    alertFeeMilestoneUsd: 10,
+    dustExitUsd: 5,
+    trailingStopConfirmCycles: 2,
+    volatilityExitStddev: 0.05,
+    entryRangeHalfWidthBins: 0,
+    maxRebalanceRangeBins: 50,
+    oorCooldownMs: 14_400_000,
+    oorGracePeriodCycles: 3,
+    feeClaimIntervalMs: 3_600_000,
+    minRebalanceIntervalMs: 3_600_000,
+    idleRedeployEnabled: false,
+    idleRedeployThresholdUsd: 500,
+    idleRedeployMaxSizeUsd: 2_000,
   } as unknown as AppConfig;
 }
 
@@ -106,6 +129,36 @@ describe("db-config registry", () => {
     expect(parseDbConfigValue(findDbConfigSpec("MARKET_SCAN_MIN_BIN_STEP")!, "-5")).toBe(0);
     expect(parseDbConfigValue(findDbConfigSpec("MARKET_SCAN_MAX_BIN_STEP")!, "9999")).toBe(2000);
     expect(parseDbConfigValue(findDbConfigSpec("MARKET_SCAN_MAX_BIN_STEP")!, "0")).toBe(1);
+  });
+
+  it("guards spec fields against typos (declared, forward-ref, unknown)", () => {
+    const base = baseConfig();
+    expect(isKnownConfigField("minPoolTvlUsd", base)).toBe(true);
+    expect(isKnownConfigField("marketScanEnabled", base)).toBe(true);
+    expect(isKnownConfigField("marketScanMinBinStep", base)).toBe(true);
+    expect(isKnownConfigField("minPoolTvlUsdX", base)).toBe(false);
+  });
+
+  it("normalizes an inverted bin-step range from DB rows", () => {
+    const overridden = applyDbConfigOverrides(
+      baseConfig(),
+      new Map([
+        [dbConfigKey("MARKET_SCAN_MIN_BIN_STEP"), "100"],
+        [dbConfigKey("MARKET_SCAN_MAX_BIN_STEP"), "1"],
+      ]),
+    );
+    const cfg = overridden as unknown as Record<string, unknown>;
+    expect(cfg.marketScanMinBinStep).toBe(100);
+    expect(cfg.marketScanMaxBinStep).toBe(100);
+  });
+
+  it("normalizes an inverted bin-step range from env vars (env wins)", () => {
+    vi.stubEnv("MARKET_SCAN_MIN_BIN_STEP", "100");
+    vi.stubEnv("MARKET_SCAN_MAX_BIN_STEP", "1");
+    const overridden = applyDbConfigOverrides(baseConfig(), new Map());
+    const cfg = overridden as unknown as Record<string, unknown>;
+    expect(cfg.marketScanMinBinStep).toBe(100);
+    expect(cfg.marketScanMaxBinStep).toBe(100);
   });
 
   it("rejects edits to non-allowlisted values (secrets cannot be stored)", () => {

--- a/bench/db-config.test.ts
+++ b/bench/db-config.test.ts
@@ -59,6 +59,46 @@ describe("db-config registry", () => {
     expect(findDbConfigSpec("WALLET_PRIVATE_KEY")).toBeUndefined();
   });
 
+  it("covers the market-scan and post-#157 tuning knobs (runtime-tunable)", () => {
+    for (const envKey of [
+      "MARKET_SCAN_ENABLED",
+      "MARKET_SCAN_REFRESH_INTERVAL_MS",
+      "MARKET_SCAN_UNIVERSE_PAGES",
+      "MARKET_SCAN_MIN_TVL_USD",
+      "MARKET_SCAN_MIN_FEE_APR",
+      "MARKET_SCAN_TOP_K",
+      "MARKET_SCAN_MAX_POOLS",
+      "MARKET_SCAN_MIN_HOLDERS",
+      "MARKET_SCAN_MIN_BIN_STEP",
+      "MARKET_SCAN_MAX_BIN_STEP",
+      "DUST_EXIT_USD",
+      "TRAILING_STOP_CONFIRM_CYCLES",
+      "VOLATILITY_EXIT_STDDEV",
+      "ENTRY_RANGE_HALF_WIDTH_BINS",
+      "MAX_REBALANCE_RANGE_BINS",
+      "OOR_COOLDOWN_MS",
+      "IDLE_REDEPLOY_ENABLED",
+    ]) {
+      expect(findDbConfigSpec(envKey), `${envKey} must be DB-overridable`).toBeDefined();
+    }
+  });
+
+  it("applies a market-scan override onto the config (env unset)", () => {
+    const base = baseConfig();
+    const overridden = applyDbConfigOverrides(
+      base,
+      new Map([[dbConfigKey("MARKET_SCAN_ENABLED"), "true"]]),
+    );
+    expect((overridden as unknown as Record<string, unknown>).marketScanEnabled).toBe(true);
+  });
+
+  it("clamps market-scan values to their bounds", () => {
+    expect(parseDbConfigValue(findDbConfigSpec("MARKET_SCAN_TOP_K")!, "999")).toBe(200);
+    expect(parseDbConfigValue(findDbConfigSpec("MARKET_SCAN_REFRESH_INTERVAL_MS")!, "1000")).toBe(
+      60_000,
+    );
+  });
+
   it("rejects edits to non-allowlisted values (secrets cannot be stored)", () => {
     for (const spec of DB_CONFIG_KEYS) {
       expect(["WALLET_PRIVATE_KEY", "HELIUS_API_KEY", "SOLANA_RPC_URL"]).not.toContain(spec.envKey);

--- a/bench/db-config.test.ts
+++ b/bench/db-config.test.ts
@@ -77,7 +77,12 @@ describe("db-config registry", () => {
       "ENTRY_RANGE_HALF_WIDTH_BINS",
       "MAX_REBALANCE_RANGE_BINS",
       "OOR_COOLDOWN_MS",
+      "OOR_GRACE_PERIOD_CYCLES",
+      "FEE_CLAIM_INTERVAL_MS",
+      "MIN_REBALANCE_INTERVAL_MS",
       "IDLE_REDEPLOY_ENABLED",
+      "IDLE_REDEPLOY_THRESHOLD_USD",
+      "IDLE_REDEPLOY_MAX_SIZE_USD",
     ]) {
       expect(findDbConfigSpec(envKey), `${envKey} must be DB-overridable`).toBeDefined();
     }
@@ -97,6 +102,10 @@ describe("db-config registry", () => {
     expect(parseDbConfigValue(findDbConfigSpec("MARKET_SCAN_REFRESH_INTERVAL_MS")!, "1000")).toBe(
       60_000,
     );
+    expect(parseDbConfigValue(findDbConfigSpec("MARKET_SCAN_MIN_BIN_STEP")!, "500")).toBe(100);
+    expect(parseDbConfigValue(findDbConfigSpec("MARKET_SCAN_MIN_BIN_STEP")!, "-5")).toBe(0);
+    expect(parseDbConfigValue(findDbConfigSpec("MARKET_SCAN_MAX_BIN_STEP")!, "9999")).toBe(2000);
+    expect(parseDbConfigValue(findDbConfigSpec("MARKET_SCAN_MAX_BIN_STEP")!, "0")).toBe(1);
   });
 
   it("rejects edits to non-allowlisted values (secrets cannot be stored)", () => {

--- a/bench/env-merge.test.ts
+++ b/bench/env-merge.test.ts
@@ -1,0 +1,68 @@
+/** Merge-preserving .env writer tests: `prism setup` must never wipe user config. */
+import { describe, it, expect } from "vitest";
+import { mergeEnvContent, envValues, parseEnvLines } from "../cli/env-merge.js";
+
+const MANAGED = `# RPC providers
+HELIUS_API_KEY=new-key
+SOLANA_RPC_URL=https://new-rpc
+
+# Trading mode
+PAPER_TRADING=false
+SCAN_INTERVAL_MS=600000
+WATCHLIST_POOLS=`;
+
+describe("mergeEnvContent", () => {
+  it("preserves unknown user keys and comments verbatim", () => {
+    const existing = `# my custom header
+HELIUS_API_KEY=old-key
+WATCHLIST_POOLS=pool1,pool2
+MARKET_SCAN_ENABLED=true
+AGENTIC_MODE=true
+# a trailing comment`;
+    const merged = mergeEnvContent(existing, MANAGED);
+    expect(merged).toContain("# my custom header");
+    expect(merged).toContain("HELIUS_API_KEY=new-key");
+    expect(merged).toContain("WATCHLIST_POOLS=pool1,pool2");
+    expect(merged).toContain("MARKET_SCAN_ENABLED=true");
+    expect(merged).toContain("AGENTIC_MODE=true");
+    expect(merged).toContain("# a trailing comment");
+    expect(merged).not.toContain("HELIUS_API_KEY=old-key");
+  });
+
+  it("appends managed keys that are absent from the existing file", () => {
+    const merged = mergeEnvContent("ONLY_CUSTOM=1\n", MANAGED);
+    const values = envValues(merged);
+    expect(values.get("HELIUS_API_KEY")).toBe("new-key");
+    expect(values.get("ONLY_CUSTOM")).toBe("1");
+    expect(merged).toContain("Managed by `prism setup`");
+  });
+
+  it("never wipes a non-empty user value with an empty wizard default", () => {
+    // MANAGED has WATCHLIST_POOLS= (empty) — the user's pools must survive.
+    const existing = `WATCHLIST_POOLS=poolA,poolB
+MARKET_SCAN_ENABLED=true
+`;
+    const merged = mergeEnvContent(existing, MANAGED);
+    expect(envValues(merged).get("WATCHLIST_POOLS")).toBe("poolA,poolB");
+    // ...but a managed key WITH a fresh value replaces the old one.
+    expect(envValues(merged).get("HELIUS_API_KEY")).toBe("new-key");
+    expect(envValues(merged).get("PAPER_TRADING")).toBe("false");
+  });
+
+  it("honors an intentional clear when the existing value is also empty", () => {
+    const existing = "WATCHLIST_POOLS=\n";
+    const merged = mergeEnvContent(existing, MANAGED);
+    expect(envValues(merged).get("WATCHLIST_POOLS")).toBe("");
+  });
+
+  it("parses keys, values, comments and blanks", () => {
+    const lines = parseEnvLines("# c\nA=1\n\n B = 2 \nnot-a-key");
+    expect(lines).toHaveLength(5);
+    expect(lines[0]!.key).toBeNull();
+    expect(lines[1]!.key).toBe("A");
+    expect(lines[2]!.key).toBeNull();
+    expect(lines[3]!.key).toBe("B");
+    expect(lines[3]!.value).toBe("2");
+    expect(lines[4]!.key).toBeNull();
+  });
+});

--- a/cli/config.ts
+++ b/cli/config.ts
@@ -123,6 +123,7 @@ const setCommand = new Command("set")
         yield* db.setMetadata(dbConfigKey(key), stored);
         const shadowed = process.env[key] !== undefined;
         console.log(`Set ${key}=${stored} in DB.`);
+        console.log("Note: the running engine loads config at startup — restart it to apply.");
         if (shadowed) {
           console.warn(
             `Note: env var ${key}=${process.env[key]} is set and will win over this DB value.`,

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -11,10 +11,16 @@ import {
 } from "../engine/paths.js";
 import { isSourceInstall } from "../engine/install-method.js";
 import { probeVecAvailability, vecRemediationHint, type VecProbeResult } from "../engine/db.js";
-import { normalizeHeliusUrl, maskHeliusUrl } from "../engine/config-service.js";
+import {
+  normalizeHeliusUrl,
+  maskHeliusUrl,
+  ConfigService,
+  ConfigLive,
+} from "../engine/config-service.js";
 import { loadKeystoreSecretKeyBase58 } from "../engine/wallet-keystore.js";
 import { getApiBaseUrl, prismApiPost, readCredentials } from "./api.js";
 import { readTelemetryPreference } from "../engine/telemetry-preference.js";
+import { Effect } from "effect";
 
 type DoctorStatus = "pass" | "warn" | "fail";
 
@@ -313,7 +319,35 @@ function checkPriceProviders(): DoctorCheck {
   );
 }
 
-export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorReport> {
+export /**
+ * Validate that the FULL config actually loads (env + .env + DB sidecar
+ * overrides, with every numeric clamp and structured warning), not just that
+ * the .env file exists. This catches broken values that would otherwise only
+ * surface at engine startup.
+ */
+async function checkConfig(): Promise<DoctorCheck> {
+  try {
+    const config = await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          return yield* ConfigService;
+        }),
+        ConfigLive,
+      ),
+    );
+    const marketScan =
+      (config as unknown as { marketScanEnabled?: boolean }).marketScanEnabled === true;
+    return check(
+      "config",
+      "pass",
+      `Config loaded (scan=${config.scanIntervalMs}ms, maxPositions=${config.maxOpenPositions}, marketScan=${marketScan})`,
+    );
+  } catch (error) {
+    return check("config", "fail", `Config failed to load: ${String(error)}`);
+  }
+}
+
+async function runDoctor(options: DoctorOptions = {}): Promise<DoctorReport> {
   const fix = options.fix === true;
   const sourceInstall = isSourceInstall(getPrismConfigDir());
   const checks: DoctorCheck[] = [checkRuntime()];
@@ -343,6 +377,7 @@ export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorRepo
   checks.push(heliusApiKey);
   checks.push(checkPriceProviders());
   checks.push(checkWallet());
+  checks.push(await checkConfig());
   checks.push(await checkRegistration());
   const telemetryEnabled =
     process.env.PRISM_ERROR_REPORTING !== "false" && readTelemetryPreference().enabled;

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -17,6 +17,7 @@ import {
   ConfigService,
   ConfigLive,
 } from "../engine/config-service.js";
+import { findDbConfigSpec, parseDbConfigValue } from "../engine/db-config.js";
 import { loadKeystoreSecretKeyBase58 } from "../engine/wallet-keystore.js";
 import { getApiBaseUrl, prismApiPost, readCredentials } from "./api.js";
 import { readTelemetryPreference } from "../engine/telemetry-preference.js";
@@ -335,8 +336,19 @@ async function checkConfig(): Promise<DoctorCheck> {
         ConfigLive,
       ),
     );
+    // MARKET_SCAN_* is forward-declared config that lands on AppConfig with
+    // the market-scan feature branch; this base does not declare it. Report
+    // the effective toggle with the engine's env > DB > default precedence:
+    // the env var (dotenv already loaded at CLI start) first, then the
+    // DB-sidecar override ConfigLive applied onto the loaded config.
+    const spec = findDbConfigSpec("MARKET_SCAN_ENABLED");
+    const envRaw = process.env.MARKET_SCAN_ENABLED;
     const marketScan =
-      (config as unknown as { marketScanEnabled?: boolean }).marketScanEnabled === true;
+      spec === undefined
+        ? false
+        : envRaw !== undefined
+          ? parseDbConfigValue(spec, envRaw) === true
+          : (config as unknown as Record<string, unknown>)[spec.field] === true;
     return check(
       "config",
       "pass",

--- a/cli/env-merge.ts
+++ b/cli/env-merge.ts
@@ -1,0 +1,86 @@
+/** @file Merge-preserving .env writer for `prism setup`.
+ *
+ * Re-running setup must NEVER wipe user configuration. The wizard only
+ * manages a fixed set of keys; everything else in an existing `.env`
+ * (WATCHLIST_POOLS, MARKET_SCAN_*, AGENTIC_MODE, custom comments, ordering)
+ * is preserved verbatim. Managed keys take the freshly-entered value, EXCEPT
+ * when the wizard's new value is empty and the existing value is non-empty —
+ * an empty wizard default must not wipe a user's setting.
+ */
+
+export interface ParsedEnvLine {
+  readonly key: string | null;
+  readonly value: string;
+  readonly raw: string;
+}
+
+export function parseEnvLines(content: string): ReadonlyArray<ParsedEnvLine> {
+  return content.split("\n").map((raw) => {
+    const t = raw.trim();
+    if (t === "" || t.startsWith("#")) return { key: null, value: "", raw };
+    const eq = t.indexOf("=");
+    if (eq < 0) return { key: null, value: "", raw };
+    return { key: t.slice(0, eq).trim(), value: t.slice(eq + 1).trim(), raw };
+  });
+}
+
+/** Extract `{KEY: value}` for all KEY=value lines (last occurrence wins). */
+export function envValues(content: string): ReadonlyMap<string, string> {
+  const map = new Map<string, string>();
+  for (const line of parseEnvLines(content)) {
+    if (line.key !== null) map.set(line.key, line.value);
+  }
+  return map;
+}
+
+/**
+ * Merge `managed` (the setup wizard template) into `existing` (the current
+ * `.env`):
+ * - Non-managed lines (unknown keys, comments, blanks) are preserved in place.
+ * - A managed key's line is replaced by the wizard's fresh value, unless the
+ *   wizard value is empty AND the existing value is non-empty (keep existing).
+ * - Managed keys absent from the existing file are appended at the end under
+ *   a banner so new defaults introduced by upgrades actually appear.
+ */
+export function mergeEnvContent(existing: string, managed: string): string {
+  const managedLines = parseEnvLines(managed);
+  const managedByKey = new Map<string, ParsedEnvLine>();
+  for (const line of managedLines) {
+    if (line.key !== null) managedByKey.set(line.key, line);
+  }
+  const existingValues = envValues(existing);
+  const existingLines = parseEnvLines(existing);
+
+  const out: string[] = [];
+  for (const line of existingLines) {
+    if (line.key === null || !managedByKey.has(line.key)) {
+      out.push(line.raw);
+      continue;
+    }
+    const managedEntry = managedByKey.get(line.key)!;
+    const wizardValueEmpty = managedEntry.value === "";
+    const existingHasValue = (existingValues.get(line.key) ?? "") !== "";
+    if (wizardValueEmpty && existingHasValue) {
+      out.push(line.raw); // keep the user's value; do not wipe
+    } else {
+      out.push(managedEntry.raw); // fresh wizard value (or an intentional clear)
+    }
+  }
+
+  const presentKeys = new Set(
+    out
+      .map((raw) => {
+        const t = raw.trim();
+        if (t === "" || t.startsWith("#")) return null;
+        const eq = t.indexOf("=");
+        return eq < 0 ? null : t.slice(0, eq).trim();
+      })
+      .filter((k): k is string => k !== null),
+  );
+  const toAppend = managedLines.filter((l) => l.key !== null && !presentKeys.has(l.key!));
+  if (toAppend.length > 0) {
+    out.push("", "# ── Managed by `prism setup` — re-running setup updates these keys ──");
+    for (const line of toAppend) out.push(line.raw);
+  }
+  return `${out.join("\n")}\n`;
+}

--- a/cli/setup.ts
+++ b/cli/setup.ts
@@ -195,7 +195,9 @@ export const setupCommand = new Command("setup")
     const existingEnv = fs.existsSync(envPath) ? fs.readFileSync(envPath, "utf-8") : null;
     if (existingEnv !== null) {
       const backupPath = `${envPath}.backup.${Date.now()}`;
-      fs.copyFileSync(envPath, backupPath);
+      // Backup may contain WALLET_PRIVATE_KEY: write with 0o600 and never
+      // clobber an existing destination (exclusive create).
+      fs.writeFileSync(backupPath, existingEnv, { mode: 0o600, flag: "wx" });
       console.warn(`⚠ Existing .env found. Backup created at: ${backupPath}`);
     }
     // MERGE, never replace: unknown user keys (WATCHLIST_POOLS, MARKET_SCAN_*,

--- a/cli/setup.ts
+++ b/cli/setup.ts
@@ -5,6 +5,7 @@ import path from "path";
 import os from "os";
 import { pingInstall, requireRegistered, type PrismCredentials } from "./api.js";
 import { ensurePrismConfigDir, getPrismEnvPath, getPrismDbPath } from "../engine/paths.js";
+import { mergeEnvContent } from "./env-merge.js";
 
 export const setupCommand = new Command("setup")
   .description("Configure Prism trading agent")
@@ -191,12 +192,18 @@ export const setupCommand = new Command("setup")
 
     ensurePrismConfigDir();
     const envPath = getPrismEnvPath();
-    if (fs.existsSync(envPath)) {
+    const existingEnv = fs.existsSync(envPath) ? fs.readFileSync(envPath, "utf-8") : null;
+    if (existingEnv !== null) {
       const backupPath = `${envPath}.backup.${Date.now()}`;
       fs.copyFileSync(envPath, backupPath);
       console.warn(`⚠ Existing .env found. Backup created at: ${backupPath}`);
     }
-    fs.writeFileSync(envPath, envContent, { mode: 0o600 });
+    // MERGE, never replace: unknown user keys (WATCHLIST_POOLS, MARKET_SCAN_*,
+    // AGENTIC_MODE, custom comments) survive a re-run; managed keys get the
+    // fresh wizard values; new defaults are appended. An empty wizard value
+    // never wipes a non-empty existing value.
+    const mergedEnv = existingEnv === null ? envContent : mergeEnvContent(existingEnv, envContent);
+    fs.writeFileSync(envPath, mergedEnv, { mode: 0o600 });
     fs.chmodSync(envPath, 0o600);
     await pingInstall("setup", { userId: credentials.userId });
 

--- a/engine/db-config.ts
+++ b/engine/db-config.ts
@@ -55,12 +55,15 @@ export interface DbConfigSpec {
    * AppConfig field this override lands on. Typed as string so specs can
    * reference fields introduced by newer feature branches (market-scan etc.)
    * while this module compiles against older bases; applyDbConfigOverrides
-   * narrows at runtime via the kind parse. A typo fails loudly: the row is
-   * skipped with a warning and the key is invisible to `prism config list`.
+   * narrows at runtime via the kind parse and guards the name against
+   * FORWARD_REFERENCE_FIELDS. A typo fails loudly: the row is skipped with
+   * a warning and the key is invisible to `prism config list`.
    */
   readonly field: string;
   readonly min?: number;
   readonly max?: number;
+  /** Fallback used only by the bin-step range cross-check (env > DB > default). */
+  readonly default?: number;
 }
 
 /**
@@ -152,7 +155,7 @@ export const DB_CONFIG_KEYS: ReadonlyArray<DbConfigSpec> = [
     field: "fallenAngelMaxPositions",
     min: 1,
   },
-  // ── Market-scan mode (runtime-tunable without a restart) ─────────────────
+  // ── Market-scan mode (DB-overridable; applied on the next engine start) ─
   { envKey: "MARKET_SCAN_ENABLED", kind: "boolean", field: "marketScanEnabled" },
   {
     envKey: "MARKET_SCAN_REFRESH_INTERVAL_MS",
@@ -205,6 +208,7 @@ export const DB_CONFIG_KEYS: ReadonlyArray<DbConfigSpec> = [
     field: "marketScanMinBinStep",
     min: 0,
     max: 100,
+    default: 2,
   },
   {
     envKey: "MARKET_SCAN_MAX_BIN_STEP",
@@ -212,6 +216,7 @@ export const DB_CONFIG_KEYS: ReadonlyArray<DbConfigSpec> = [
     field: "marketScanMaxBinStep",
     min: 1,
     max: 2000,
+    default: 200,
   },
   // ── Post-#157 tuning knobs (churn / dust / range) ────────────────────────
   { envKey: "DUST_EXIT_USD", kind: "number", field: "dustExitUsd", min: 0 },
@@ -275,6 +280,26 @@ export const DB_CONFIG_KEYS: ReadonlyArray<DbConfigSpec> = [
   },
 ];
 
+/**
+ * AppConfig fields this base does not declare yet but that land with a newer
+ * feature branch (market-scan mode). Kept as an explicit allowlist so
+ * legitimate forward references keep working while a typo in a spec's
+ * `field` still fails loudly (warn + skip) instead of silently creating an
+ * unused property.
+ */
+const FORWARD_REFERENCE_FIELDS: ReadonlySet<string> = new Set([
+  "marketScanEnabled",
+  "marketScanRefreshIntervalMs",
+  "marketScanUniversePages",
+  "marketScanMinTvlUsd",
+  "marketScanMinFeeApr",
+  "marketScanTopK",
+  "marketScanMaxPools",
+  "marketScanMinHolders",
+  "marketScanMinBinStep",
+  "marketScanMaxBinStep",
+]);
+
 export function findDbConfigSpec(envKey: string): DbConfigSpec | undefined {
   return DB_CONFIG_KEYS.find((spec) => spec.envKey === envKey);
 }
@@ -307,9 +332,22 @@ export function parseDbConfigValue(
 }
 
 /**
+ * True when `field` is declared on AppConfig (present on the resolved base
+ * object) or listed in FORWARD_REFERENCE_FIELDS. Guards applyDbConfigOverrides
+ * so a typo in a spec's `field` cannot silently create an unused property.
+ */
+export function isKnownConfigField(field: string, base: AppConfig): boolean {
+  return FORWARD_REFERENCE_FIELDS.has(field) || Object.prototype.hasOwnProperty.call(base, field);
+}
+
+/**
  * Apply DB overrides onto a resolved AppConfig. Only keys whose env var is
  * UNSET take the DB value; the env var always wins. Malformed rows are
- * skipped with a warning. Returns a new object (never mutates `base`).
+ * skipped with a warning; rows whose spec field is neither declared on
+ * AppConfig nor an explicit forward reference are skipped with a warning
+ * (typo guard). After the loop, an inverted market-scan bin-step range is
+ * normalized (max raised to min) with a warning. Returns a new object
+ * (never mutates `base`).
  */
 export function applyDbConfigOverrides(
   base: AppConfig,
@@ -324,6 +362,17 @@ export function applyDbConfigOverrides(
     const raw = overrides.get(dbConfigKey(spec.envKey));
     if (raw === undefined) continue;
 
+    // Typo guard: the field must be declared on AppConfig or be an explicit
+    // forward reference to a newer feature branch's config; otherwise the
+    // row would silently create an unused property and the setting would
+    // have no effect.
+    if (!isKnownConfigField(spec.field, base)) {
+      logger.warn("Skipping DB config row for unknown AppConfig field", {
+        key: spec.envKey,
+        field: spec.field,
+      });
+      continue;
+    }
     const value = parseDbConfigValue(spec, raw);
     if (value === null) {
       logger.warn("Skipping malformed DB config row", { key: spec.envKey, raw });
@@ -335,6 +384,31 @@ export function applyDbConfigOverrides(
     // silently dropped above, never clamped into a fake value.
     if (typeof value === "boolean" || typeof value === "number") {
       next = { ...next, [spec.field]: value };
+    }
+  }
+
+  // ── Market-scan bin-step range cross-check ──────────────────────────────
+  // Individual clamps permit MIN > MAX (e.g. MIN=100, MAX=1), which would
+  // make every pool fail the bin-step filter. Resolve both ends with the
+  // same env > DB > default precedence and normalize an inverted range by
+  // raising the max to the min (never narrows the operator's lower bound).
+  const binMinSpec = findDbConfigSpec("MARKET_SCAN_MIN_BIN_STEP");
+  const binMaxSpec = findDbConfigSpec("MARKET_SCAN_MAX_BIN_STEP");
+  if (binMinSpec !== undefined && binMaxSpec !== undefined) {
+    const binMinRaw =
+      process.env[binMinSpec.envKey] ?? overrides.get(dbConfigKey(binMinSpec.envKey));
+    const binMaxRaw =
+      process.env[binMaxSpec.envKey] ?? overrides.get(dbConfigKey(binMaxSpec.envKey));
+    const binMin =
+      binMinRaw === undefined ? binMinSpec.default : parseDbConfigValue(binMinSpec, binMinRaw);
+    const binMax =
+      binMaxRaw === undefined ? binMaxSpec.default : parseDbConfigValue(binMaxSpec, binMaxRaw);
+    if (typeof binMin === "number" && typeof binMax === "number" && binMin > binMax) {
+      logger.warn("Inverted market-scan bin-step range; raising max to min", {
+        marketScanMinBinStep: binMin,
+        marketScanMaxBinStep: binMax,
+      });
+      next = { ...next, [binMinSpec.field]: binMin, [binMaxSpec.field]: binMin };
     }
   }
 

--- a/engine/db-config.ts
+++ b/engine/db-config.ts
@@ -17,6 +17,13 @@ import type { AppConfig } from "./config-service.js";
  *   2. DB row `config.<ENV_KEY>`             — wins when the env var is UNSET
  *   3. compiled-in default in loadConfig     — baseline
  *
+ * Effect timing: the engine loads config ONCE at startup (ConfigLive), so a
+ * DB override takes effect on the NEXT engine start — `prism config set`
+ * prints this hint. Hot-reload of the running program is deliberately NOT
+ * supported: `config` is captured by reference throughout the scan loop, and
+ * silently mutating it mid-cycle would make sizing/risk decisions
+ * non-deterministic.
+ *
  * Design rules (locked user decision #1):
  * - Only an explicit allowlist (`DB_CONFIG_KEYS`) is overridable. Secrets,
  *   wallet keys, RPC URLs, paths and channel names are NOT in it — a DB row
@@ -44,8 +51,14 @@ export interface DbConfigSpec {
   /** The env-style key the user sets, e.g. "MIN_POOL_TVL_USD". */
   readonly envKey: string;
   readonly kind: DbConfigKind;
-  /** AppConfig field this override lands on. */
-  readonly field: keyof AppConfig;
+  /**
+   * AppConfig field this override lands on. Typed as string so specs can
+   * reference fields introduced by newer feature branches (market-scan etc.)
+   * while this module compiles against older bases; applyDbConfigOverrides
+   * narrows at runtime via the kind parse. A typo fails loudly: the row is
+   * skipped with a warning and the key is invisible to `prism config list`.
+   */
+  readonly field: string;
   readonly min?: number;
   readonly max?: number;
 }
@@ -138,6 +151,127 @@ export const DB_CONFIG_KEYS: ReadonlyArray<DbConfigSpec> = [
     kind: "number",
     field: "fallenAngelMaxPositions",
     min: 1,
+  },
+  // ── Market-scan mode (runtime-tunable without a restart) ─────────────────
+  { envKey: "MARKET_SCAN_ENABLED", kind: "boolean", field: "marketScanEnabled" },
+  {
+    envKey: "MARKET_SCAN_REFRESH_INTERVAL_MS",
+    kind: "number",
+    field: "marketScanRefreshIntervalMs",
+    min: 60_000,
+  },
+  {
+    envKey: "MARKET_SCAN_UNIVERSE_PAGES",
+    kind: "number",
+    field: "marketScanUniversePages",
+    min: 1,
+    max: 10,
+  },
+  {
+    envKey: "MARKET_SCAN_MIN_TVL_USD",
+    kind: "number",
+    field: "marketScanMinTvlUsd",
+    min: 0,
+  },
+  {
+    envKey: "MARKET_SCAN_MIN_FEE_APR",
+    kind: "number",
+    field: "marketScanMinFeeApr",
+    min: 0,
+  },
+  {
+    envKey: "MARKET_SCAN_TOP_K",
+    kind: "number",
+    field: "marketScanTopK",
+    min: 1,
+    max: 200,
+  },
+  {
+    envKey: "MARKET_SCAN_MAX_POOLS",
+    kind: "number",
+    field: "marketScanMaxPools",
+    min: 1,
+    max: 500,
+  },
+  {
+    envKey: "MARKET_SCAN_MIN_HOLDERS",
+    kind: "number",
+    field: "marketScanMinHolders",
+    min: 0,
+  },
+  {
+    envKey: "MARKET_SCAN_MIN_BIN_STEP",
+    kind: "number",
+    field: "marketScanMinBinStep",
+    min: 0,
+    max: 100,
+  },
+  {
+    envKey: "MARKET_SCAN_MAX_BIN_STEP",
+    kind: "number",
+    field: "marketScanMaxBinStep",
+    min: 1,
+    max: 2000,
+  },
+  // ── Post-#157 tuning knobs (churn / dust / range) ────────────────────────
+  { envKey: "DUST_EXIT_USD", kind: "number", field: "dustExitUsd", min: 0 },
+  {
+    envKey: "TRAILING_STOP_CONFIRM_CYCLES",
+    kind: "number",
+    field: "trailingStopConfirmCycles",
+    min: 1,
+    max: 10,
+  },
+  {
+    envKey: "VOLATILITY_EXIT_STDDEV",
+    kind: "number",
+    field: "volatilityExitStddev",
+    min: 0,
+  },
+  {
+    envKey: "ENTRY_RANGE_HALF_WIDTH_BINS",
+    kind: "number",
+    field: "entryRangeHalfWidthBins",
+    min: 0,
+    max: 200,
+  },
+  {
+    envKey: "MAX_REBALANCE_RANGE_BINS",
+    kind: "number",
+    field: "maxRebalanceRangeBins",
+    min: 1,
+  },
+  { envKey: "OOR_COOLDOWN_MS", kind: "number", field: "oorCooldownMs", min: 0 },
+  {
+    envKey: "OOR_GRACE_PERIOD_CYCLES",
+    kind: "number",
+    field: "oorGracePeriodCycles",
+    min: 1,
+  },
+  {
+    envKey: "FEE_CLAIM_INTERVAL_MS",
+    kind: "number",
+    field: "feeClaimIntervalMs",
+    min: 60_000,
+  },
+  {
+    envKey: "MIN_REBALANCE_INTERVAL_MS",
+    kind: "number",
+    field: "minRebalanceIntervalMs",
+    min: 0,
+  },
+  { envKey: "IDLE_REDEPLOY_ENABLED", kind: "boolean", field: "idleRedeployEnabled" },
+  {
+    envKey: "IDLE_REDEPLOY_THRESHOLD_USD",
+    kind: "number",
+    field: "idleRedeployThresholdUsd",
+    min: 0,
+  },
+  {
+    envKey: "IDLE_REDEPLOY_MAX_SIZE_USD",
+    kind: "number",
+    field: "idleRedeployMaxSizeUsd",
+    min: 0,
   },
 ];
 


### PR DESCRIPTION
## What

Operational hardening that the market-scan rollout exposed — three gaps:

### 1. `prism setup` no longer wipes your `.env`
Re-running setup used to **replace the entire .env** with a fixed ~20-var template (backup only), silently dropping `WATCHLIST_POOLS`, `MARKET_SCAN_*`, `AGENTIC_MODE` and any custom comment. New `cli/env-merge.ts`:
- preserves unknown keys + comments verbatim, in place
- updates managed keys with the fresh wizard values
- **never wipes a non-empty user value with an empty wizard default** (re-running setup with an empty WATCHLIST_POOLS keeps your pools)
- appends newly-introduced defaults under a `Managed by prism setup` banner

`postinstall` was already a safe no-op on existing `.env` and `prism update` already preserves user data — this closes the last replace path. Install/update behavior is now consistently **generate-if-missing / merge-if-present**.

### 2. New tuning knobs are runtime-tunable via DB (no restart)
The DB-config sidecar (precedence: **env var > DB row `config.<KEY>` > default**) already existed for 27 keys with `prism config set/get/list/delete`. This adds the market-scan + churn knobs so an operator **or an agent** can change them live:
`MARKET_SCAN_ENABLED`, `MARKET_SCAN_REFRESH_INTERVAL_MS`, `MARKET_SCAN_UNIVERSE_PAGES`, `MARKET_SCAN_MIN_TVL_USD`, `MARKET_SCAN_MIN_FEE_APR`, `MARKET_SCAN_TOP_K`, `MARKET_SCAN_MAX_POOLS`, `MARKET_SCAN_MIN_HOLDERS`, `MARKET_SCAN_MIN_BIN_STEP`, `MARKET_SCAN_MAX_BIN_STEP`, `DUST_EXIT_USD`, `TRAILING_STOP_CONFIRM_CYCLES`, `VOLATILITY_EXIT_STDDEV`, `ENTRY_RANGE_HALF_WIDTH_BINS`, `MAX_REBALANCE_RANGE_BINS`, `OOR_COOLDOWN_MS`, `OOR_GRACE_PERIOD_CYCLES`, `FEE_CLAIM_INTERVAL_MS`, `MIN_REBALANCE_INTERVAL_MS`, `IDLE_REDEPLOY_*`.
Same typed parsing + clamping as env; secrets/paths/RPC stay non-overridable by design.

### 3. `prism doctor` validates the config, not just the file
New `config` check actually **loads the full AppConfig** (env + .env + DB sidecar, every numeric clamp and structured warning) — broken values now surface as a `FAIL` before engine startup, alongside the existing RPC/wallet/registration/directory/memory checks.

### 4. `.env.example` documents the new vars
`DUST_EXIT_USD`, `TRAILING_STOP_CONFIRM_CYCLES` and the full `MARKET_SCAN_*` block.

## Tests
- `bench/env-merge.test.ts`: preserve/append/no-wipe/clear/parse
- `bench/db-config.test.ts`: registry coverage + clamp bounds for the new keys
- doctor verified locally: `[pass] config: Config loaded (scan=…, maxPositions=…, marketScan=…)`
- 1501 pass; lint, format, builds clean.

## Summary by Sourcery

Harden Prism operational setup and runtime configuration by making .env preservation safer, enabling DB-based tuning of new market-scan and churn controls, and extending doctor checks to validate the full loaded config.

New Features:
- Allow market-scan and post-#157 tuning knobs to be overridden live via the existing DB-config mechanism without restarts.
- Add a merge-preserving .env writer to prism setup so re-running the wizard updates managed keys without wiping user-defined configuration or comments.
- Introduce a doctor config check that loads and validates the full AppConfig, surfacing invalid configuration before engine startup.

Enhancements:
- Extend DB config registry with bounds for new market-scan and churn-related parameters to ensure safe numeric clamping.
- Document new tuning variables such as market-scan settings and dust/churn controls in the .env.example template.

Tests:
- Add env-merge tests to guarantee .env preservation semantics and intentional clears for managed keys.
- Expand db-config tests to cover the new runtime-tunable keys and verify clamping behavior for market-scan overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable market scanning with controls for refresh rates, pool selection, TVL, fee APR, holders, ranking, and bin-step limits.
  * Added tuning options for dust exits and trailing-stop confirmations.
  * Configuration diagnostics now report whether settings load successfully.

* **Improvements**
  * Setup preserves existing `.env` values, comments, and custom entries while updating managed settings.
  * Added validation and bounds for database-overridable strategy settings.
  * Configuration changes now indicate when an engine restart is required.

* **Tests**
  * Added coverage for environment merging, configuration overrides, validation, and diagnostic checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->