### PR TITLE
feat(engine): high-frequency rotation — configurable entry cap, rotation metrics, fast-churn profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,9 @@ OOR_RECOVERY_FORCE_REBALANCE_THRESHOLD=0.2
 # F5: Multi-pool allocation — split exposure across N pools with per-pool cap
 MAX_PER_POOL_ALLOCATION_PCT=0.4
 MAX_OPEN_POSITIONS=3
+# Hard USD ceiling per conservative entry (default 500). Raise for
+# high-frequency rotation profiles with larger per-position deployment.
+MAX_ENTRY_SIZE_USD=500
 
 # F6: Paper-trading validation — require N paper days before live ENTER
 PAPER_VALIDATION_MIN_DAYS=7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,25 @@ When `MARKET_SCAN_ENABLED=true`, `WATCHLIST_POOLS` becomes an OPTIONAL manual ov
 - **Candidates**: when `autonomousTokenMode != off`, the ranked market pools also feed the existing `token_candidates` lifecycle (health scans → eligible) for observability.
 - **Cadence**: `SCAN_INTERVAL_MS` bounds decision frequency; a 60 s interval with `MAX_OPEN_POSITIONS` raised enables high-frequency in/out (hundreds of round-trips/day) once capital supports it. Cycle duration grows with the active set — keep `MARKET_SCAN_TOP_K` in the tens for sub-minute cycles.
 
+### High-frequency rotation (200-300 positions/day)
+
+The engine is not position-count-limited by code: `MAX_OPEN_POSITIONS` has a default of 3 but **no upper clamp** (`validatedNumber` clamps upward only when a max is passed), so 10-30 concurrent positions are configurable today; the risk/allocation gates are config-driven. What throttles rotation is a set of conservative defaults plus RPC cost — the fast-churn profile:
+
+| Setting | Default (slow) | Fast-churn value |
+|---|---|---|
+| `SCAN_INTERVAL_MS` | `600000` (10 min) | `10000`-`60000` (min 10 s) |
+| `MAX_OPEN_POSITIONS` | `3` | `10`-`30` (no upper clamp) |
+| `MAX_ENTRY_SIZE_USD` | `500` | `2000`+ (per-position cap) |
+| `OOR_COOLDOWN_MS` | `14400000` (4 h) | `0` |
+| `REPEAT_OOR_COOLDOWN_MS` | `43200000` (12 h) | `0` |
+| `FEE_DENSITY_COOLDOWNS` | `true` | `false` (or keep — floor is configurable to 0) |
+| `MIN_REBALANCE_INTERVAL_MS` | `86400000` (24 h) | `0` |
+| `TRAILING_STOP_CONFIRM_CYCLES` | `2` | `1` |
+| `MARKET_SCAN_TOP_K` / `MAX_POOLS` | `30` / `60` | `100`-`200` / `200`-`500` |
+| `MARKET_SCAN_MIN_FEE_APR` | `25` | `25`-`50` (hot pools only) |
+
+Systemic constraints, not config: (1) **RPC budget** — ~4-8 calls per pool per cycle (pool state, bins, positions, value marks, wallet, prices); 60 pools @ 60 s ≈ 4-8 RPS is fine on Helius paid tiers, 500 pools @ 10 s ≈ 100-200 RPS breaks standard tiers — active set × interval is the real scale equation; (2) **exit-and-re-enter on the same pool is blocked in one pass** (re-entry next cycle, 1 ENTER per pool per cycle); (3) the ENTER quality gates (volume auth > 0.8, fee/IL ≥ 1.2, bin utilization, token-risk) reject most pools most cycles — throughput = pools passing gates × cycles/day, so a high `MARKET_SCAN_MIN_FEE_APR` matters more than raising caps; (4) sync advisor mode serializes the cycle (see Agent runtime overlay — use the async `/propose` queue for high throughput). The `Scan cycle complete` log reports session rotation metrics (`rotation.entriesExecuted`, `rotation.exitsExecuted`, `rotation.avgPositionAgeMin`) so throughput is measurable.
+
 ### Wallet balance (walletBalanceUsd)
 
 `walletBalanceUsd` is a **per-cycle chain reconciliation**, not an incremental ledger. It is read **once at the top of `runScanCycle`** (before the per-pool loop) in `program.ts` and reused for every pool's risk/sizing context in that cycle — a transient read never fails an individual pool, and one cycle shares one consistent figure for `portfolioValueUsd = walletBalanceUsd + Σ openPositions.currentValueUsd` and the `min(walletBalanceUsd * 0.5, …)` size cap.
