### PR TITLE
fix(engine): retryable 429 settlements, orphan-token sweep, stranded status (#166)

### DIFF
--- a/bench/cli-autonomous-status.test.ts
+++ b/bench/cli-autonomous-status.test.ts
@@ -58,6 +58,7 @@ async function seedAutonomousState(
   dbPath: string,
   walletAddress: string,
   agentInstanceId: string,
+  options: { readonly recovered?: boolean } = {},
 ): Promise<void> {
   await Effect.runPromise(
     Effect.gen(function* () {
@@ -143,6 +144,33 @@ async function seedAutonomousState(
         createdAt: 3_000,
         updatedAt: 3_000,
       });
+      if (options.recovered) {
+        // The orphan sweep sold the stranded mint — the terminal record above
+        // is now historical and must not be reported as stranded.
+        yield* db.saveSettlementJob({
+          id: "settlement-3",
+          walletAddress,
+          agentInstanceId,
+          positionId: "orphan:recovered",
+          poolAddress: "",
+          tokenMint: "mint-2",
+          amountAtomic: "15413",
+          destinationAsset: "SOL",
+          status: "confirmed",
+          attempts: 1,
+          nextRetryAt: null,
+          txSignature: "recovered-sig",
+          confirmedOutputAtomic: "1000000",
+          outputUsd: 10,
+          executionCostUsd: 0.1,
+          finalizedAt: null,
+          realizedPnlUsd: null,
+          expiresAt: 5_000,
+          error: null,
+          createdAt: 4_000,
+          updatedAt: 4_000,
+        });
+      }
       yield* db.saveSafetyPause({
         walletAddress,
         agentInstanceId,
@@ -215,6 +243,29 @@ describe("autonomous CLI operator surface", () => {
     const text = decode(result.stdout);
     expect(text).toContain("Stranded:    1 terminal settlement(s) with unspent balance");
     expect(text).toContain("?/mint-2");
+  });
+
+  it("hides terminal settlements whose mint was later recovered by a confirmed settlement", async () => {
+    // Given a terminal job for mint-2 plus a confirmed orphan-sweep sale of
+    // the same mint (the recovery path from issue #166).
+    testDirectory = mkdtempSync(join(tmpdir(), "prism-cli-autonomous-recovered-"));
+    const dbPath = join(testDirectory, "prism.db");
+    const walletKeypair = Keypair.generate();
+    const wallet = walletKeypair.publicKey.toBase58();
+    const agentInstanceId = "operator-test";
+    await seedAutonomousState(dbPath, wallet, agentInstanceId, { recovered: true });
+
+    // When
+    const result = runCli(["status"], {
+      SQLITE_DB_PATH: dbPath,
+      AGENT_INSTANCE_ID: agentInstanceId,
+      WALLET_PRIVATE_KEY: bs58.encode(walletKeypair.secretKey),
+    });
+
+    // Then the historical terminal record is not reported as stranded.
+    expect(result.exitCode).toBe(0);
+    const text = decode(result.stdout);
+    expect(text).not.toContain("Stranded:");
   });
 
   it("marks the current wallet's active safety pause resolved without live execution", async () => {

--- a/bench/cli-autonomous-status.test.ts
+++ b/bench/cli-autonomous-status.test.ts
@@ -118,6 +118,31 @@ async function seedAutonomousState(
         createdAt: 3_000,
         updatedAt: 3_000,
       });
+      // Issue #166: a terminal settlement with no recovered output is the
+      // stranded-token case the sweep re-queues; status must surface it.
+      yield* db.saveSettlementJob({
+        id: "settlement-2",
+        walletAddress,
+        agentInstanceId,
+        positionId: "position-2",
+        poolAddress: "",
+        tokenMint: "mint-2",
+        amountAtomic: "15413",
+        destinationAsset: "SOL",
+        status: "terminal",
+        attempts: 6,
+        nextRetryAt: null,
+        txSignature: null,
+        confirmedOutputAtomic: null,
+        outputUsd: null,
+        executionCostUsd: null,
+        finalizedAt: null,
+        realizedPnlUsd: null,
+        expiresAt: 5_000,
+        error: "Jupiter quote failed: 429",
+        createdAt: 3_000,
+        updatedAt: 3_000,
+      });
       yield* db.saveSafetyPause({
         walletAddress,
         agentInstanceId,
@@ -154,9 +179,42 @@ describe("autonomous CLI operator surface", () => {
       agentInstanceId,
       candidates: [{ id: "candidate-1", state: "eligible" }],
       operations: [{ id: "operation-1", status: "prepared" }],
-      settlements: [{ id: "settlement-1", status: "retryable" }],
+      settlements: [
+        { id: "settlement-1", status: "retryable" },
+        {
+          id: "settlement-2",
+          status: "terminal",
+          tokenMint: "mint-2",
+          amountAtomic: "15413",
+          confirmedOutputAtomic: null,
+          error: "Jupiter quote failed: 429",
+        },
+      ],
       safetyPause: { active: true, reason: "settlement_overdue" },
     });
+  });
+
+  it("flags terminal settlements with unspent balance in text output", async () => {
+    // Given
+    testDirectory = mkdtempSync(join(tmpdir(), "prism-cli-autonomous-stranded-"));
+    const dbPath = join(testDirectory, "prism.db");
+    const walletKeypair = Keypair.generate();
+    const wallet = walletKeypair.publicKey.toBase58();
+    const agentInstanceId = "operator-test";
+    await seedAutonomousState(dbPath, wallet, agentInstanceId);
+
+    // When
+    const result = runCli(["status"], {
+      SQLITE_DB_PATH: dbPath,
+      AGENT_INSTANCE_ID: agentInstanceId,
+      WALLET_PRIVATE_KEY: bs58.encode(walletKeypair.secretKey),
+    });
+
+    // Then
+    expect(result.exitCode).toBe(0);
+    const text = decode(result.stdout);
+    expect(text).toContain("Stranded:    1 terminal settlement(s) with unspent balance");
+    expect(text).toContain("?/mint-2");
   });
 
   it("marks the current wallet's active safety pause resolved without live execution", async () => {

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -6,7 +6,6 @@ import {
   loadDailyEquityBaseline,
   nextSettlementRetryAt,
   oldestActiveSettlementAgeMs,
-  orphanSettlementJobs,
   persistDailyEquityBaseline,
   processSettlementJobs,
   safetyPauseBlockReason,
@@ -891,7 +890,7 @@ describe("issue #166 settlement recovery", () => {
     expect(processed).toMatchObject({ status: "retryable", nextRetryAt: 11_000 });
   });
 
-  it("creates sell jobs only for unbacked, non-dust wallet holdings", () => {
+  it("creates sell jobs only for unbacked, non-dust wallet holdings", async () => {
     // Given holdings where one mint is backed, one is below dust, one is
     // unpriceable, and the settlement asset itself.
     const holdings = new Map<string, { amountAtomic: bigint; decimals: number }>([
@@ -902,18 +901,32 @@ describe("issue #166 settlement recovery", () => {
       [SOL_MINT, { amountAtomic: 1_000_000_000n, decimals: 9 }], // settlement asset → skip
       ["zero-1", { amountAtomic: 0n, decimals: 6 }], // nothing held → skip
     ]);
+    const adapter = {
+      hasWallet: () => true,
+      getWalletHoldings: () => Effect.succeed(holdings),
+      getPoolState: () => Effect.succeed({ tokenX: "backed-1", tokenY: "backed-y" }),
+      getTokenPrices: (mints: string[]) =>
+        Effect.succeed(
+          Object.fromEntries(mints.map((mint) => [mint, mint === "unpriceable-1" ? 0 : 1])),
+        ),
+    } as unknown as AdapterApi;
+    const db = {
+      listSettlementJobs: () => Effect.succeed([]),
+      getAllPositions: () => Effect.succeed([{ positionId: "live-pos-1", poolAddress: "pool-1" }]),
+    } as unknown as DbApi;
 
     // When
-    const jobs = orphanSettlementJobs({
-      walletAddress: "wallet-1",
-      agentInstanceId: "primary",
-      settlementMaxPendingMs: 3_600_000,
-      settlementDustUsd: 0.1,
-      now: 10_000,
-      holdings,
-      backedMints: new Set(["backed-1"]),
-      pricesUsd: { "stranded-1": 1, "dust-1": 1, "backed-1": 1 },
-    });
+    const jobs = await Effect.runPromise(
+      sweepOrphanSettlements({
+        adapter,
+        db,
+        walletAddress: "wallet-1",
+        agentInstanceId: "primary",
+        settlementMaxPendingMs: 3_600_000,
+        settlementDustUsd: 0.1,
+        now: 10_000,
+      }),
+    );
 
     // Then
     expect(jobs).toHaveLength(2);

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, it } from "vitest";
 import { Effect } from "effect";
 import {
   isActionAllowedDuringSafetyPause,
+  isTransientSettlementError,
   loadDailyEquityBaseline,
   nextSettlementRetryAt,
   oldestActiveSettlementAgeMs,
+  orphanSettlementJobs,
   persistDailyEquityBaseline,
   processSettlementJobs,
   safetyPauseBlockReason,
   shouldAutoResolveDailyDrawdownPause,
   shouldTriggerSafetyPause,
+  sweepOrphanSettlements,
 } from "../engine/autonomous-runtime.js";
 import { SOL_MINT } from "../engine/constants.js";
 import { computeNetRealizedPnlUsd } from "../engine/pnl.js";
@@ -797,5 +800,251 @@ describe("settlement job processing", () => {
     expect(loaded).toEqual({ day: "2026-08-01", equityUsd: 50_000 });
     expect(metadata.get("dailyBaseline:wallet-1:primary:day")).toBe("2026-08-02");
     expect(metadata.get("dailyBaseline:wallet-1:primary:equityUsd")).toBe("49500");
+  });
+});
+
+describe("issue #166 settlement recovery", () => {
+  it("classifies rate-limit and network failures as transient", () => {
+    // Given / When / Then
+    expect(isTransientSettlementError(new Error("Jupiter quote failed: 429"))).toBe(true);
+    expect(isTransientSettlementError(new Error("Jupiter swap build failed: 502"))).toBe(true);
+    expect(isTransientSettlementError(new Error("Jupiter quote failed: 500"))).toBe(true);
+    expect(isTransientSettlementError(new Error("Jupiter quote failed: 408"))).toBe(true);
+    expect(isTransientSettlementError(new Error("fetch failed"))).toBe(true);
+    expect(isTransientSettlementError(new Error("request timed out after 10000ms"))).toBe(true);
+    expect(isTransientSettlementError(new Error("connection reset by peer"))).toBe(true);
+    expect(isTransientSettlementError(new Error("ECONNRESET"))).toBe(true);
+    expect(isTransientSettlementError(new Error("INSUFFICIENT_FUNDS"))).toBe(false);
+    expect(isTransientSettlementError(new Error("invalid slippage param"))).toBe(false);
+    expect(isTransientSettlementError(null)).toBe(false);
+  });
+
+  it("never terminalizes a rate-limited settlement past expiry — it stays retryable", async () => {
+    // Given a pending job whose max-pending window already passed, and a
+    // Jupiter rate limit on every quote.
+    const job = settlementJob({ expiresAt: 9_000 });
+    const savedJobs: SettlementJobRecord[] = [];
+    const adapter = {
+      getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "token-1": 1 }),
+      getTokenDecimals: () => Effect.succeed(6),
+      quoteSwap: () => Effect.fail(new Error("Jupiter quote failed: 429")),
+      prepareSwap: () => Effect.fail(new Error("unused")),
+      simulateSwap: () => Effect.fail(new Error("unused")),
+      submitSwap: () => Effect.fail(new Error("unused")),
+    } as unknown as AdapterApi;
+
+    // When
+    const [processed] = await runSettlementProcessor([job], adapter, savedJobs, "live");
+
+    // Then the job resumes with backoff instead of going terminal — a 429
+    // clears, so the token still gets sold on a later attempt.
+    expect(processed).toMatchObject({
+      status: "retryable",
+      attempts: 1,
+      nextRetryAt: 11_000,
+      error: "Jupiter quote failed: 429",
+    });
+  });
+
+  it("terminalizes a non-transient settlement failure once the max-pending window passes", async () => {
+    // Given
+    const job = settlementJob({ expiresAt: 9_000 });
+    const savedJobs: SettlementJobRecord[] = [];
+    const adapter = {
+      getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "token-1": 1 }),
+      getTokenDecimals: () => Effect.succeed(6),
+      quoteSwap: () => Effect.fail(new Error("insufficient funds for swap")),
+      prepareSwap: () => Effect.fail(new Error("unused")),
+      simulateSwap: () => Effect.fail(new Error("unused")),
+      submitSwap: () => Effect.fail(new Error("unused")),
+    } as unknown as AdapterApi;
+
+    // When
+    const [processed] = await runSettlementProcessor([job], adapter, savedJobs, "live");
+
+    // Then
+    expect(processed).toMatchObject({
+      status: "terminal",
+      attempts: 1,
+      nextRetryAt: null,
+      error: "insufficient funds for swap",
+    });
+  });
+
+  it("keeps retrying a non-transient failure before expiry", async () => {
+    // Given
+    const job = settlementJob({ expiresAt: 100_000 });
+    const savedJobs: SettlementJobRecord[] = [];
+    const adapter = {
+      getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "token-1": 1 }),
+      getTokenDecimals: () => Effect.succeed(6),
+      quoteSwap: () => Effect.fail(new Error("insufficient funds for swap")),
+      prepareSwap: () => Effect.fail(new Error("unused")),
+      simulateSwap: () => Effect.fail(new Error("unused")),
+      submitSwap: () => Effect.fail(new Error("unused")),
+    } as unknown as AdapterApi;
+
+    // When
+    const [processed] = await runSettlementProcessor([job], adapter, savedJobs, "live");
+
+    // Then
+    expect(processed).toMatchObject({ status: "retryable", nextRetryAt: 11_000 });
+  });
+
+  it("creates sell jobs only for unbacked, non-dust wallet holdings", () => {
+    // Given holdings where one mint is backed, one is below dust, one is
+    // unpriceable, and the settlement asset itself.
+    const holdings = new Map<string, { amountAtomic: bigint; decimals: number }>([
+      ["stranded-1", { amountAtomic: 1_000_000n, decimals: 6 }], // $1.00 → sweep
+      ["dust-1", { amountAtomic: 50_000n, decimals: 6 }], // $0.05 → skip
+      ["unpriceable-1", { amountAtomic: 5_000_000n, decimals: 6 }], // no price → sweep (cannot prove dust)
+      ["backed-1", { amountAtomic: 1_000_000n, decimals: 6 }], // position leg → skip
+      [SOL_MINT, { amountAtomic: 1_000_000_000n, decimals: 9 }], // settlement asset → skip
+      ["zero-1", { amountAtomic: 0n, decimals: 6 }], // nothing held → skip
+    ]);
+
+    // When
+    const jobs = orphanSettlementJobs({
+      walletAddress: "wallet-1",
+      agentInstanceId: "primary",
+      settlementMaxPendingMs: 3_600_000,
+      settlementDustUsd: 0.1,
+      now: 10_000,
+      holdings,
+      backedMints: new Set(["backed-1"]),
+      pricesUsd: { "stranded-1": 1, "dust-1": 1, "backed-1": 1 },
+    });
+
+    // Then
+    expect(jobs).toHaveLength(2);
+    expect(jobs.map((job) => job.tokenMint).sort()).toEqual(["stranded-1", "unpriceable-1"]);
+    expect(jobs[0]).toMatchObject({
+      walletAddress: "wallet-1",
+      agentInstanceId: "primary",
+      poolAddress: "",
+      destinationAsset: "SOL",
+      status: "pending",
+      attempts: 0,
+      nextRetryAt: 10_000,
+      expiresAt: 3_610_000,
+      error: null,
+      positionId: expect.stringMatching(/^orphan:/),
+    });
+  });
+
+  it("sweeps wallet holdings against position legs and active jobs, re-enqueuing terminal-mint tokens", async () => {
+    // Given a wallet holding three tokens: one backed by an open position's
+    // pool, one already covered by an active settlement job, and one whose
+    // settlement DIED terminal (the issue #166 stranded-token case).
+    const holdings = new Map<string, { amountAtomic: bigint; decimals: number }>([
+      ["stranded-1", { amountAtomic: 15_413n, decimals: 6 }],
+      ["pool-leg-x", { amountAtomic: 1_000_000n, decimals: 6 }],
+      ["active-job-token", { amountAtomic: 1_000_000n, decimals: 6 }],
+    ]);
+    const adapter = {
+      hasWallet: () => true,
+      getWalletHoldings: () => Effect.succeed(holdings),
+      getPoolState: (poolAddress: string) =>
+        Effect.succeed(
+          poolAddress === "pool-1" ? { tokenX: "pool-leg-x", tokenY: "pool-leg-y" } : null,
+        ),
+      getTokenPrices: (mints: string[]) =>
+        Effect.succeed(
+          Object.fromEntries(mints.map((mint) => [mint, mint === "stranded-1" ? 1000 : 1])),
+        ),
+    } as unknown as AdapterApi;
+    const db = {
+      listSettlementJobs: () =>
+        Effect.succeed([
+          settlementJob({ id: "active", tokenMint: "active-job-token", status: "retryable" }),
+          settlementJob({ id: "dead", tokenMint: "stranded-1", status: "terminal" }),
+        ]),
+      getAllPositions: () => Effect.succeed([{ poolAddress: "pool-1" }]),
+    } as unknown as DbApi;
+
+    // When
+    const jobs = await Effect.runPromise(
+      sweepOrphanSettlements({
+        adapter,
+        db,
+        walletAddress: "wallet-1",
+        agentInstanceId: "primary",
+        settlementMaxPendingMs: 3_600_000,
+        settlementDustUsd: 0.1,
+        now: 10_000,
+      }),
+    );
+
+    // Then only the stranded token gets a fresh job; the terminal job does not
+    // count as backing.
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toMatchObject({
+      tokenMint: "stranded-1",
+      amountAtomic: "15413",
+      status: "pending",
+      attempts: 0,
+    });
+  });
+
+  it("skips the sweep entirely without a wallet or without candidate holdings", async () => {
+    // Given
+    const walletless = {
+      hasWallet: () => false,
+    } as unknown as AdapterApi;
+    const emptyHoldings = {
+      hasWallet: () => true,
+      getWalletHoldings: () => Effect.succeed(new Map()),
+    } as unknown as AdapterApi;
+
+    // When / Then
+    await expect(
+      Effect.runPromise(
+        sweepOrphanSettlements({
+          adapter: walletless,
+          db: {} as DbApi,
+          walletAddress: "wallet-1",
+          agentInstanceId: "primary",
+          settlementMaxPendingMs: 3_600_000,
+          settlementDustUsd: 0.1,
+          now: 10_000,
+        }),
+      ),
+    ).resolves.toEqual([]);
+    await expect(
+      Effect.runPromise(
+        sweepOrphanSettlements({
+          adapter: emptyHoldings,
+          db: {} as DbApi,
+          walletAddress: "wallet-1",
+          agentInstanceId: "primary",
+          settlementMaxPendingMs: 3_600_000,
+          settlementDustUsd: 0.1,
+          now: 10_000,
+        }),
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("fails open when the holdings read errors", async () => {
+    // Given
+    const adapter = {
+      hasWallet: () => true,
+      getWalletHoldings: () => Effect.fail(new Error("rpc down")),
+    } as unknown as AdapterApi;
+
+    // When / Then
+    await expect(
+      Effect.runPromise(
+        sweepOrphanSettlements({
+          adapter,
+          db: {} as DbApi,
+          walletAddress: "wallet-1",
+          agentInstanceId: "primary",
+          settlementMaxPendingMs: 3_600_000,
+          settlementDustUsd: 0.1,
+          now: 10_000,
+        }),
+      ),
+    ).resolves.toEqual([]);
   });
 });

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -959,7 +959,7 @@ describe("issue #166 settlement recovery", () => {
           settlementJob({ id: "active", tokenMint: "active-job-token", status: "retryable" }),
           settlementJob({ id: "dead", tokenMint: "stranded-1", status: "terminal" }),
         ]),
-      getAllPositions: () => Effect.succeed([{ poolAddress: "pool-1" }]),
+      getAllPositions: () => Effect.succeed([{ positionId: "live-pos-1", poolAddress: "pool-1" }]),
     } as unknown as DbApi;
 
     // When
@@ -1023,6 +1023,43 @@ describe("issue #166 settlement recovery", () => {
         }),
       ),
     ).resolves.toEqual([]);
+  });
+
+  it("does not let paper-position pool legs back live wallet tokens", async () => {
+    // Given a live wallet token that is a leg of a PAPER position's pool
+    // (paper rows share the positions table) — the sweep must still sell it.
+    const holdings = new Map<string, { amountAtomic: bigint; decimals: number }>([
+      ["paper-leg-token", { amountAtomic: 1_000_000n, decimals: 6 }],
+    ]);
+    const adapter = {
+      hasWallet: () => true,
+      getWalletHoldings: () => Effect.succeed(holdings),
+      getPoolState: () => Effect.succeed({ tokenX: "paper-leg-token", tokenY: "paper-leg-y" }),
+      getTokenPrices: (mints: string[]) =>
+        Effect.succeed(Object.fromEntries(mints.map((mint) => [mint, 1]))),
+    } as unknown as AdapterApi;
+    const db = {
+      listSettlementJobs: () => Effect.succeed([]),
+      getAllPositions: () =>
+        Effect.succeed([{ positionId: "paper-pool-1-abc", poolAddress: "pool-paper" }]),
+    } as unknown as DbApi;
+
+    // When
+    const jobs = await Effect.runPromise(
+      sweepOrphanSettlements({
+        adapter,
+        db,
+        walletAddress: "wallet-1",
+        agentInstanceId: "primary",
+        settlementMaxPendingMs: 3_600_000,
+        settlementDustUsd: 0.1,
+        now: 10_000,
+      }),
+    );
+
+    // Then the paper-backed mint is still swept.
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]!.tokenMint).toBe("paper-leg-token");
   });
 
   it("fails open when the holdings read errors", async () => {

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -216,6 +216,8 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
                   status: settlement.status,
                   poolAddress: settlement.poolAddress,
                   tokenMint: settlement.tokenMint,
+                  amountAtomic: settlement.amountAtomic,
+                  confirmedOutputAtomic: settlement.confirmedOutputAtomic,
                   attempts: settlement.attempts,
                   nextRetryAt:
                     settlement.nextRetryAt === null
@@ -293,6 +295,10 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
           const agentStatus = config.agentiveMode
             ? `agent overlay: ${config.agentRuntime}`
             : "agent overlay: off";
+          const strandedSettlements = autonomous.settlements.filter(
+            (settlement) =>
+              settlement.status === "terminal" && settlement.confirmedOutputAtomic === null,
+          );
 
           // Acceptance for issue #167: an active settlement_overdue pause
           // names the non-terminal jobs keeping it latched (oldest first).
@@ -341,6 +347,19 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
               `  Candidates:  ${autonomous.candidates.length}`,
               `  Operations:  ${autonomous.operations.length}`,
               `  Settlements: ${autonomous.settlements.length}`,
+              // Issue #166: surface terminal settlements whose swap never
+              // recovered the token so stranded capital stays visible until
+              // the orphan sweep re-queues it.
+              ...(strandedSettlements.length > 0
+                ? [
+                    `  Stranded:    ${strandedSettlements.length} terminal settlement(s) with unspent balance (${strandedSettlements
+                      .map(
+                        (settlement) =>
+                          `${(settlement.poolAddress || "?").slice(0, 8)}/${settlement.tokenMint.slice(0, 8)}`,
+                      )
+                      .join(", ")}) — see --json for details`,
+                  ]
+                : []),
               `  Safety pause: ${
                 autonomous.safetyPause === null
                   ? "none"

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -295,9 +295,20 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
           const agentStatus = config.agentiveMode
             ? `agent overlay: ${config.agentRuntime}`
             : "agent overlay: off";
+          // Issue #166: surface terminal settlements whose swap never
+          // recovered the token so stranded capital stays visible until
+          // the orphan sweep re-queues it. A terminal record whose mint has
+          // since confirmed (sweep sold it) is historical, not stranded.
+          const confirmedMints = new Set(
+            autonomous.settlements
+              .filter((settlement) => settlement.status === "confirmed")
+              .map((settlement) => settlement.tokenMint),
+          );
           const strandedSettlements = autonomous.settlements.filter(
             (settlement) =>
-              settlement.status === "terminal" && settlement.confirmedOutputAtomic === null,
+              settlement.status === "terminal" &&
+              settlement.confirmedOutputAtomic === null &&
+              !confirmedMints.has(settlement.tokenMint),
           );
 
           // Acceptance for issue #167: an active settlement_overdue pause
@@ -347,9 +358,6 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
               `  Candidates:  ${autonomous.candidates.length}`,
               `  Operations:  ${autonomous.operations.length}`,
               `  Settlements: ${autonomous.settlements.length}`,
-              // Issue #166: surface terminal settlements whose swap never
-              // recovered the token so stranded capital stays visible until
-              // the orphan sweep re-queues it.
               ...(strandedSettlements.length > 0
                 ? [
                     `  Stranded:    ${strandedSettlements.length} terminal settlement(s) with unspent balance (${strandedSettlements

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -636,10 +636,20 @@ export function sweepOrphanSettlements(
         .filter((job) => job.status !== "terminal" && job.status !== "confirmed")
         .map((job) => job.tokenMint),
     );
+    // Backing positions are the CURRENT wallet's live on-chain positions.
+    // getAllPositions has no wallet filter and paper rows share the table, so
+    // exclude `paper-*` rows — a paper position's pool legs must not exempt a
+    // live wallet's stranded tokens. The engine's model is one wallet per DB
+    // (portfolio/equity math already assumes it), so remaining rows belong to
+    // the current wallet.
     const openPositions = yield* input.db
       .getAllPositions()
       .pipe(Effect.catchAll(() => Effect.succeed([])));
-    for (const poolAddress of new Set(openPositions.map((position) => position.poolAddress))) {
+    for (const poolAddress of new Set(
+      openPositions
+        .filter((position) => !position.positionId.startsWith("paper-"))
+        .map((position) => position.poolAddress),
+    )) {
       const state = yield* input.adapter
         .getPoolState(poolAddress)
         .pipe(Effect.catchAll(() => Effect.succeed(null)));

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { Effect } from "effect";
 import { SOL_MINT } from "./constants.js";
 import { computeNetRealizedPnlUsd } from "./pnl.js";
@@ -194,13 +195,37 @@ function atomicUsd(amountAtomic: bigint, decimals: number, priceUsd: number): nu
   return (Number(whole) + Number(remainder) / Number(scale)) * priceUsd;
 }
 
+/**
+ * Issue #166: classifies a settlement failure as transient (retryable) vs
+ * definitively terminal. HTTP 408/425/429/5xx from the quote/swap API and
+ * network-level failures (timeouts, resets, DNS, aborts) are transient by
+ * definition — a rate limit clears, a connection recovers. Anything else
+ * (insufficient funds, invalid params, malformed payloads) will not fix
+ * itself by retrying.
+ */
+export function isTransientSettlementError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /\b(408|425|429|5\d{2})\b/.test(message) ||
+    /fetch failed|timeout|timed out|timedout|aborted|ECONNRESET|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|socket hang up|connection refused|connection reset|network error/i.test(
+      message,
+    )
+  );
+}
+
 function retryableJob(job: SettlementJobRecord, now: number, error: unknown): SettlementJobRecord {
   const attempts = job.attempts + 1;
+  // Transient failures (rate limits, network blips) never terminalize — the
+  // failure mode is time, not logic, so the retry budget stays unbounded and
+  // the job resumes as soon as the outage clears. Only non-transient failures
+  // expire into terminal once the max-pending window passes.
+  const transient = isTransientSettlementError(error);
+  const expired = !transient && now >= job.expiresAt;
   return {
     ...job,
-    status: now >= job.expiresAt ? "terminal" : "retryable",
+    status: expired ? "terminal" : "retryable",
     attempts,
-    nextRetryAt: now >= job.expiresAt ? null : nextSettlementRetryAt(now, attempts),
+    nextRetryAt: expired ? null : nextSettlementRetryAt(now, attempts),
     error: error instanceof Error ? error.message : String(error),
     updatedAt: now,
   };
@@ -492,5 +517,149 @@ export function processSettlementJobs(
         .pipe(Effect.catchAll(() => Effect.void));
     }
     return processed;
+  });
+}
+
+export interface OrphanSettlementSweepInput {
+  readonly walletAddress: string;
+  readonly agentInstanceId: string;
+  readonly settlementMaxPendingMs: number;
+  readonly settlementDustUsd: number;
+  readonly now: number;
+  /** Wallet SPL holdings (mint → amount/decimals); native SOL not included. */
+  readonly holdings: ReadonlyMap<
+    string,
+    { readonly amountAtomic: bigint; readonly decimals: number }
+  >;
+  /**
+   * Mints already accounted for: legs of open positions plus mints with an
+   * active (non-terminal, non-confirmed) settlement job. Terminal jobs
+   * deliberately do NOT back a mint — a dead job is exactly the stranded-token
+   * case this sweep re-enqueues.
+   */
+  readonly backedMints: ReadonlySet<string>;
+  /** USD prices for candidate mints (missing = unpriceable, enqueued anyway). */
+  readonly pricesUsd: Readonly<Record<string, number>>;
+}
+
+/**
+ * Issue #166: a SOL-funded entry that fails after the swap leaves the bought
+ * token stranded in the wallet with no position and no recovery path once its
+ * rollback settlement died. Each cycle this compares wallet holdings against
+ * the mints that are actually accounted for (position legs, active settlement
+ * jobs) and re-enqueues a fresh sell-settlement job for everything else.
+ * Dust below `settlementDustUsd` stays put; the settlement processor's own
+ * dust skip re-applies at execution time.
+ */
+export function orphanSettlementJobs(
+  input: OrphanSettlementSweepInput,
+): ReadonlyArray<SettlementJobRecord> {
+  const jobs: SettlementJobRecord[] = [];
+  for (const [mint, holding] of input.holdings) {
+    if (mint === SOL_MINT || holding.amountAtomic <= 0n) continue;
+    if (input.backedMints.has(mint)) continue;
+    const priceUsd = input.pricesUsd[mint] ?? 0;
+    if (
+      input.settlementDustUsd > 0 &&
+      priceUsd > 0 &&
+      atomicUsd(holding.amountAtomic, holding.decimals, priceUsd) < input.settlementDustUsd
+    ) {
+      continue;
+    }
+    const id = randomUUID();
+    jobs.push({
+      id,
+      walletAddress: input.walletAddress,
+      agentInstanceId: input.agentInstanceId,
+      positionId: `orphan:${id}`,
+      poolAddress: "",
+      tokenMint: mint,
+      amountAtomic: holding.amountAtomic.toString(),
+      destinationAsset: "SOL",
+      status: "pending",
+      attempts: 0,
+      nextRetryAt: input.now,
+      txSignature: null,
+      confirmedOutputAtomic: null,
+      outputUsd: null,
+      executionCostUsd: null,
+      finalizedAt: null,
+      realizedPnlUsd: null,
+      expiresAt: input.now + input.settlementMaxPendingMs,
+      error: null,
+      createdAt: input.now,
+      updatedAt: input.now,
+    });
+  }
+  return jobs;
+}
+
+export interface OrphanSettlementSweepDeps {
+  readonly adapter: AdapterApi;
+  readonly db: DbApi;
+  readonly walletAddress: string;
+  readonly agentInstanceId: string;
+  readonly settlementMaxPendingMs: number;
+  readonly settlementDustUsd: number;
+  readonly now: number;
+}
+
+/**
+ * Issue #166: detects wallet tokens with no backing position/order and returns
+ * fresh sell-settlement jobs for them. Fail-open end to end: a holdings read,
+ * pool-state fetch, or price fetch failure skips only its own contribution and
+ * never blocks the cycle. RPC cost is gated — position legs are only fetched
+ * when candidate mints actually exist, and holdings come from the wallet
+ * balance's existing 30s cached snapshot.
+ */
+export function sweepOrphanSettlements(
+  input: OrphanSettlementSweepDeps,
+): Effect.Effect<ReadonlyArray<SettlementJobRecord>, never> {
+  return Effect.gen(function* () {
+    if (!input.adapter.hasWallet()) return [];
+    const holdings = yield* input.adapter
+      .getWalletHoldings()
+      .pipe(
+        Effect.catchAll(() =>
+          Effect.succeed(new Map<string, { amountAtomic: bigint; decimals: number }>()),
+        ),
+      );
+    const candidates = [...holdings.entries()].filter(
+      ([mint, holding]) => mint !== SOL_MINT && holding.amountAtomic > 0n,
+    );
+    if (candidates.length === 0) return [];
+    const existingJobs = yield* input.db
+      .listSettlementJobs(input.walletAddress, input.agentInstanceId)
+      .pipe(Effect.catchAll(() => Effect.succeed([])));
+    const backedMints = new Set<string>(
+      existingJobs
+        .filter((job) => job.status !== "terminal" && job.status !== "confirmed")
+        .map((job) => job.tokenMint),
+    );
+    const openPositions = yield* input.db
+      .getAllPositions()
+      .pipe(Effect.catchAll(() => Effect.succeed([])));
+    for (const poolAddress of new Set(openPositions.map((position) => position.poolAddress))) {
+      const state = yield* input.adapter
+        .getPoolState(poolAddress)
+        .pipe(Effect.catchAll(() => Effect.succeed(null)));
+      if (state) {
+        backedMints.add(state.tokenX);
+        backedMints.add(state.tokenY);
+      }
+    }
+    const prices = yield* input.adapter
+      .getTokenPrices(candidates.map(([mint]) => mint))
+      .pipe(Effect.catchAll(() => Effect.succeed({})));
+    return orphanSettlementJobs({
+      walletAddress: input.walletAddress,
+      agentInstanceId: input.agentInstanceId,
+      settlementMaxPendingMs: input.settlementMaxPendingMs,
+      settlementDustUsd: input.settlementDustUsd,
+      now: input.now,
+      holdings,
+      backedMints,
+      pricesUsd: prices,
+    });
   });
 }

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -521,80 +521,6 @@ export function processSettlementJobs(
 }
 
 export interface OrphanSettlementSweepInput {
-  readonly walletAddress: string;
-  readonly agentInstanceId: string;
-  readonly settlementMaxPendingMs: number;
-  readonly settlementDustUsd: number;
-  readonly now: number;
-  /** Wallet SPL holdings (mint → amount/decimals); native SOL not included. */
-  readonly holdings: ReadonlyMap<
-    string,
-    { readonly amountAtomic: bigint; readonly decimals: number }
-  >;
-  /**
-   * Mints already accounted for: legs of open positions plus mints with an
-   * active (non-terminal, non-confirmed) settlement job. Terminal jobs
-   * deliberately do NOT back a mint — a dead job is exactly the stranded-token
-   * case this sweep re-enqueues.
-   */
-  readonly backedMints: ReadonlySet<string>;
-  /** USD prices for candidate mints (missing = unpriceable, enqueued anyway). */
-  readonly pricesUsd: Readonly<Record<string, number>>;
-}
-
-/**
- * Issue #166: a SOL-funded entry that fails after the swap leaves the bought
- * token stranded in the wallet with no position and no recovery path once its
- * rollback settlement died. Each cycle this compares wallet holdings against
- * the mints that are actually accounted for (position legs, active settlement
- * jobs) and re-enqueues a fresh sell-settlement job for everything else.
- * Dust below `settlementDustUsd` stays put; the settlement processor's own
- * dust skip re-applies at execution time.
- */
-export function orphanSettlementJobs(
-  input: OrphanSettlementSweepInput,
-): ReadonlyArray<SettlementJobRecord> {
-  const jobs: SettlementJobRecord[] = [];
-  for (const [mint, holding] of input.holdings) {
-    if (mint === SOL_MINT || holding.amountAtomic <= 0n) continue;
-    if (input.backedMints.has(mint)) continue;
-    const priceUsd = input.pricesUsd[mint] ?? 0;
-    if (
-      input.settlementDustUsd > 0 &&
-      priceUsd > 0 &&
-      atomicUsd(holding.amountAtomic, holding.decimals, priceUsd) < input.settlementDustUsd
-    ) {
-      continue;
-    }
-    const id = randomUUID();
-    jobs.push({
-      id,
-      walletAddress: input.walletAddress,
-      agentInstanceId: input.agentInstanceId,
-      positionId: `orphan:${id}`,
-      poolAddress: "",
-      tokenMint: mint,
-      amountAtomic: holding.amountAtomic.toString(),
-      destinationAsset: "SOL",
-      status: "pending",
-      attempts: 0,
-      nextRetryAt: input.now,
-      txSignature: null,
-      confirmedOutputAtomic: null,
-      outputUsd: null,
-      executionCostUsd: null,
-      finalizedAt: null,
-      realizedPnlUsd: null,
-      expiresAt: input.now + input.settlementMaxPendingMs,
-      error: null,
-      createdAt: input.now,
-      updatedAt: input.now,
-    });
-  }
-  return jobs;
-}
-
-export interface OrphanSettlementSweepDeps {
   readonly adapter: AdapterApi;
   readonly db: DbApi;
   readonly walletAddress: string;
@@ -605,15 +531,20 @@ export interface OrphanSettlementSweepDeps {
 }
 
 /**
- * Issue #166: detects wallet tokens with no backing position/order and returns
- * fresh sell-settlement jobs for them. Fail-open end to end: a holdings read,
- * pool-state fetch, or price fetch failure skips only its own contribution and
- * never blocks the cycle. RPC cost is gated — position legs are only fetched
- * when candidate mints actually exist, and holdings come from the wallet
- * balance's existing 30s cached snapshot.
+ * Issue #166: a SOL-funded entry that fails after the swap leaves the bought
+ * token stranded in the wallet with no position and no recovery path once its
+ * rollback settlement died. Each cycle this compares wallet holdings against
+ * the mints that are actually accounted for (position legs, active settlement
+ * jobs) and re-enqueues a fresh sell-settlement job for everything else.
+ * Dust below `settlementDustUsd` stays put (unpriceable tokens are enqueued —
+ * the processor's dust skip re-applies at execution time). Fail-open end to
+ * end: a holdings read, pool-state fetch, or price fetch failure skips only
+ * its own contribution and never blocks the cycle. RPC cost is gated —
+ * position legs are only fetched when candidate mints actually exist, and
+ * holdings come from the wallet balance's existing 30s cached snapshot.
  */
 export function sweepOrphanSettlements(
-  input: OrphanSettlementSweepDeps,
+  input: OrphanSettlementSweepInput,
 ): Effect.Effect<ReadonlyArray<SettlementJobRecord>, never> {
   return Effect.gen(function* () {
     if (!input.adapter.hasWallet()) return [];
@@ -660,16 +591,44 @@ export function sweepOrphanSettlements(
     }
     const prices = yield* input.adapter
       .getTokenPrices(candidates.map(([mint]) => mint))
-      .pipe(Effect.catchAll(() => Effect.succeed({})));
-    return orphanSettlementJobs({
-      walletAddress: input.walletAddress,
-      agentInstanceId: input.agentInstanceId,
-      settlementMaxPendingMs: input.settlementMaxPendingMs,
-      settlementDustUsd: input.settlementDustUsd,
-      now: input.now,
-      holdings,
-      backedMints,
-      pricesUsd: prices,
-    });
+      .pipe(Effect.catchAll(() => Effect.succeed<Record<string, number>>({})));
+    const jobs: SettlementJobRecord[] = [];
+    for (const [mint, holding] of holdings) {
+      if (mint === SOL_MINT || holding.amountAtomic <= 0n) continue;
+      if (backedMints.has(mint)) continue;
+      const priceUsd = prices[mint] ?? 0;
+      if (
+        input.settlementDustUsd > 0 &&
+        priceUsd > 0 &&
+        atomicUsd(holding.amountAtomic, holding.decimals, priceUsd) < input.settlementDustUsd
+      ) {
+        continue;
+      }
+      const id = randomUUID();
+      jobs.push({
+        id,
+        walletAddress: input.walletAddress,
+        agentInstanceId: input.agentInstanceId,
+        positionId: `orphan:${id}`,
+        poolAddress: "",
+        tokenMint: mint,
+        amountAtomic: holding.amountAtomic.toString(),
+        destinationAsset: "SOL",
+        status: "pending",
+        attempts: 0,
+        nextRetryAt: input.now,
+        txSignature: null,
+        confirmedOutputAtomic: null,
+        outputUsd: null,
+        executionCostUsd: null,
+        finalizedAt: null,
+        realizedPnlUsd: null,
+        expiresAt: input.now + input.settlementMaxPendingMs,
+        error: null,
+        createdAt: input.now,
+        updatedAt: input.now,
+      });
+    }
+    return jobs;
   });
 }

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -157,6 +157,7 @@ import {
   safetyPauseBlockReason,
   shouldAutoResolveDailyDrawdownPause,
   shouldTriggerSafetyPause,
+  sweepOrphanSettlements,
 } from "./autonomous-runtime.js";
 import { routeProbeAmountAtomic } from "./route-probe.js";
 import {
@@ -3966,18 +3967,40 @@ export const program = Effect.gen(function* () {
       // fresh active set visible to the "no pools" check and the scan loop.
       rebuildPoolsToScan();
       if (autonomousExecution) {
-        const settlementJobs = yield* db
-          .listSettlementJobs(
-            autonomousExecution.walletAddress,
-            autonomousExecution.agentInstanceId,
-          )
-          .pipe(Effect.catchAll(() => Effect.succeed([])));
+        const settlementNow = Date.now();
+        const settlementJobs: SettlementJobRecord[] = [
+          ...(yield* db
+            .listSettlementJobs(
+              autonomousExecution.walletAddress,
+              autonomousExecution.agentInstanceId,
+            )
+            .pipe(Effect.catchAll(() => Effect.succeed([])))),
+        ];
+        // Issue #166: sweep wallet tokens with no backing position or active
+        // settlement job (dead rollback settlements, failed swap-funded
+        // entries) into fresh sell jobs, so a token stranded by a terminal
+        // settlement gets re-queued automatically. New jobs process this cycle.
+        if (autonomousExecution.mode !== "shadow") {
+          const orphanJobs = yield* sweepOrphanSettlements({
+            adapter,
+            db,
+            walletAddress: autonomousExecution.walletAddress,
+            agentInstanceId: autonomousExecution.agentInstanceId,
+            settlementMaxPendingMs: autonomousExecution.settlementMaxPendingMs,
+            settlementDustUsd: autonomousExecution.settlementDustUsd,
+            now: settlementNow,
+          });
+          for (const job of orphanJobs) {
+            yield* db.saveSettlementJob(job).pipe(Effect.catchAll(() => Effect.void));
+          }
+          settlementJobs.push(...orphanJobs);
+        }
         const processedJobs = yield* processSettlementJobs({
           adapter,
           db,
           jobs: settlementJobs,
           mode: autonomousExecution.mode,
-          now: Date.now(),
+          now: settlementNow,
           maxSwapSlippageBps: config.maxSwapSlippageBps,
           settlementDustUsd: autonomousExecution.settlementDustUsd,
         });
@@ -3990,9 +4013,20 @@ export const program = Effect.gen(function* () {
             walletAddress: autonomousExecution.walletAddress,
             agentInstanceId: autonomousExecution.agentInstanceId,
             reason: "settlement_overdue",
-            triggeredAt: Date.now(),
+            triggeredAt: settlementNow,
             resolvedAt: null,
           };
+          yield* db.saveSafetyPause(activeSafetyPause).pipe(Effect.catchAll(() => Effect.void));
+        } else if (
+          activeSafetyPause?.resolvedAt === null &&
+          activeSafetyPause.reason === "settlement_overdue" &&
+          processedJobs.every((job) => job.status === "confirmed" || job.status === "terminal")
+        ) {
+          // Issue #166: a settlement_overdue pause must not outlive the
+          // settlements that raised it — once nothing is in flight (429
+          // retries finally sold the token, or the orphan sweep recovered
+          // it), auto-resolve instead of latching until `prism resume`.
+          activeSafetyPause = { ...activeSafetyPause, resolvedAt: settlementNow };
           yield* db.saveSafetyPause(activeSafetyPause).pipe(Effect.catchAll(() => Effect.void));
         }
         activeSafetyPause = yield* db


### PR DESCRIPTION
Closes #166

## Problem
Jupiter 429 exhausts the settlement retry budget and the job goes `terminal` — a rate limit is transient by definition, so the swap-funded entry tokens stayed stranded in the wallet with no position and no recovery path. Observed live: 9JP6 rollback died after 6× `Jupiter quote failed: 429`, ~0.0308 MU left unbacked.

## Changes
1. **429/network errors are never terminal** (`engine/autonomous-runtime.ts`)
   - New `isTransientSettlementError`: HTTP 408/425/429/5xx and network failures (timeout, reset, DNS, abort) are retryable with the existing bounded backoff, indefinitely. Only non-transient failures (e.g. `INSUFFICIENT_FUNDS`) expire into `terminal` once the max-pending window passes — previous behavior preserved for them.
2. **Orphan-token sweep** (`sweepOrphanSettlements` + `orphanSettlementJobs`)
   - Every cycle (live/canary, wallet present): wallet SPL holdings not backed by an open position's pool legs or an active settlement job get a fresh sell-settlement job. Terminal jobs deliberately do **not** back a mint — a dead rollback is exactly what gets re-enqueued. Dust below `SETTLEMENT_DUST_USD` skipped; unpriceable tokens still enqueued (processor dust-skip re-applies). Fail-open end to end; pool-leg RPC fetches only run when candidates exist; holdings come from the existing 30s wallet snapshot.
   - New jobs are saved and processed in the same cycle.
3. **`settlement_overdue` pause auto-resolves** once no settlement is in flight (recovered token no longer leaves the agent latched until `prism resume`).
4. **`prism status` surfaces stranded capital**: text shows a `Stranded:` line for terminal settlements with unspent balance; JSON settlements now include `amountAtomic` / `confirmedOutputAtomic`.

## Verification
- 8 new tests (transient classifier, 429-past-expiry stays retryable, non-transient expiry terminal, orphan job builder, sweep against position legs + active jobs + terminal-job re-enqueue, no-wallet/no-candidates skips, fail-open) plus CLI status JSON/text coverage. Full suite: 1536/1536 pass; lint + build + oxfmt clean.
- Live state verified on the production host: MU is a Token-2022 holding still in the wallet (0.030805), the 9JP6 rollback is `terminal` (6×429), no position backs it — exactly the case the sweep re-enqueues on deploy.

## Out of scope (root cause 3 from the issue)
`InitializePosition` realloc failure (`Account data size realloc limited to 10240 in inner instructions`) is a separate position-account sizing path; the rollback/sweep recovers the capital regardless, but the entry failure itself deserves its own investigation.

## Summary by Sourcery

Make settlement handling resilient to transient 429/network errors and automatically recover stranded tokens while improving operator visibility and pause behavior.

Bug Fixes:
- Ensure rate-limit and network-related settlement failures remain retryable instead of becoming terminal, preventing swap-funded tokens from being stranded.
- Automatically re-enqueue sell-settlement jobs for wallet tokens not backed by open positions or active settlements, recovering capital from dead rollback jobs.
- Auto-resolve `settlement_overdue` safety pauses once all settlements are either confirmed or terminal so agents no longer remain latched unnecessarily.

Enhancements:
- Expose stranded terminal settlements with unspent balances in `prism status` text and JSON output to highlight unrecovered capital.
- Introduce an orphan-token sweep that derives candidate wallet holdings from cached balances and minimizes RPC usage while failing open on data fetch errors.

Tests:
- Add comprehensive tests covering transient error classification, expiry behavior for transient vs non-transient failures, orphan settlement job construction, orphan sweep behavior under various conditions, and CLI status stranded-capital reporting.