### PR TITLE
fix(autonomous): exclude terminal settlement jobs from overdue safety pause

### DIFF
--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -4,6 +4,7 @@ import {
   isActionAllowedDuringSafetyPause,
   loadDailyEquityBaseline,
   nextSettlementRetryAt,
+  oldestActiveSettlementAgeMs,
   persistDailyEquityBaseline,
   processSettlementJobs,
   safetyPauseBlockReason,
@@ -248,6 +249,23 @@ describe("autonomous token runtime policy", () => {
         dayRolledOver: true,
       }),
     ).toBe(false);
+  });
+
+  it("excludes confirmed and terminal jobs from the overdue settlement age (issue #167)", () => {
+    // Given a dead-end terminal job (failed rollback) and a confirmed job,
+    // both older than any pending limit.
+    const terminal = settlementJob({ status: "terminal", createdAt: 1 });
+    const confirmed = settlementJob({ id: "settlement-2", status: "confirmed", createdAt: 1 });
+
+    // Then no active job remains — the pause must not re-arm on their age.
+    expect(oldestActiveSettlementAgeMs([terminal, confirmed], 100_000)).toBe(0);
+
+    // Active jobs still count, oldest first, regardless of the terminal rows.
+    const pending = settlementJob({ id: "settlement-3", status: "pending", createdAt: 1 });
+    const retryable = settlementJob({ id: "settlement-4", status: "retryable", createdAt: 50_000 });
+    expect(oldestActiveSettlementAgeMs([terminal, confirmed, pending, retryable], 100_000)).toBe(
+      99_999,
+    );
   });
 
   it("caps deterministic settlement retry backoff", () => {

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -259,6 +259,15 @@ describe("autonomous token runtime policy", () => {
 
     // Then no active job remains — the pause must not re-arm on their age.
     expect(oldestActiveSettlementAgeMs([terminal, confirmed], 100_000)).toBe(0);
+    expect(
+      oldestActiveSettlementAgeMs([settlementJob({ status: "prepared", createdAt: 1 })], 100_000),
+    ).toBe(99_999);
+    expect(
+      oldestActiveSettlementAgeMs(
+        [settlementJob({ status: "submitted", createdAt: 50_000 })],
+        100_000,
+      ),
+    ).toBe(50_000);
 
     // Active jobs still count, oldest first, regardless of the terminal rows.
     const pending = settlementJob({ id: "settlement-3", status: "pending", createdAt: 1 });

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -295,6 +295,30 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
             ? `agent overlay: ${config.agentRuntime}`
             : "agent overlay: off";
 
+          // Acceptance for issue #167: an active settlement_overdue pause
+          // names the non-terminal jobs keeping it latched (oldest first).
+          const latchedBySettlements = (() => {
+            if (
+              autonomous.safetyPause === null ||
+              autonomous.safetyPause.resolvedAt !== null ||
+              autonomous.safetyPause.reason !== "settlement_overdue"
+            ) {
+              return null;
+            }
+            const now = Date.now();
+            const offenders = autonomous.settlements
+              .filter((job) => job.status !== "confirmed" && job.status !== "terminal")
+              .sort((a, b) => b.createdAt - a.createdAt)
+              .slice(0, 3);
+            if (offenders.length === 0) return null;
+            return `  Latched by: ${offenders
+              .map(
+                (job) =>
+                  `${job.id.slice(0, 8)}… ${job.status} ${((now - job.createdAt) / 3_600_000).toFixed(1)}h${job.error ? ` (${job.error})` : ""}`,
+              )
+              .join(", ")}`;
+          })();
+
           console.log(
             [
               "Prism Status",
@@ -325,6 +349,7 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
                     ? `ACTIVE (${autonomous.safetyPause.reason})`
                     : `resolved (${autonomous.safetyPause.reason})`
               }`,
+              ...(latchedBySettlements !== null ? [latchedBySettlements] : []),
               "",
               `  Recent decisions: ${recentAudit.length}`,
               ...recentAudit

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -308,7 +308,7 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
             const now = Date.now();
             const offenders = autonomous.settlements
               .filter((job) => job.status !== "confirmed" && job.status !== "terminal")
-              .sort((a, b) => b.createdAt - a.createdAt)
+              .sort((a, b) => a.createdAt - b.createdAt)
               .slice(0, 3);
             if (offenders.length === 0) return null;
             return `  Latched by: ${offenders

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -112,6 +112,21 @@ export function nextSettlementRetryAt(now: number, attempts: number): number {
   return now + Math.min(2 ** exponent * 1_000, 300_000);
 }
 
+/**
+ * Age in ms of the oldest ACTIVE settlement job. `confirmed` and `terminal`
+ * are final states: a dead-end terminal job (e.g. a failed rollback) must not
+ * keep the `settlement_overdue` safety pause latched forever after
+ * `prism resume` (issue #167). Returns 0 when no active jobs remain.
+ */
+export function oldestActiveSettlementAgeMs(
+  jobs: ReadonlyArray<SettlementJobRecord>,
+  now: number,
+): number {
+  return jobs
+    .filter((job) => job.status !== "confirmed" && job.status !== "terminal")
+    .reduce((oldest, job) => Math.max(oldest, now - job.createdAt), 0);
+}
+
 export interface SettlementProcessorInput {
   readonly adapter: AdapterApi;
   readonly db: DbApi;

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -159,6 +159,7 @@ import {
 import { computeCooldownForExit } from "./cooldown.js";
 import {
   loadDailyEquityBaseline,
+  oldestActiveSettlementAgeMs,
   persistDailyEquityBaseline,
   processSettlementJobs,
   safetyPauseBlockReason,
@@ -3912,9 +3913,7 @@ export const program = Effect.gen(function* () {
           maxSwapSlippageBps: config.maxSwapSlippageBps,
           settlementDustUsd: autonomousExecution.settlementDustUsd,
         });
-        oldestSettlementAgeMs = processedJobs
-          .filter((job) => job.status !== "confirmed")
-          .reduce((oldest, job) => Math.max(oldest, Date.now() - job.createdAt), 0);
+        oldestSettlementAgeMs = oldestActiveSettlementAgeMs(processedJobs, Date.now());
         if (
           oldestSettlementAgeMs > config.settlementMaxPendingMs &&
           activeSafetyPause?.resolvedAt !== null


### PR DESCRIPTION
Fixes #167

## Problem

`safe_pause` reason `settlement_overdue` re-latches every scan cycle even after `prism resume`, because terminal (dead-end) settlement jobs are never excluded from the overdue age computation. `processSettlementJobs` leaves terminal jobs unchanged, and the age reduce only filtered out `confirmed` — so a terminal job (e.g. the failed rollback from #166, `Jupiter quote failed: 429`) contributed `Date.now() - createdAt` forever, re-arming the pause every cycle.

## Change

- **`engine/autonomous-runtime.ts`** — new `oldestActiveSettlementAgeMs(jobs, now)`: `confirmed` and `terminal` are final states; only `pending` / `prepared` / `submitted` / `retryable` count toward the overdue age.
- **`engine/program.ts`** — the scan cycle uses the helper instead of the inline `filter(status !== "confirmed")` reduce.
- **`cli/status.ts`** — an active `settlement_overdue` pause now shows a `Latched by: <job-id>… <status> <age>h (<error>)` line naming the non-terminal jobs keeping it latched (oldest first, up to 3).
- **`bench/program-autonomous-token.test.ts`** — regression test: terminal + confirmed jobs alone yield age 0; active jobs still count.

## Acceptance

- [x] After `prism resume`, a pause caused solely by a terminal job does not re-arm on the next cycle.
- [x] `prism status` shows why a `settlement_overdue` pause keeps re-latching (the offending job id).

## Verification

- `bunx tsc --noEmit` clean
- `bun run test`: 119 files / 1528 tests pass
- `oxlint` + `oxfmt --check` clean on changed files

## Summary by Sourcery

Adjust autonomous settlement overdue safety pause logic to ignore final jobs and surface which active jobs keep the pause latched.

Bug Fixes:
- Prevent terminal settlement jobs from causing the settlement_overdue safety pause to re-arm after prism resume by excluding final states from overdue age calculation.

Enhancements:
- Introduce a shared helper to compute the oldest active settlement job age, used by the autonomous engine scan cycle.
- Display in prism status which non-terminal settlement jobs are currently latching an active settlement_overdue safety pause, including age and error details.

Tests:
- Add regression tests ensuring confirmed and terminal settlement jobs do not contribute to overdue age while active jobs still do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status reporting for overdue settlement pauses.
  * Status details now identify up to three active settlement jobs contributing to a pause, including their IDs, statuses, elapsed time, and errors.
  * Corrected settlement-age calculations to exclude confirmed and terminal jobs while retaining pending and retryable jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->