### PR TITLE
feat(engine): sync advisor proposals get latency skip, outer deadline, no slow-model penalty

### DIFF
--- a/bench/agent-service.test.ts
+++ b/bench/agent-service.test.ts
@@ -7,6 +7,7 @@ import {
   buildProposalPrompt,
   selectTransport,
   connectReviewTransport,
+  LatencyWindow,
 } from "../engine/agent-service.js";
 import { AcpTransport } from "../engine/acp-transport.js";
 import { GatewayTransport } from "../engine/gateway-transport.js";
@@ -249,6 +250,62 @@ describe("AgentNoOp", () => {
     const status = await Effect.runPromise(AgentNoOp.getStatus());
     expect(status.connected).toBe(false);
     expect(status.transport).toBeNull();
+  });
+
+  it("shouldSkipSyncProposal returns false (no-op never skips)", async () => {
+    expect(await Effect.runPromise(AgentNoOp.shouldSkipSyncProposal())).toBe(false);
+  });
+});
+
+describe("LatencyWindow", () => {
+  // Budget 1000ms → skip threshold 950ms; skip needs ≥3 fresh samples of
+  // which ≥2 are individually slow.
+  const makeWindow = (): LatencyWindow =>
+    new LatencyWindow({
+      budgetMs: 1000,
+      windowSize: 20,
+      minSamples: 3,
+      minSlowSamples: 2,
+      sampleMaxAgeMs: 60_000,
+    });
+
+  it("does not skip before enough fresh samples exist", () => {
+    const w = makeWindow();
+    w.record(990, 1_000);
+    expect(w.shouldSkip(1_000).skip).toBe(false);
+    w.record(990, 2_000);
+    expect(w.shouldSkip(2_000).skip).toBe(false);
+  });
+
+  it("engages the skip when the fresh-window p95 exceeds 95% of the budget", () => {
+    const w = makeWindow();
+    for (let i = 1; i <= 3; i++) w.record(990, i * 1_000);
+    const result = w.shouldSkip(3_000);
+    expect(result.skip).toBe(true);
+    expect(result.p95Ms).toBe(990);
+    expect(result.slowCount).toBe(3);
+  });
+
+  it("never engages when samples are fast", () => {
+    const w = makeWindow();
+    for (let i = 1; i <= 5; i++) w.record(100, i * 1_000);
+    expect(w.shouldSkip(5_000).skip).toBe(false);
+  });
+
+  it("requires multiple slow samples — a single outlier cannot latch the skip", () => {
+    const w = makeWindow();
+    for (let i = 1; i <= 3; i++) w.record(100, i * 1_000);
+    w.record(990, 4_000);
+    expect(w.shouldSkip(4_000).skip).toBe(false);
+  });
+
+  it("drains and disengages once slow samples age out", () => {
+    const w = makeWindow();
+    for (let i = 1; i <= 3; i++) w.record(990, i * 1_000);
+    expect(w.shouldSkip(3_000).skip).toBe(true);
+    // All samples are older than sampleMaxAgeMs now; the window is empty.
+    expect(w.shouldSkip(3_000 + 60_001).skip).toBe(false);
+    expect(w.shouldSkip(3_000 + 60_001).windowSize).toBe(0);
   });
 });
 

--- a/engine/agent-service.ts
+++ b/engine/agent-service.ts
@@ -24,6 +24,89 @@ const logger = createLogger("AgentService");
 
 const VALID_ACTIONS: ReadonlySet<string> = new Set(["HOLD", "REBALANCE", "EXIT", "ENTER"]);
 