@@ -420,6 +439,7 @@ The `Dockerfile` builds the engine bundle with `oven/bun:canary-slim`, then copi
 | `FEE_DENSITY_LOW_PCT`         | `0.0005`                                                           | Fee density (fees/TVL per day) at/below which the low-yield cooldown stays at the static `OOR_COOLDOWN_MS`; between the thresholds the duration is linearly interpolated. |
 | `MAX_OPEN_POSITIONS`          | `3`                                                                | Concurrent positions cap (total, portfolio-wide).                                                                    |
 | `MAX_POSITIONS_PER_POOL`      | `2`                                                                | Max simultaneous positions on one pool (Wave 10). Aggregate per-pool exposure stays bounded by `MAX_PER_POOL_ALLOCATION_PCT`. Set `1` for legacy single-position behavior. |
+| `MAX_ENTRY_SIZE_USD`          | `500`                                                              | Hard USD ceiling per conservative entry (the sizing formula's cap term). Raise for high-frequency rotation profiles. |
 | `MAX_PER_POOL_ALLOCATION_PCT` | `0.4`                                                              | Max portfolio share for one pool (aggregate across all of that pool's positions).                                     |
 | `SQLITE_DB_PATH`              | `~/.local/share/prism/prism.db` (bundled) or `./prism.db` (source) | SQLite database path.                                                                                              |
 | `ENABLE_SNAPSHOT_CAPTURE`     | `false`                                                            | Store full bin-array detail in per-cycle snapshots (paper only). Lightweight per-cycle snapshot rows are always persisted — TVL velocity and IL drift need the history. |
@@ -495,6 +515,7 @@ In test mode (`NODE_ENV=test` or `VITEST=true`), missing `HELIUS_API_KEY` defaul
 - Deploying Cloudflare: `cloudflare/README.md`.
 
 # AGENTS.md
+
 - Do not preserve backward compatibility. Remove obsolete paths instead of adding compatibility layers, fallbacks, or migrations.
 - Choose the simplest implementation that fully meets the current requirements. Avoid speculative abstractions, configuration, and indirection.
 - Grow the system in layers. Start from the smallest version that works end to end, and add each new capability on top of a product that already works. Never trade a working product for unfinished complexity.

--- a/bench/agent-service.test.ts
+++ b/bench/agent-service.test.ts
@@ -91,6 +91,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     maxPerPoolAllocationPct: 0.4,
     maxOpenPositions: 3,
     maxPositionsPerPool: 2,
+    maxEntrySizeUsd: 500,
     paperValidationMinDays: 7,
     paperValidationEnforce: false,
     agentiveMode: true,

--- a/bench/auto-update.test.ts
+++ b/bench/auto-update.test.ts
@@ -80,6 +80,7 @@ function buildLayer(
     maxPerPoolAllocationPct: 0.4,
     maxOpenPositions: 3,
     maxPositionsPerPool: 2,
+    maxEntrySizeUsd: 500,
     paperValidationMinDays: 7,
     paperValidationEnforce: false,
     agentiveMode: false,

--- a/bench/feedback-service.test.ts
+++ b/bench/feedback-service.test.ts
@@ -99,6 +99,7 @@ function buildLayer(
     maxPerPoolAllocationPct: 0.4,
     maxOpenPositions: 3,
     maxPositionsPerPool: 2,
+    maxEntrySizeUsd: 500,
     paperValidationMinDays: 7,
     paperValidationEnforce: false,
     agentiveMode: false,

--- a/bench/helpers.ts
+++ b/bench/helpers.ts
@@ -197,6 +197,7 @@ export function defaultAppConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     maxPerPoolAllocationPct: 0.4,
     maxOpenPositions: 3,
     maxPositionsPerPool: 2,
+    maxEntrySizeUsd: 500,
     paperValidationMinDays: 7,
     paperValidationEnforce: false,
     agentiveMode: false,

--- a/bench/http-status-server.test.ts
+++ b/bench/http-status-server.test.ts
@@ -69,6 +69,7 @@ function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     maxPerPoolAllocationPct: 0.4,
     maxOpenPositions: 3,
     maxPositionsPerPool: 2,
+    maxEntrySizeUsd: 500,
     paperValidationMinDays: 7,
     paperValidationEnforce: false,
     agentiveMode: false,

--- a/bench/idle-redeploy.test.ts
+++ b/bench/idle-redeploy.test.ts
@@ -68,6 +68,17 @@ describe("computeEntrySizeUsd — legacy-identical conservative sizing", () => {
     expect(computeEntrySizeUsd({ walletBalanceUsd: 0, tvlUsd: 0 })).toBe(10);
   });
 
+  it("a caller-supplied maxSizeUsd replaces the $500 cap (high-frequency rotation)", () => {
+    expect(
+      computeEntrySizeUsd({ walletBalanceUsd: 10_000, tvlUsd: 1_000_000, maxSizeUsd: 2_000 }),
+    ).toBe(2_000);
+    expect(
+      computeEntrySizeUsd({ walletBalanceUsd: 10_000, tvlUsd: 1_000_000, maxSizeUsd: 100 }),
+    ).toBe(100);
+    // The floor still binds under a tiny override.
+    expect(computeEntrySizeUsd({ walletBalanceUsd: 0, tvlUsd: 0, maxSizeUsd: 100 })).toBe(10);
+  });
+
   it("matches the legacy inline formula max(min(w*0.5, tvl*0.005, 500), 10) over a grid", () => {
     for (const walletBalanceUsd of [0, 10, 100, 999, 1000, 10_000, 123_456]) {
       for (const tvlUsd of [0, 1000, 50_000, 100_000, 1_000_000, 12_345_678]) {

--- a/bench/mcp-server.test.ts
+++ b/bench/mcp-server.test.ts
@@ -68,6 +68,7 @@ function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     maxPerPoolAllocationPct: 0.4,
     maxOpenPositions: 3,
     maxPositionsPerPool: 2,
+    maxEntrySizeUsd: 500,
     paperValidationMinDays: 7,
     paperValidationEnforce: false,
     agentiveMode: false,

--- a/bench/multi-position.test.ts
+++ b/bench/multi-position.test.ts
@@ -579,6 +579,28 @@ describe("evaluatePerPoolAllocation — aggregate per-pool exposure", () => {
     expect(result.approved).toBe(false);
     expect(result.reason).toMatch(/Max open positions/);
   });
+
+  it("scales to high-frequency rotation: 20-position cap admits the 20th and rejects the 21st", () => {
+    const highCountBase = { ...base, maxOpenPositions: 20 };
+    const nineteenPositions = Array.from({ length: 19 }, (_, i) =>
+      makeRiskPosition(`Pool${i}`, `pos-${i}`, 100),
+    );
+    const twentieth = evaluatePerPoolAllocation({
+      ...highCountBase,
+      proposedDepositUsd: 500,
+      openPositions: nineteenPositions,
+    });
+    expect(twentieth.approved).toBe(true);
+    expect(twentieth.adjustedDepositUsd).toBe(500);
+
+    const twentyFirst = evaluatePerPoolAllocation({
+      ...highCountBase,
+      proposedDepositUsd: 500,
+      openPositions: [...nineteenPositions, makeRiskPosition("Pool19", "pos-19", 100)],
+    });
+    expect(twentyFirst.approved).toBe(false);
+    expect(twentyFirst.reason).toMatch(/Max open positions reached \(20\/20\)/);
+  });
 });
 
 describe("evaluateAgentProposal — multi-position", () => {

--- a/bench/multi-position.test.ts
+++ b/bench/multi-position.test.ts
@@ -1482,6 +1482,38 @@ describe("program — multiple positions per pool", () => {
     expect(enters).toHaveLength(1);
   }, 15_000);
 
+  it("honors MAX_ENTRY_SIZE_USD on the normal ENTER path (raised cap reaches execution)", async () => {
+    // Default $500 cap would bind (wallet half 5000, tvl fraction 5000);
+    // with the cap raised to $2000 the executed paper position must be $2000.
+    const layer = makeProgramLayer({
+      adapter: makeProgramAdapter({ [POOL]: makePool({ address: POOL, tvlUsd: 1_000_000 }) }),
+      datapi: {
+        getPoolData: () => Effect.succeed(makeDatapiStats({ tvlUsd: 1_000_000 })),
+      },
+      configOverrides: {
+        watchlistPools: [POOL],
+        maxEntrySizeUsd: 2_000,
+        paperPortfolioUsd: 10_000,
+        scanIntervalMs: 600_000,
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const db = yield* DbService;
+      const positions = yield* db.getAllPositions();
+      return positions;
+    });
+    const positions = await Effect.runPromise(
+      Effect.provide(test, layer) as Effect.Effect<ReadonlyArray<PositionRecord>, unknown, never>,
+    );
+
+    expect(positions).toHaveLength(1);
+    expect(positions[0]!.depositedUsd).toBe(2_000);
+    expect(positions[0]!.entryAmountXUsd).toBe(1_000);
+    expect(positions[0]!.entryAmountYUsd).toBe(1_000);
+  }, 15_000);
+
   it("runs an independent lifecycle per position: OOR + trailing-stop EXIT on A leaves B intact", async () => {
     // Pool price halves to $75: with the price-anchored HODL mark (the old
     // bin-drift heuristic is gone), A's value genuinely collapses (400 X-leg

--- a/bench/revenue-split.test.ts
+++ b/bench/revenue-split.test.ts
@@ -73,6 +73,7 @@ function buildLayer() {
     maxPerPoolAllocationPct: 0.4,
     maxOpenPositions: 3,
     maxPositionsPerPool: 2,
+    maxEntrySizeUsd: 500,
     paperValidationMinDays: 7,
     paperValidationEnforce: false,
     agentiveMode: false,

--- a/bench/risk-service.test.ts
+++ b/bench/risk-service.test.ts
@@ -99,6 +99,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     maxPerPoolAllocationPct: 0.4,
     maxOpenPositions: 3,
     maxPositionsPerPool: 2,
+    maxEntrySizeUsd: 500,
     paperValidationMinDays: 0,
     paperValidationEnforce: false,
     oorCooldownMs: 3_600_000,

--- a/bench/screener-discover.test.ts
+++ b/bench/screener-discover.test.ts
@@ -83,6 +83,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     maxPerPoolAllocationPct: 0.4,
     maxOpenPositions: 3,
     maxPositionsPerPool: 2,
+    maxEntrySizeUsd: 500,
     paperValidationMinDays: 7,
     paperValidationEnforce: false,
     agentiveMode: false,

--- a/bench/update-check.test.ts
+++ b/bench/update-check.test.ts
@@ -82,6 +82,7 @@ function buildLayer(
     maxPerPoolAllocationPct: 0.4,
     maxOpenPositions: 3,
     maxPositionsPerPool: 2,
+    maxEntrySizeUsd: 500,
     paperValidationMinDays: 7,
     paperValidationEnforce: false,
     agentiveMode: false,

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -11,6 +11,7 @@ import type {
 import { PublicKey } from "@solana/web3.js";
 import { createLogger } from "./logger.js";
 import { applyDbConfigOverrides, readDbConfigOverrides } from "./db-config.js";
+import { ENTRY_SIZE_CAP_USD, ENTRY_SIZE_FLOOR_USD } from "./entry-sizing.js";
 
 const logger = createLogger("ConfigService");
 
@@ -319,6 +320,8 @@ export interface AppConfig {
    * behavior.
    */
   readonly maxPositionsPerPool: number;
+  /** Hard USD ceiling per conservative entry (default 500; see MAX_ENTRY_SIZE_USD). */
+  readonly maxEntrySizeUsd: number;
 
   // ─── F6: Paper-trading validation period ────────────────────────────────────
   /** Require N days of paper trading before allowing live ENTER. */
@@ -869,6 +872,14 @@ const loadConfig = Effect.gen(function* () {
   );
   const maxOpenPositions = yield* validatedNumber("MAX_OPEN_POSITIONS", 1, 3);
   const maxPositionsPerPool = yield* validatedNumber("MAX_POSITIONS_PER_POOL", 1, 2);
+  // Hard USD ceiling per conservative entry (the sizing formula's cap term).
+  // Raisable for high-frequency rotation profiles where the default $500
+  // constant would cap deployed capital per position.
+  const maxEntrySizeUsd = yield* validatedNumber(
+    "MAX_ENTRY_SIZE_USD",
+    ENTRY_SIZE_FLOOR_USD,
+    ENTRY_SIZE_CAP_USD,
+  );
 
   // ─── Idle-capital auto-redeploy (opt-in) ─────────────────────────────────
   const idleRedeployEnabled = yield* Config.boolean("IDLE_REDEPLOY_ENABLED").pipe(
@@ -1505,6 +1516,7 @@ const loadConfig = Effect.gen(function* () {
     maxPerPoolAllocationPct,
     maxOpenPositions,
     maxPositionsPerPool,
+    maxEntrySizeUsd,
     paperValidationMinDays,
     paperValidationEnforce,
     oorCooldownMs,

--- a/engine/db-config.ts
+++ b/engine/db-config.ts
@@ -83,6 +83,7 @@ export const DB_CONFIG_KEYS: ReadonlyArray<DbConfigSpec> = [
   { envKey: "PAPER_PORTFOLIO_USD", kind: "number", field: "paperPortfolioUsd", min: 1 },
   { envKey: "MAX_OPEN_POSITIONS", kind: "number", field: "maxOpenPositions", min: 1 },
   { envKey: "MAX_POSITIONS_PER_POOL", kind: "number", field: "maxPositionsPerPool", min: 1 },
+  { envKey: "MAX_ENTRY_SIZE_USD", kind: "number", field: "maxEntrySizeUsd", min: 10 },
   {
     envKey: "MAX_PER_POOL_ALLOCATION_PCT",
     kind: "number",

--- a/engine/entry-sizing.ts
+++ b/engine/entry-sizing.ts
@@ -16,22 +16,25 @@ export const ENTRY_SIZE_FLOOR_USD = 10;
 export interface EntrySizeInput {
   readonly walletBalanceUsd: number;
   readonly tvlUsd: number;
+  /** Hard dollar ceiling on the entry; defaults to ENTRY_SIZE_CAP_USD. */
+  readonly maxSizeUsd?: number;
 }
 
 /**
  * Conservative base entry size: the tightest of half the wallet balance,
- * 0.5% of pool TVL, and the $500 ceiling, with a $10 floor. Byte-identical
- * to the formula the ENTER slot always used
- * (`max(min(walletBalanceUsd * 0.5, tvlUsd * 0.005, 500), 10)`) — this path
- * is UNCHANGED by the idle-redeploy feature; the wider redeploy size is
- * computed separately by the redeploy pass (see computeIdleRedeploySizeUsd)
- * and still re-capped by every risk gate downstream.
+ * 0.5% of pool TVL, and the ceiling (ENTRY_SIZE_CAP_USD by default, or the
+ * caller's `maxSizeUsd`), with a $10 floor. Byte-identical to the legacy
+ * inline formula (`max(min(walletBalanceUsd * 0.5, tvlUsd * 0.005, 500), 10)`)
+ * when no override is supplied — this path is UNCHANGED by the idle-redeploy
+ * feature; the wider redeploy size is computed separately by the redeploy
+ * pass (see computeIdleRedeploySizeUsd) and still re-capped by every risk
+ * gate downstream.
  */
 export function computeEntrySizeUsd(input: EntrySizeInput): number {
   const maxPositionSize = Math.min(
     input.walletBalanceUsd * ENTRY_SIZE_WALLET_FRACTION,
     input.tvlUsd * ENTRY_SIZE_TVL_FRACTION,
-    ENTRY_SIZE_CAP_USD,
+    input.maxSizeUsd ?? ENTRY_SIZE_CAP_USD,
   );
   return Math.max(maxPositionSize, ENTRY_SIZE_FLOOR_USD);
 }

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -5851,6 +5851,7 @@ export const program = Effect.gen(function* () {
               const proposedSizeUsd = computeEntrySizeUsd({
                 walletBalanceUsd,
                 tvlUsd: pool.tvlUsd,
+                maxSizeUsd: config.maxEntrySizeUsd,
               });
 
               // F5: per-pool allocation cap — aggregate across the pool's

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -572,6 +572,17 @@ export function positionsForPool(
   return out;
 }
 
+/** Mean age of tracked positions in minutes (0 when none open). */
+export function avgTrackedPositionAgeMin(
+  trackedPositions: Map<string, PositionRecord>,
+  now: number,
+): number {
+  if (trackedPositions.size === 0) return 0;
+  let totalMs = 0;
+  for (const pos of trackedPositions.values()) totalMs += now - pos.timestamp;
+  return totalMs / trackedPositions.size / 60_000;
+}
+
 /**
  * Idle-redeploy confidence (P2 3654054423 + follow-up 3655288403): repo
  * doctrine (AGENTS.md §decision-loop) gives a modeled/fabricated fee/IL ratio
@@ -3712,6 +3723,7 @@ export const program = Effect.gen(function* () {
         if (executed) {
           cycle.poolsExecuted++;
           recordExecutionOutcome(true);
+          sessionEntriesExecuted++;
           idleRedeployLogger.info("Idle capital redeployed", {
             pool: candidate.poolAddress,
             sizeUsd: decision.positionSizeUsd,
@@ -3802,7 +3814,14 @@ export const program = Effect.gen(function* () {
       });
     });
 
-  // ─── Scan cycle ────────────────────────────────────────────────────────────
+  // ─── Rotation metrics (session-scoped) ─────────────────────────────────
+  // Counters since process start for the high-frequency-rotation profile:
+  // ENTER/EXIT executions and the average age of tracked positions. Logged
+  // at the end of every cycle so throughput is measurable, not guessed.
+  let sessionEntriesExecuted = 0;
+  let sessionExitsExecuted = 0;
+
+  // ─── Scan cycle ────────────────────────────────────────────────────────
 
   const runScanCycle = (): Effect.Effect<void, never, EntryPrepService> =>
     Effect.gen(function* () {
@@ -4046,6 +4065,13 @@ export const program = Effect.gen(function* () {
         executed: cycle.poolsExecuted,
         failed: cycle.poolsFailed,
         durationSec: (durationMs / 1000).toFixed(1),
+        rotation: {
+          entriesExecuted: sessionEntriesExecuted,
+          exitsExecuted: sessionExitsExecuted,
+          avgPositionAgeMin: Number(
+            avgTrackedPositionAgeMin(trackedPositions, Date.now()).toFixed(1),
+          ),
+        },
       });
 
       // Prune expired memories after each cycle
@@ -5510,7 +5536,11 @@ export const program = Effect.gen(function* () {
               metrics,
               entryScore,
               feeIlRatio,
-              normalEntrySizeUsd: computeEntrySizeUsd({ walletBalanceUsd, tvlUsd: pool.tvlUsd }),
+              normalEntrySizeUsd: computeEntrySizeUsd({
+                walletBalanceUsd,
+                tvlUsd: pool.tvlUsd,
+                maxSizeUsd: config.maxEntrySizeUsd,
+              }),
               volatilityStddev,
               netDriftBins,
             };
@@ -5687,6 +5717,7 @@ export const program = Effect.gen(function* () {
             const faProposedSizeUsd = computeEntrySizeUsd({
               walletBalanceUsd,
               tvlUsd: pool.tvlUsd,
+              maxSizeUsd: config.maxEntrySizeUsd,
             });
             const faAllocation = evaluatePerPoolAllocation({
               proposedDepositUsd: faProposedSizeUsd,
@@ -6814,6 +6845,8 @@ export const program = Effect.gen(function* () {
           if (executed) {
             cycle.poolsExecuted++;
             recordExecutionOutcome(true);
+            if (decision.action === "ENTER") sessionEntriesExecuted++;
+            else if (decision.action === "EXIT") sessionExitsExecuted++;
           } else {
             cycle.poolsFailed++;
             recordExecutionOutcome(false);


### PR DESCRIPTION
## Summary

Closes #162. Deep research (issue) showed the engine is NOT position-count limited by code — `MAX_OPEN_POSITIONS` has no upper clamp — but a hardcoded $500 entry ceiling and conservative defaults throttle high-frequency rotation (200-300 positions/day as published by other DLMM bots).

## Changes

- **engine/config-service.ts** — `MAX_ENTRY_SIZE_USD` (default 500, min = $10 floor), wired into `AppConfig`.
- **engine/entry-sizing.ts** — `EntrySizeInput.maxSizeUsd` replaces the hardcoded cap term; legacy formula byte-identical when unset.
- **engine/program.ts** — cap threaded through all three `computeEntrySizeUsd` call sites (normal ENTER, fallen-angel, candidate comparison); session rotation counters (entries/exits executed, incl. idle-redeploy) + average tracked position age in the `Scan cycle complete` log.
- **engine/db-config.ts** — DB-config mirror row.
- **.env.example / AGENTS.md** — `MAX_ENTRY_SIZE_USD` documented; new `High-frequency rotation` section with the full fast-churn tuning table (intervals, caps, cooldowns, market-scan knobs) and the systemic constraints (RPC budget, per-cycle ENTER rules, quality-gate throughput, sync-advisor serialization).
- **Tests** — `maxSizeUsd` override respects the $10 floor; `evaluatePerPoolAllocation` admits the 20th position at `maxOpenPositions=20` and rejects the 21st (scale proof for >3 concurrent positions).

## Verification

- `bun run lint` clean
- `bun run test`: 1513/1513 pass
- `bun run format` applied, re-lint clean

Out of scope (noted in the issue): a live paper soak run of the fast-churn profile and RPS profiling at `SCAN_INTERVAL_MS=60s` with 100+ active pools.

## Summary by Sourcery

Introduce configurable per-entry USD cap and high-frequency rotation metrics to support fast-churn trading profiles.

New Features:
- Add configurable MAX_ENTRY_SIZE_USD cap to entry sizing and expose it via AppConfig, environment, and DB overrides.
- Track and log session-level rotation metrics, including executed entries/exits and average tracked position age, at the end of each scan cycle.

Enhancements:
- Update entry sizing to accept an optional maxSizeUsd override while preserving legacy behavior by default.
- Extend documentation with a high-frequency rotation profile, tuning table, and description of system constraints.

Tests:
- Add tests verifying the configurable entry cap respects the $10 floor and that per-pool allocation enforces a 20-position cap, admitting the 20th position and rejecting the 21st.
- Update bench configs to include the new maxEntrySizeUsd field across engine tests.