### PR TITLE
feat(engine): agent decision context carries targeted position state

### DIFF
--- a/bench/agent-service.test.ts
+++ b/bench/agent-service.test.ts
@@ -4,6 +4,7 @@ import {
   parseResponse,
   validateOverride,
   AgentNoOp,
+  buildPrompt,
   buildProposalPrompt,
   selectTransport,
   connectReviewTransport,
@@ -13,6 +14,7 @@ import { GatewayTransport } from "../engine/gateway-transport.js";
 import type { AgentDecision } from "../engine/types.js";
 import { AUTONOMOUS_TOKEN_CONFIG_DEFAULTS, type AppConfig } from "../engine/config-service.js";
 import type {
+  AgentPositionState,
   AgentRuntimeContext,
   AgentRuntimeDetection,
   AgentRuntimeTransport,
@@ -252,34 +254,53 @@ describe("AgentNoOp", () => {
   });
 });
 
-describe("buildProposalPrompt", () => {
-  const makeCtx = (decision: AgentDecision): AgentRuntimeContext =>
-    ({
-      decision,
-      pool: {
-        address: decision.poolAddress,
-        tokenXSymbol: "SOL",
-        tokenYSymbol: "USDC",
-        tvlUsd: 100_000,
-        volume24hUsd: 50_000,
-        fees24hUsd: 500,
-        apr: 12,
-      },
-      metrics: {
-        feeIlRatio: 1.5,
-        volumeAuthenticity: 0.9,
-        binUtilization: 0.5,
-        tvlVelocity: 0.01,
-      },
-      warnings: [],
-      recentDecisions: [],
-      hasOpenPosition: decision.action === "REBALANCE" || decision.action === "EXIT",
-    }) as unknown as AgentRuntimeContext;
+const makePromptCtx = (decision: AgentDecision): AgentRuntimeContext =>
+  ({
+    decision,
+    pool: {
+      address: decision.poolAddress,
+      tokenXSymbol: "SOL",
+      tokenYSymbol: "USDC",
+      tvlUsd: 100_000,
+      volume24hUsd: 50_000,
+      fees24hUsd: 500,
+      apr: 12,
+    },
+    metrics: {
+      feeIlRatio: 1.5,
+      volumeAuthenticity: 0.9,
+      binUtilization: 0.5,
+      tvlVelocity: 0.01,
+    },
+    warnings: [],
+    recentDecisions: [],
+    hasOpenPosition: decision.action === "REBALANCE" || decision.action === "EXIT",
+  }) as unknown as AgentRuntimeContext;
 
+const makePositionState = (overrides: Partial<AgentPositionState> = {}): AgentPositionState => ({
+  positionId: "pos-1",
+  valueUsd: 1200,
+  depositedUsd: 1000,
+  unrealizedPnlUsd: 250,
+  feesClaimedUsd: 50,
+  rewardsClaimedUsd: 0,
+  outOfRangeSinceMs: null,
+  oorCycleCount: 0,
+  hoursHeld: 3.5,
+  activeBinId: 100,
+  lowerBinId: 95,
+  upperBinId: 110,
+  entryPriceUsd: 1.2,
+  highestValueUsd: 1300,
+  lastRebalanceAtMs: 0,
+  ...overrides,
+});
+
+describe("buildProposalPrompt", () => {
   it("embeds the current ENTER size in the decision block and response template", () => {
     const prompt = buildProposalPrompt(
       makeDecision({ action: "ENTER", positionSizeUsd: 2_500 }),
-      makeCtx(makeDecision({ action: "ENTER", positionSizeUsd: 2_500 })),
+      makePromptCtx(makeDecision({ action: "ENTER", positionSizeUsd: 2_500 })),
     );
     expect(prompt).toContain("Position Size: $2500");
     expect(prompt).toContain('"positionSizeUsd": 2500');
@@ -291,7 +312,7 @@ describe("buildProposalPrompt", () => {
       action: "REBALANCE",
       rebalanceParams: { newLowerBinId: 500, newUpperBinId: 520, slippageBps: 50 },
     });
-    const prompt = buildProposalPrompt(decision, makeCtx(decision));
+    const prompt = buildProposalPrompt(decision, makePromptCtx(decision));
     expect(prompt).toContain("Bin Range: 500 to 520");
     expect(prompt).toContain('"lowerBinId": 500, "upperBinId": 520');
     expect(prompt).not.toContain('"lowerBinId": 100, "upperBinId": 110');
@@ -299,7 +320,7 @@ describe("buildProposalPrompt", () => {
 
   it("falls back to placeholder values when the decision has no executable params", () => {
     const decision = makeDecision({ action: "HOLD" });
-    const prompt = buildProposalPrompt(decision, makeCtx(decision));
+    const prompt = buildProposalPrompt(decision, makePromptCtx(decision));
     expect(prompt).not.toContain("Position Size:");
     expect(prompt).not.toContain("Bin Range:");
     expect(prompt).toContain('"positionSizeUsd": 100');
@@ -308,7 +329,7 @@ describe("buildProposalPrompt", () => {
 
   it("limits allowed actions for a deterministic HOLD decision with an open position", () => {
     const decision = makeDecision({ action: "HOLD" });
-    const ctx = { ...makeCtx(decision), hasOpenPosition: true };
+    const ctx = { ...makePromptCtx(decision), hasOpenPosition: true };
     const prompt = buildProposalPrompt(decision, ctx);
     expect(prompt).toContain("You may propose only: HOLD, REBALANCE, EXIT.");
     expect(prompt).toContain("allowed actions: HOLD, REBALANCE, EXIT");
@@ -317,7 +338,7 @@ describe("buildProposalPrompt", () => {
 
   it("limits allowed actions for a deterministic HOLD decision without an open position", () => {
     const decision = makeDecision({ action: "HOLD" });
-    const ctx = { ...makeCtx(decision), hasOpenPosition: false };
+    const ctx = { ...makePromptCtx(decision), hasOpenPosition: false };
     const prompt = buildProposalPrompt(decision, ctx);
     expect(prompt).toContain("You may propose only: HOLD.");
     expect(prompt).toContain("allowed actions: HOLD");
@@ -327,7 +348,7 @@ describe("buildProposalPrompt", () => {
 
   it("limits allowed actions for a deterministic EXIT decision", () => {
     const decision = makeDecision({ action: "EXIT" });
-    const prompt = buildProposalPrompt(decision, makeCtx(decision));
+    const prompt = buildProposalPrompt(decision, makePromptCtx(decision));
     expect(prompt).toContain("You may propose only: EXIT.");
     expect(prompt).toContain("allowed actions: EXIT");
     expect(prompt).toContain('"action": "EXIT"');
@@ -336,11 +357,74 @@ describe("buildProposalPrompt", () => {
 
   it("allows only executable actions for a deterministic ENTER decision", () => {
     const decision = makeDecision({ action: "ENTER", positionSizeUsd: 1_000 });
-    const prompt = buildProposalPrompt(decision, makeCtx(decision));
+    const prompt = buildProposalPrompt(decision, makePromptCtx(decision));
     expect(prompt).toContain("You may propose only: HOLD, ENTER.");
     expect(prompt).toContain("allowed actions: HOLD, ENTER");
     expect(prompt).toContain('"action": "ENTER"');
     expect(prompt).not.toContain("allowed actions: HOLD, REBALANCE, EXIT, ENTER");
+  });
+
+  it("embeds the POSITION block when the decision targets an open position", () => {
+    const decision = makeDecision({ action: "REBALANCE" });
+    const ctx = {
+      ...makePromptCtx(decision),
+      hasOpenPosition: true,
+      position: makePositionState(),
+    };
+    const prompt = buildProposalPrompt(decision, ctx);
+    expect(prompt).toContain("POSITION:");
+    expect(prompt).toContain("Value: $1200.00 (deposited $1000.00)");
+    expect(prompt).toContain("Unrealized PnL: +$250.00");
+    expect(prompt).toContain("fees claimed $50.00, rewards $0.00");
+    expect(prompt).toContain("In range: yes");
+    expect(prompt).toContain("Age: 3.5h | range: bins 95..110 (active 100)");
+    expect(prompt).toContain("Base EXIT/REBALANCE proposals on the POSITION state below.");
+  });
+
+  it("shows out-of-range and negative-PnL state in the POSITION block", () => {
+    const decision = makeDecision({ action: "EXIT" });
+    const ctx = {
+      ...makePromptCtx(decision),
+      hasOpenPosition: true,
+      position: makePositionState({
+        valueUsd: 800,
+        unrealizedPnlUsd: -150,
+        outOfRangeSinceMs: Date.now() - 7_200_000,
+        oorCycleCount: 2,
+      }),
+    };
+    const prompt = buildProposalPrompt(decision, ctx);
+    expect(prompt).toContain("Unrealized PnL: −$150.00");
+    expect(prompt).toContain("In range: NO — out of range 2.0h (2 OOR cycle(s))");
+  });
+
+  it("omits the POSITION block for positionless decisions", () => {
+    const decision = makeDecision({ action: "ENTER", positionSizeUsd: 1_000 });
+    const prompt = buildProposalPrompt(decision, makePromptCtx(decision));
+    expect(prompt).not.toContain("POSITION:");
+  });
+});
+
+describe("buildPrompt (veto overlay)", () => {
+  it("embeds the POSITION block for position-targeted decisions", () => {
+    const decision = makeDecision({ action: "EXIT" });
+    const ctx = {
+      ...makePromptCtx(decision),
+      hasOpenPosition: true,
+      position: makePositionState(),
+    };
+    const prompt = buildPrompt(decision, ctx);
+    expect(prompt).toContain("POSITION:");
+    expect(prompt).toContain("Unrealized PnL: +$250.00");
+    expect(prompt).toContain(
+      "Base EXIT reviews on the position's PnL and out-of-range state below.",
+    );
+  });
+
+  it("omits the POSITION block for positionless decisions", () => {
+    const decision = makeDecision({ action: "HOLD" });
+    const prompt = buildPrompt(decision, makePromptCtx(decision));
+    expect(prompt).not.toContain("POSITION:");
   });
 });
 

--- a/bench/agent-service.test.ts
+++ b/bench/agent-service.test.ts
@@ -286,6 +286,7 @@ const makePositionState = (overrides: Partial<AgentPositionState> = {}): AgentPo
   rewardsClaimedUsd: 0,
   outOfRangeSinceMs: null,
   oorCycleCount: 0,
+  hoursOutOfRange: null,
   hoursHeld: 3.5,
   activeBinId: 100,
   lowerBinId: 95,
@@ -390,6 +391,7 @@ describe("buildProposalPrompt", () => {
         valueUsd: 800,
         unrealizedPnlUsd: -150,
         outOfRangeSinceMs: Date.now() - 7_200_000,
+        hoursOutOfRange: 2,
         oorCycleCount: 2,
       }),
     };
@@ -425,6 +427,27 @@ describe("buildPrompt (veto overlay)", () => {
     const decision = makeDecision({ action: "HOLD" });
     const prompt = buildPrompt(decision, makePromptCtx(decision));
     expect(prompt).not.toContain("POSITION:");
+  });
+
+  it("shows out-of-range and negative-PnL state on the safety-critical EXIT review", () => {
+    const decision = makeDecision({ action: "EXIT" });
+    const ctx = {
+      ...makePromptCtx(decision),
+      hasOpenPosition: true,
+      position: makePositionState({
+        valueUsd: 800,
+        unrealizedPnlUsd: -150,
+        outOfRangeSinceMs: Date.now() - 7_200_000,
+        hoursOutOfRange: 2,
+        oorCycleCount: 2,
+      }),
+    };
+    const prompt = buildPrompt(decision, ctx);
+    expect(prompt).toContain("Unrealized PnL: −$150.00");
+    expect(prompt).toContain("In range: NO — out of range 2.0h (2 OOR cycle(s))");
+    expect(prompt).toContain(
+      "Base EXIT reviews on the position's PnL and out-of-range state below.",
+    );
   });
 });
 

--- a/bench/decision-loop-exit.test.ts
+++ b/bench/decision-loop-exit.test.ts
@@ -33,6 +33,7 @@ import {
   type MeteoraPoolStats,
 } from "../engine/services.js";
 import type { PoolSnapshot } from "../engine/types.js";
+import type { AgentRuntimeContext } from "../engine/agent-transport.js";
 import { defaultAppConfig, makePool, makeBinArray, makePosition } from "./helpers.js";
 import { stringifySafe } from "../engine/bigint-json.js";
 
@@ -568,5 +569,66 @@ describe("veto deadline bounds the entire transport operation (P1)", () => {
     expect(wallMs, "cycle cost is the veto budget (~300ms), not the 60s stall").toBeLessThan(
       10_000,
     );
+  }, 15_000);
+});
+
+// ─── Wave 20: agent position context wiring ──────────────────────────────────
+
+describe("agent position context wiring", () => {
+  const POOL = "PoolAgentPosCtx11111111111111111111111111111";
+
+  it("passes the targeted position state to the sync-proposal advisor", async () => {
+    let capturedContext: AgentRuntimeContext | undefined;
+    const layer = makeTestLayer({
+      adapter: makeAdapter({ [POOL]: makePool({ address: POOL, tvlUsd: 60_000 }) }),
+      configOverrides: {
+        watchlistPools: [POOL],
+        tvlDropExitPct: 0.3,
+        agentiveMode: true,
+        agentProposalMode: "full",
+        agentProposalTimeoutMs: 300,
+      },
+      agent: {
+        ...AgentNoOp,
+        getStatus: () =>
+          Effect.succeed({ connected: true, transport: "acp", lastPromptAt: null, errorCount: 0 }),
+        enhanceDecision: (decision, context) => {
+          capturedContext = context;
+          return Effect.succeed(null);
+        },
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(
+        makePosition({ poolAddress: POOL, depositedUsd: 1_000, currentValueUsd: 1_000 }),
+      );
+      yield* db.saveSnapshot({
+        poolAddress: POOL,
+        timestamp: Date.now() - 600_000,
+        activeBinId: 5000,
+        tvlUsd: 100_000, // → -40% vs current 60k (threshold 30%)
+        volume24hUsd: 30_000,
+        fees24hUsd: 300,
+        apr: 60,
+        currentPrice: 150,
+        binStep: 10,
+        tokenXSymbol: "SOL",
+        tokenYSymbol: "USDC",
+        binArray: makeBinArray(),
+      });
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+    });
+    await Effect.runPromise(Effect.provide(test, layer) as Effect.Effect<unknown, unknown, never>);
+
+    expect(capturedContext, "sync advisor must be consulted for the EXIT").toBeDefined();
+    expect(capturedContext?.position, "position state must reach the advisor").toBeDefined();
+    expect(capturedContext?.position?.positionId).toBeDefined();
+    expect(capturedContext?.position?.depositedUsd).toBe(1_000);
+    expect(capturedContext?.position?.valueUsd).toBe(1_000);
+    // value + fees + rewards − deposited = 0
+    expect(capturedContext?.position?.unrealizedPnlUsd).toBe(0);
+    expect(capturedContext?.position?.hoursHeld).toBeGreaterThanOrEqual(0);
   }, 15_000);
 });

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -89,7 +89,7 @@ function formatRuntimeContext(ctx: AgentRuntimeContext): {
           `  Unrealized PnL: ${position.unrealizedPnlUsd >= 0 ? "+" : "−"}$${Math.abs(position.unrealizedPnlUsd).toFixed(2)} (fees claimed $${position.feesClaimedUsd.toFixed(2)}, rewards $${position.rewardsClaimedUsd.toFixed(2)})`,
           position.outOfRangeSinceMs === null
             ? "  In range: yes"
-            : `  In range: NO — out of range ${((Date.now() - position.outOfRangeSinceMs) / 3_600_000).toFixed(1)}h (${position.oorCycleCount} OOR cycle(s))`,
+            : `  In range: NO — out of range ${position.hoursOutOfRange === null ? "?" : position.hoursOutOfRange.toFixed(1)}h (${position.oorCycleCount} OOR cycle(s))`,
           `  Age: ${position.hoursHeld.toFixed(1)}h | range: bins ${position.lowerBinId}..${position.upperBinId} (active ${position.activeBinId})`,
           `  Entry price: ${position.entryPriceUsd === null ? "n/a" : `$${position.entryPriceUsd.toFixed(6)}`} | peak value: ${position.highestValueUsd === null ? "n/a" : `$${position.highestValueUsd.toFixed(2)}`}`,
           `  Last rebalance: ${position.lastRebalanceAtMs === 0 ? "never" : new Date(position.lastRebalanceAtMs).toISOString()}`,

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -61,8 +61,9 @@ export const AgentNoOp: AgentApi = {
 function formatRuntimeContext(ctx: AgentRuntimeContext): {
   warningsBlock: string;
   decisionsBlock: string;
+  positionBlock: string;
 } {
-  const { warnings, recentDecisions } = ctx;
+  const { warnings, recentDecisions, position } = ctx;
   const warningsBlock =
     warnings.length > 0
       ? warnings.map((w) => `  - [${w.category}] ${w.content}`).join("\n")
@@ -79,12 +80,27 @@ function formatRuntimeContext(ctx: AgentRuntimeContext): {
           .join("\n")
       : "  (none)";
 
-  return { warningsBlock, decisionsBlock };
+  const positionBlock =
+    position === undefined
+      ? ""
+      : [
+          "POSITION:",
+          `  Value: $${position.valueUsd.toFixed(2)} (deposited $${position.depositedUsd.toFixed(2)})`,
+          `  Unrealized PnL: ${position.unrealizedPnlUsd >= 0 ? "+" : "−"}$${Math.abs(position.unrealizedPnlUsd).toFixed(2)} (fees claimed $${position.feesClaimedUsd.toFixed(2)}, rewards $${position.rewardsClaimedUsd.toFixed(2)})`,
+          position.outOfRangeSinceMs === null
+            ? "  In range: yes"
+            : `  In range: NO — out of range ${((Date.now() - position.outOfRangeSinceMs) / 3_600_000).toFixed(1)}h (${position.oorCycleCount} OOR cycle(s))`,
+          `  Age: ${position.hoursHeld.toFixed(1)}h | range: bins ${position.lowerBinId}..${position.upperBinId} (active ${position.activeBinId})`,
+          `  Entry price: ${position.entryPriceUsd === null ? "n/a" : `$${position.entryPriceUsd.toFixed(6)}`} | peak value: ${position.highestValueUsd === null ? "n/a" : `$${position.highestValueUsd.toFixed(2)}`}`,
+          `  Last rebalance: ${position.lastRebalanceAtMs === 0 ? "never" : new Date(position.lastRebalanceAtMs).toISOString()}`,
+        ].join("\n");
+
+  return { warningsBlock, decisionsBlock, positionBlock };
 }
 
-function buildPrompt(decision: AgentDecision, ctx: AgentRuntimeContext): string {
+export function buildPrompt(decision: AgentDecision, ctx: AgentRuntimeContext): string {
   const { pool, metrics } = ctx;
-  const { warningsBlock, decisionsBlock } = formatRuntimeContext(ctx);
+  const { warningsBlock, decisionsBlock, positionBlock } = formatRuntimeContext(ctx);
 
   return `You are a liquidity pool risk overlay. Review the deterministic agent's decision and optionally override it.
 
@@ -95,7 +111,7 @@ RULES (strict — you must follow them):
 - You may NEVER change HOLD/ENTER/REBALANCE into EXIT.
 - You may NEVER change EXIT into HOLD or any other action.
 - If the decision looks reasonable, return the same action and confidence.
-
+${positionBlock === "" ? "" : "- Base EXIT reviews on the position's PnL and out-of-range state below.\n"}
 DECISION TO REVIEW:
 Action: ${decision.action}
 Confidence: ${decision.confidence.toFixed(2)}
@@ -105,7 +121,7 @@ TVL: $${pool.tvlUsd.toFixed(0)}
 24h Volume: $${pool.volume24hUsd.toFixed(0)}
 24h Fees: $${pool.fees24hUsd.toFixed(0)}
 APR: ${pool.apr.toFixed(2)}%
-
+${positionBlock === "" ? "" : `\n${positionBlock}`}
 METRICS:
 - Fee/IL Ratio: ${metrics.feeIlRatio.toFixed(2)}
 - Volume Authenticity: ${metrics.volumeAuthenticity.toFixed(2)}
@@ -125,7 +141,7 @@ Respond with JSON only:
 
 export function buildProposalPrompt(decision: AgentDecision, ctx: AgentRuntimeContext): string {
   const { pool, metrics } = ctx;
-  const { warningsBlock, decisionsBlock } = formatRuntimeContext(ctx);
+  const { warningsBlock, decisionsBlock, positionBlock } = formatRuntimeContext(ctx);
   const currentParamsBlock = [
     decision.positionSizeUsd !== undefined
       ? `Position Size: $${decision.positionSizeUsd.toFixed(0)}`
@@ -160,7 +176,7 @@ RULES (strict — you must follow them):
 - When echoing the engine's action, reuse the current executable values shown below — do not invent new ones.
 - Do not propose actions for pools outside the current context.
 - If the engine's decision is already optimal, return the same action and confidence.
-
+${positionBlock === "" ? "" : "- Base EXIT/REBALANCE proposals on the POSITION state below.\n"}
 DECISION TO REVIEW:
 Action: ${decision.action}
 Confidence: ${decision.confidence.toFixed(2)}
@@ -170,7 +186,7 @@ TVL: $${pool.tvlUsd.toFixed(0)}
 24h Volume: $${pool.volume24hUsd.toFixed(0)}
 24h Fees: $${pool.fees24hUsd.toFixed(0)}
 APR: ${pool.apr.toFixed(2)}%
-
+${positionBlock === "" ? "" : `\n${positionBlock}`}
 METRICS:
 - Fee/IL Ratio: ${metrics.feeIlRatio.toFixed(2)}
 - Volume Authenticity: ${metrics.volumeAuthenticity.toFixed(2)}

--- a/engine/agent-transport.ts
+++ b/engine/agent-transport.ts
@@ -17,6 +17,30 @@ export interface AgentRuntimeContext {
   readonly recentDecisions: ReadonlyArray<DecisionRecord>;
   /** Whether the pool currently has an open position; used to restrict proposal actions. */
   readonly hasOpenPosition: boolean;
+  /** The targeted open position's state, when the decision acts on one. */
+  readonly position?: AgentPositionState;
+}
+
+/** Position state shown to the advisor for decisions that target an open
+ *  position (EXIT/REBALANCE/HOLD). Undefined for positionless decisions
+ *  (ENTER, default HOLD). Mirrors the checkin's per-position vocabulary so
+ *  transports need no second schema. */
+export interface AgentPositionState {
+  readonly positionId: string;
+  readonly valueUsd: number;
+  readonly depositedUsd: number;
+  readonly unrealizedPnlUsd: number;
+  readonly feesClaimedUsd: number;
+  readonly rewardsClaimedUsd: number;
+  readonly outOfRangeSinceMs: number | null;
+  readonly oorCycleCount: number;
+  readonly hoursHeld: number;
+  readonly activeBinId: number;
+  readonly lowerBinId: number;
+  readonly upperBinId: number;
+  readonly entryPriceUsd: number | null;
+  readonly highestValueUsd: number | null;
+  readonly lastRebalanceAtMs: number;
 }
 
 export interface AgentRuntimeResponse {

--- a/engine/agent-transport.ts
+++ b/engine/agent-transport.ts
@@ -34,6 +34,8 @@ export interface AgentPositionState {
   readonly rewardsClaimedUsd: number;
   readonly outOfRangeSinceMs: number | null;
   readonly oorCycleCount: number;
+  /** Hours out of range at context-construction time (null when in range). */
+  readonly hoursOutOfRange: number | null;
   readonly hoursHeld: number;
   readonly activeBinId: number;
   readonly lowerBinId: number;

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -303,7 +303,11 @@ export function toAgentPositionState(pos: PositionRecord, now: number): AgentPos
     rewardsClaimedUsd: pos.cumulativeRewardsClaimedUsd,
     outOfRangeSinceMs: pos.outOfRangeSince,
     oorCycleCount: pos.oorCycleCount,
-    hoursHeld: (now - pos.timestamp) / 3_600_000,
+    hoursOutOfRange:
+      pos.outOfRangeSince === null ? null : Math.max(0, now - pos.outOfRangeSince) / 3_600_000,
+    // Clamp against future timestamps (clock skew) — mirrors pnl.ts's
+    // Math.max(0, nowMs - openedAtMs).
+    hoursHeld: Math.max(0, now - pos.timestamp) / 3_600_000,
     activeBinId: pos.activeBinId,
     lowerBinId: pos.lowerBinId,
     upperBinId: pos.upperBinId,
@@ -6226,6 +6230,9 @@ export const program = Effect.gen(function* () {
                       .getRecentDecisions(10)
                       .pipe(Effect.catchAll(() => Effect.succeed([]))),
                     hasOpenPosition,
+                    ...(pos !== undefined
+                      ? { position: toAgentPositionState(pos, Date.now()) }
+                      : {}),
                   })
                   .pipe(
                     Effect.catchAll((err) => {

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -137,7 +137,11 @@ import type {
   TokenCandidateRecord,
 } from "./types.js";
 import { isMeasuredStatsSource } from "./types.js";
-import type { AgentRuntimeAlert, AgentRuntimeCheckin } from "./agent-transport.js";
+import type {
+  AgentPositionState,
+  AgentRuntimeAlert,
+  AgentRuntimeCheckin,
+} from "./agent-transport.js";
 import { randomUUID } from "crypto";
 import { AgentLive, AgentNoOp } from "./agent-service.js";
 import { createLogger } from "./logger.js";
@@ -280,6 +284,33 @@ export function shouldHoldForSupervisedApproval(
     !approvedProposalApplied &&
     (action === "ENTER" || action === "REBALANCE")
   );
+}
+
+/** Derive the advisor-facing position snapshot for a decision that targets an
+ *  open position. Unrealized PnL mirrors pnl.ts:
+ *  value + fees claimed + rewards claimed − deposited (cost basis). */
+export function toAgentPositionState(pos: PositionRecord, now: number): AgentPositionState {
+  return {
+    positionId: pos.positionId,
+    valueUsd: pos.currentValueUsd,
+    depositedUsd: pos.depositedUsd,
+    unrealizedPnlUsd:
+      pos.currentValueUsd +
+      pos.cumulativeFeesClaimedUsd +
+      pos.cumulativeRewardsClaimedUsd -
+      pos.depositedUsd,
+    feesClaimedUsd: pos.cumulativeFeesClaimedUsd,
+    rewardsClaimedUsd: pos.cumulativeRewardsClaimedUsd,
+    outOfRangeSinceMs: pos.outOfRangeSince,
+    oorCycleCount: pos.oorCycleCount,
+    hoursHeld: (now - pos.timestamp) / 3_600_000,
+    activeBinId: pos.activeBinId,
+    lowerBinId: pos.lowerBinId,
+    upperBinId: pos.upperBinId,
+    entryPriceUsd: pos.entryPriceUsd,
+    highestValueUsd: pos.highestValueUsd,
+    lastRebalanceAtMs: pos.lastRebalanceAt,
+  };
 }
 
 // Consume an applied queued proposal only once its outcome is final: after
@@ -6073,6 +6104,7 @@ export const program = Effect.gen(function* () {
                   .getRecentDecisions(10)
                   .pipe(Effect.catchAll(() => Effect.succeed([]))),
                 hasOpenPosition,
+                ...(pos !== undefined ? { position: toAgentPositionState(pos, Date.now()) } : {}),
               })
               .pipe(
                 // Bound the ENTIRE veto op by the veto deadline, CONNECT included.


### PR DESCRIPTION
## Summary

Closes #160. The per-decision agent overlay was blind to position state: `AgentRuntimeContext` exposed only a `hasOpenPosition` boolean while advisors are allowed to propose EXIT/REBALANCE in `full` mode. They could not see PnL, out-of-range status, fees claimed, or position age — exactly the facts EXIT/rebalance advice needs.

## Changes

- **engine/agent-transport.ts** — new `AgentPositionState` (value, deposited, unrealized PnL, fees/rewards claimed, OOR status, age, range, entry price, peak, last rebalance), optional `position` field on `AgentRuntimeContext`, mirroring the checkin's vocabulary.
- **engine/agent-service.ts** — `POSITION:` block rendered in both `buildPrompt` (veto) and `buildProposalPrompt` (full/suggest) when a position is present, with a rule line grounding EXIT/REBALANCE advice on it. `buildPrompt` exported for testing.
- **engine/program.ts** — `toAgentPositionState()` derives the snapshot from the in-scope `PositionRecord` (PnL formula matches pnl.ts: value + fees + rewards − deposited); populated at both the veto and sync-proposal call sites; undefined for positionless decisions (ENTER, default HOLD).
- **bench/agent-service.test.ts** — prompt tests: POSITION block renders value/PnL/range/age, out-of-range + negative-PnL rendering, omission for positionless decisions; veto prompt variants.

## Verification

- `bun run lint` clean (tsc + oxlint)
- `bun run test`: 1516/1516 pass
- `bun run format:check` clean

No behavior change without `AGENTIC_MODE`; `AgentNoOp` and the supervised queue path are untouched.

## Summary by Sourcery

Expose detailed targeted position state to agent prompts so EXIT/REBALANCE decisions can be grounded in current PnL and range status.

New Features:
- Include an optional position snapshot on AgentRuntimeContext with value, PnL, range, and lifecycle metadata for targeted positions.
- Render a POSITION block in proposal and veto prompts when a decision acts on an open position, with guidance to base EXIT/REBALANCE reviews on it.

Enhancements:
- Derive advisor-facing position snapshots from PositionRecord via a shared toAgentPositionState helper to keep PnL and lifecycle calculations consistent.
- Expand agent-service tests to cover POSITION block rendering, including in-range, out-of-range, and positionless scenarios, and expose buildPrompt for testability.

Tests:
- Add prompt-level tests validating POSITION block content and omission in both proposal and veto overlays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent decisions now include detailed information about targeted open positions, including value, deposits, profit and loss, fees, rewards, range status, pricing, and timing.
  - Proposal and veto guidance now incorporates available position details for more informed exit and rebalance decisions.

- **Bug Fixes**
  - Improved handling of positions with negative profit and loss, out-of-range status, and missing position data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->