+/** Rolling p95 latency gate for budget-constrained advisor prompts (veto
+ *  reviews and sync proposals). Samples are timestamped and age out, so a
+ *  transient slow period cannot latch the skip on permanently: once the model
+ *  recovers, the window drains and the skip disengages without a restart.
+ *  The skip engages only when BOTH the fresh-window p95 reaches 95% of the
+ *  prompt budget AND enough individual samples are slow — a single timeout
+ *  among quick reviews must not silence the advisor. */
+export class LatencyWindow {
+  private readonly samples: Array<{ readonly latencyMs: number; readonly at: number }> = [];
+
+  constructor(
+    private readonly opts: {
+      /** Prompt budget; the skip engages when p95 >= 95% of it. */
+      readonly budgetMs: number;
+      readonly windowSize?: number;
+      readonly minSamples?: number;
+      readonly minSlowSamples?: number;
+      readonly sampleMaxAgeMs?: number;
+    },
+  ) {}
+
+  private get windowSize(): number {
+    return this.opts.windowSize ?? 20;
+  }
+
+  private get minSamples(): number {
+    return this.opts.minSamples ?? 5;
+  }
+
+  private get minSlowSamples(): number {
+    return this.opts.minSlowSamples ?? 3;
+  }
+
+  private get sampleMaxAgeMs(): number {
+    return this.opts.sampleMaxAgeMs ?? 30 * 60 * 1000;
+  }
+
+  record(latencyMs: number, now: number): void {
+    this.samples.push({ latencyMs, at: now });
+    this.evict(now);
+  }
+
+  private evict(now: number): void {
+    const cutoff = now - this.sampleMaxAgeMs;
+    while (this.samples.length > 0) {
+      const oldest = this.samples[0]!;
+      if (oldest.at < cutoff || this.samples.length > this.windowSize) {
+        this.samples.shift();
+      } else {
+        break;
+      }
+    }
+  }
+
+  /** Whether a prompt should be skipped right now (fail-open), with the
+   *  stats the caller logs when it is. */
+  shouldSkip(now: number): {
+    readonly skip: boolean;
+    readonly p95Ms: number | null;
+    readonly slowCount: number;
+    readonly windowSize: number;
+  } {
+    this.evict(now);
+    const sorted = this.samples.map((s) => s.latencyMs).sort((a, b) => a - b);
+    const p95 =
+      sorted.length === 0
+        ? null
+        : sorted[Math.max(0, Math.min(Math.ceil(sorted.length * 0.95) - 1, sorted.length - 1))]!;
+    const threshold = this.opts.budgetMs * 0.95;
+    const slowCount = this.samples.filter((s) => s.latencyMs >= threshold).length;
+    return {
+      skip:
+        this.samples.length >= this.minSamples &&
+        slowCount >= this.minSlowSamples &&
+        p95 !== null &&
+        p95 >= threshold,
+      p95Ms: p95,
+      slowCount,
+      windowSize: this.samples.length,
+    };
+  }
+}
+
 interface ParsedAgentResponse {
   action?: string;
   confidence?: number;
@@ -32,6 +115,7 @@ interface ParsedAgentResponse {
 
 export const AgentNoOp: AgentApi = {
   enhanceDecision: () => Effect.succeed(null),
+  shouldSkipSyncProposal: () => Effect.succeed(false),
   getPolicy: () =>
     Effect.succeed({
       mode: "veto" as const,
@@ -460,59 +544,17 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
       let lastPromptAt: number | null = null;
       let errorCount = 0;
 
-      // ── Rolling p95 latency tracker for adaptive veto skip ─────────────
-      // Maintains a sliding window of recent prompt latencies, each timestamped
-      // so stale samples age out. When the p95 of the fresh window exceeds the
-      // configured veto timeout AND the window holds enough samples, the veto is
-      // skipped (fail-open with WARN) because the model cannot answer quickly
-      // enough for a budget-constrained yes/no review.
-      //
-      // Liveness: the skip is gated on VETO_SKIP_MIN_SAMPLES fresh samples, so a
-      // single timeout can never disable review permanently. Samples older than
-      // VETO_SAMPLE_MAX_AGE_MS are evicted, so once the model recovers the window
-      // drains, p95 falls back below the threshold, and veto review resumes on
-      // its own without a process restart.
-      const VETO_WINDOW_SIZE = 20;
-      // Do not act on latency history until this many fresh samples have been
-      // collected — prevents one slow veto from latching the skip on.
-      const VETO_SKIP_MIN_SAMPLES = 5;
-      // Require at least this many samples to individually exceed 95% of the
-      // veto budget before the skip can engage. With a nearest-rank p95 and a
-      // partially-filled window the p95 equals the window maximum, so a single
-      // timeout among otherwise quick reviews would otherwise latch the skip on
-      // until that one outlier ages out (up to 30 min). Because skipped calls
-      // record no samples, this count is the only thing that can turn the skip
-      // back off once it has engaged — the slow outliers must all age out
-      // together before the count drops below this threshold again.
-      const VETO_SKIP_MIN_SLOW_SAMPLES = 3;
-      // Fresh samples older than this are evicted, bounding the skip's blind
-      // spot and guaranteeing the window drains after a transient slow period.
-      const VETO_SAMPLE_MAX_AGE_MS = 30 * 60 * 1000;
-      const vetoLatencies: Array<{ latencyMs: number; at: number }> = [];
-
-      function evictStaleVetoSamples(now: number): void {
-        const cutoff = now - VETO_SAMPLE_MAX_AGE_MS;
-        while (vetoLatencies.length > 0) {
-          const oldest = vetoLatencies[0]!;
-          if (oldest.at < cutoff || vetoLatencies.length > VETO_WINDOW_SIZE) {
-            vetoLatencies.shift();
-          } else {
-            break;
-          }
-        }
-      }
-
-      function recordVetoLatency(latencyMs: number): void {
-        vetoLatencies.push({ latencyMs, at: Date.now() });
-        evictStaleVetoSamples(Date.now());
-      }
-
-      function computeP95(values: Array<{ latencyMs: number }>): number | null {
-        if (values.length === 0) return null;
-        const sorted = values.map((v) => v.latencyMs).sort((a, b) => a - b);
-        const idx = Math.ceil(sorted.length * 0.95) - 1;
-        return sorted[Math.max(0, Math.min(idx, sorted.length - 1))]!;
-      }
+      // ── Rolling p95 latency gates for budget-constrained advisor prompts ──
+      // One window per mode (veto budget vs proposal timeout). When the p95 of
+      // fresh samples exceeds 95% of the mode's budget, the prompt is skipped
+      // fail-open (WARN): a slow model must not stall scan cycles. The window
+      // drains automatically once latency recovers, so review resumes without
+      // a restart. Skipped calls record no samples, so the slow samples aging
+      // out together is what turns the skip back off.
+      const vetoLatencyWindow = new LatencyWindow({ budgetMs: config.agentVetoTimeoutMs });
+      const proposalLatencyWindow = new LatencyWindow({
+        budgetMs: config.agentProposalTimeoutMs,
+      });
 
       if (transport) {
         connected = yield* connectReviewTransport(transport);
@@ -533,25 +575,13 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
           const proposalMode = config.agentProposalMode;
           if (proposalMode === "veto") {
             const vetoBudgetMs = config.agentVetoTimeoutMs;
-            const vetoSlowThreshold = vetoBudgetMs * 0.95;
-            // Drop stale samples first so a transient slow period ages out and
-            // the skip cannot latch on a polluted window.
-            evictStaleVetoSamples(Date.now());
-            const p95 = computeP95(vetoLatencies);
-            // Count individuals above the slow threshold — see the constant
-            // comment above for why p95 alone is insufficient as a gate.
-            const slowCount = vetoLatencies.filter((v) => v.latencyMs >= vetoSlowThreshold).length;
-            if (
-              vetoLatencies.length >= VETO_SKIP_MIN_SAMPLES &&
-              slowCount >= VETO_SKIP_MIN_SLOW_SAMPLES &&
-              p95 !== null &&
-              p95 >= vetoSlowThreshold
-            ) {
+            const vetoSkip = vetoLatencyWindow.shouldSkip(Date.now());
+            if (vetoSkip.skip) {
               logger.warn("Skipping veto review — rolling p95 latency exceeds 95% of veto budget", {
                 pool: decision.poolAddress,
-                p95Ms: Math.round(p95),
+                p95Ms: Math.round(vetoSkip.p95Ms ?? 0),
                 budgetMs: vetoBudgetMs,
-                windowSize: vetoLatencies.length,
+                windowSize: vetoSkip.windowSize,
               });
               return Effect.succeed(null);
             }
@@ -561,7 +591,10 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
             const recordAttemptLatency = () => {
               if (!vetoLatencyRecorded) {
                 vetoLatencyRecorded = true;
-                recordVetoLatency(Math.min(Date.now() - attemptStart, vetoBudgetMs));
+                vetoLatencyWindow.record(
+                  Math.min(Date.now() - attemptStart, vetoBudgetMs),
+                  Date.now(),
+                );
               }
             };
             return transport.sendPrompt(prompt, context, vetoBudgetMs).pipe(
@@ -602,10 +635,23 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
             );
           }
 
+          const proposalBudgetMs = config.agentProposalTimeoutMs;
           const prompt = buildProposalPrompt(decision, context);
-          return transport.sendPrompt(prompt, context, config.agentProposalTimeoutMs).pipe(
+          const attemptStart = Date.now();
+          let proposalLatencyRecorded = false;
+          const recordAttemptLatency = () => {
+            if (!proposalLatencyRecorded) {
+              proposalLatencyRecorded = true;
+              proposalLatencyWindow.record(
+                Math.min(Date.now() - attemptStart, proposalBudgetMs),
+                Date.now(),
+              );
+            }
+          };
+          return transport.sendPrompt(prompt, context, proposalBudgetMs).pipe(
             Effect.flatMap((response: AgentRuntimeResponse) => {
               lastPromptAt = Date.now();
+              recordAttemptLatency();
               return parseProposalResponse(
                 response.raw,
                 decision.action,
@@ -624,14 +670,30 @@ export function AgentLive(config: AppConfig): Layer.Layer<AgentService, never, n
             }),
             Effect.catchAll((err) => {
               errorCount += 1;
+              recordAttemptLatency();
               logger.warn("Agent proposal failed", {
                 pool: decision.poolAddress,
                 error: underlyingErrorMessage(err),
               });
               return Effect.succeed(null);
             }),
+            Effect.catchAllCause((cause) => {
+              // Interruption (the outer AGENT_PROPOSAL_TIMEOUT_MS deadline in
+              // program.ts) bypasses catchAll — record the elapsed sample so
+              // the latency window learns the model could not answer, and
+              // fail open (null) exactly like a typed failure.
+              recordAttemptLatency();
+              return Effect.succeed(null);
+            }),
           );
         },
+
+        // Callers check this BEFORE a sync advisor prompt so a slow model
+        // skips the round trip entirely (fail-open, no backoff penalty) —
+        // mirroring the inline veto skip that already lives inside
+        // enhanceDecision for the veto branch.
+        shouldSkipSyncProposal: () =>
+          Effect.succeed(proposalLatencyWindow.shouldSkip(Date.now()).skip),
 
         getPolicy: () =>
           Effect.succeed({

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -3248,10 +3248,12 @@ export const program = Effect.gen(function* () {
                   }),
                 ),
               );
+              const latencySkipped = yield* agent.shouldSkipSyncProposal();
               if (
                 hasSyncProposalTransport(agentStatus) &&
                 getPoolCircuitBreaker(overlayPoolAddress).canTry(now) &&
-                !isProposalBackoffActive(proposalBackoff.get(overlayPoolAddress), now)
+                !isProposalBackoffActive(proposalBackoff.get(overlayPoolAddress), now) &&
+                !latencySkipped
               ) {
                 const syncProposal = yield* agent
                   .enhanceDecision(decision, {
@@ -3262,7 +3264,19 @@ export const program = Effect.gen(function* () {
                     recentDecisions: overlayRecentDecisions,
                     hasOpenPosition: overlayHasOpenPosition,
                   })
-                  .pipe(Effect.catchAll(() => Effect.succeed(null)));
+                  .pipe(
+                    // Outer deadline mirrors the tail: a stalled reconnect
+                    // must not stall the redeploy pass past the proposal
+                    // budget.
+                    Effect.timeoutFail({
+                      duration: `${config.agentProposalTimeoutMs} millis`,
+                      onTimeout: () =>
+                        new Error(
+                          `Agent proposal sync timed out after ${config.agentProposalTimeoutMs}ms`,
+                        ),
+                    }),
+                    Effect.catchAll(() => Effect.succeed(null)),
+                  );
                 if (syncProposal && isAgentProposal(syncProposal)) {
                   agentProposal = syncProposal;
                   proposalSource = "sync";
@@ -6184,33 +6198,56 @@ export const program = Effect.gen(function* () {
                   pool: poolAddress,
                 });
               } else {
-                const syncProposal = yield* agent
-                  .enhanceDecision(decision, {
-                    decision,
-                    pool,
-                    metrics,
-                    warnings,
-                    recentDecisions: yield* audit
-                      .getRecentDecisions(10)
-                      .pipe(Effect.catchAll(() => Effect.succeed([]))),
-                    hasOpenPosition,
-                  })
-                  .pipe(
-                    Effect.catchAll((err) => {
-                      syncFetchFailed = true;
-                      logger.warn("Agent proposal fetch failed", {
-                        pool: poolAddress,
-                        error: String(err),
-                      });
-                      return Effect.succeed(null);
-                    }),
+                // Latency skip mirrors the veto path: when the rolling p95 of
+                // proposal latencies exceeds the proposal budget, skip the
+                // round trip fail-open WITHOUT arming backoff/circuit failure
+                // (a slow model is not a bad advisor).
+                const latencySkipped = yield* agent.shouldSkipSyncProposal();
+                if (latencySkipped) {
+                  logger.info(
+                    "Agent proposal sync skipped — rolling p95 latency exceeds proposal budget",
+                    { pool: poolAddress },
                   );
-                if (syncProposal && isAgentProposal(syncProposal)) {
-                  agentProposal = syncProposal;
-                  proposalSource = "sync";
-                } else if (syncProposal === null) {
-                  // Real transport attempt returned null (parse/timeout/etc.).
-                  syncFetchFailed = true;
+                } else {
+                  const syncProposal = yield* agent
+                    .enhanceDecision(decision, {
+                      decision,
+                      pool,
+                      metrics,
+                      warnings,
+                      recentDecisions: yield* audit
+                        .getRecentDecisions(10)
+                        .pipe(Effect.catchAll(() => Effect.succeed([]))),
+                      hasOpenPosition,
+                    })
+                    .pipe(
+                      // Outer deadline mirrors the veto path: sendPrompt's own
+                      // timer starts only AFTER transport (re)connect, so a
+                      // stalled reconnect must not hold the decision loop past
+                      // the proposal budget.
+                      Effect.timeoutFail({
+                        duration: `${config.agentProposalTimeoutMs} millis`,
+                        onTimeout: () =>
+                          new Error(
+                            `Agent proposal sync timed out after ${config.agentProposalTimeoutMs}ms`,
+                          ),
+                      }),
+                      Effect.catchAll((err) => {
+                        syncFetchFailed = true;
+                        logger.warn("Agent proposal fetch failed", {
+                          pool: poolAddress,
+                          error: String(err),
+                        });
+                        return Effect.succeed(null);
+                      }),
+                    );
+                  if (syncProposal && isAgentProposal(syncProposal)) {
+                    agentProposal = syncProposal;
+                    proposalSource = "sync";
+                  } else if (syncProposal === null) {
+                    // Real transport attempt returned null (parse/timeout/etc.).
+                    syncFetchFailed = true;
+                  }
                 }
               }
             }

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -1375,6 +1375,10 @@ export interface AgentApi {
     decision: AgentDecision,
     context: AgentRuntimeContext,
   ) => Effect.Effect<AgentDecision | null, unknown>;
+  /** True when the rolling proposal-latency window says sync prompts should
+   *  be skipped this cycle (fail-open: the caller skips WITHOUT arming
+   *  backoff or circuit failure). */
+  readonly shouldSkipSyncProposal: () => Effect.Effect<boolean, never>;
   readonly getPolicy: () => Effect.Effect<AgentPolicySnapshot, unknown>;
   readonly sendCheckin: (checkin: AgentRuntimeCheckin) => Effect.Effect<void, unknown>;
   readonly sendAlert: (alert: AgentRuntimeAlert) => Effect.Effect<void, unknown>;


### PR DESCRIPTION
## Summary

Closes #161. Sync advisor prompts in `full`/`suggest` mode serialized the scan cycle with no latency protection: per-decision round trips, a 15s proposal timeout, no p95 skip (veto had one), no outer deadline (sendPrompt's timer starts only after transport reconnect), and latency failures armed bad-proposal backoff.

## Changes

- **engine/agent-service.ts** — the veto's inline rolling-p95 skip extracted into an exported `LatencyWindow` (identical constants/behavior), one instance per mode (veto budget, proposal timeout). The proposal branch now records prompt latencies on success, typed failure, and interruption. `shouldSkipSyncProposal()` exposes the window's verdict. `AgentNoOp` returns false.
- **engine/services.ts** — `AgentApi.shouldSkipSyncProposal`.
- **engine/program.ts** — main sync path and idle-redeploy sync path both check the latency skip BEFORE prompting (skip = fail-open, no backoff/circuit penalty) and wrap `enhanceDecision` in an outer `Effect.timeoutFail` bounded by `AGENT_PROPOSAL_TIMEOUT_MS`, mirroring the veto path's deadline so a stalled reconnect cannot hold the decision loop.
- **bench/agent-service.test.ts** — LatencyWindow unit tests (min-samples gate, p95 engagement, fast-model never skips, single-outlier immunity, aging-out recovery) + AgentNoOp skip test.

## Verification

- `bun run lint` clean
- `bun run test`: 1517/1517 pass
- `bun run format` applied, re-lint clean

Behavior notes: a hung transport now lands in the same backoff path as any fetch failure (genuine hang = penalty, unchanged); only latency-skipped cycles avoid the penalty. Queued-proposal path untouched.

## Summary by Sourcery

Introduce shared rolling latency window for advisor prompts and apply it to skip and bound sync proposal calls to avoid stalling decision loops.

New Features:
- Add a LatencyWindow utility to track rolling p95 latency for budget-constrained advisor prompts and decide when to skip them.
- Expose AgentApi.shouldSkipSyncProposal so callers can skip sync proposals when the latency window deems the model too slow.

Enhancements:
- Replace bespoke veto latency tracking with the shared LatencyWindow to unify skip behavior across veto reviews and sync proposals.
- Guard sync advisor proposals in the main and idle-redeploy paths with a latency-based skip and an outer timeout deadline matching the proposal budget to prevent hung transports from blocking decision cycles.

Tests:
- Add LatencyWindow unit tests covering sample thresholds, p95 engagement, outlier handling, and recovery after slow periods age out.
- Extend AgentNoOp tests to verify sync proposals are never skipped for the no-op agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards that skip synchronous agent proposals when recent latency exceeds configured limits.
  * Added rolling latency tracking based on recent samples, high-percentile performance, minimum sample counts, and sample expiration.
  * Added timeouts covering proposal requests from connection through generation.

* **Bug Fixes**
  * Prevented skipped proposals from incorrectly triggering backoff or circuit-breaker failures.
  * Preserved existing failure handling for timed-out or unsuccessful requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->