### PR TITLE
fix(engine): address #169 review — anchored transient regex, sweep revival, order-aware stranded status

### DIFF
--- a/bench/cli-autonomous-status.test.ts
+++ b/bench/cli-autonomous-status.test.ts
@@ -58,7 +58,7 @@ async function seedAutonomousState(
   dbPath: string,
   walletAddress: string,
   agentInstanceId: string,
-  options: { readonly recovered?: boolean } = {},
+  options: { readonly recovered?: boolean; readonly recurring?: boolean } = {},
 ): Promise<void> {
   await Effect.runPromise(
     Effect.gen(function* () {
@@ -171,6 +171,33 @@ async function seedAutonomousState(
           updatedAt: 4_000,
         });
       }
+      if (options.recurring) {
+        // A PREVIOUS recovery (confirmed, older than the terminal row) — the
+        // terminal record is a NEW stranding and must stay visible.
+        yield* db.saveSettlementJob({
+          id: "settlement-4",
+          walletAddress,
+          agentInstanceId,
+          positionId: "orphan:previous",
+          poolAddress: "",
+          tokenMint: "mint-2",
+          amountAtomic: "15413",
+          destinationAsset: "SOL",
+          status: "confirmed",
+          attempts: 1,
+          nextRetryAt: null,
+          txSignature: "previous-sig",
+          confirmedOutputAtomic: "1000000",
+          outputUsd: 10,
+          executionCostUsd: 0.1,
+          finalizedAt: null,
+          realizedPnlUsd: null,
+          expiresAt: 5_000,
+          error: null,
+          createdAt: 2_000,
+          updatedAt: 2_000,
+        });
+      }
       yield* db.saveSafetyPause({
         walletAddress,
         agentInstanceId,
@@ -266,6 +293,29 @@ describe("autonomous CLI operator surface", () => {
     expect(result.exitCode).toBe(0);
     const text = decode(result.stdout);
     expect(text).not.toContain("Stranded:");
+  });
+
+  it("still reports a terminal settlement newer than any confirmed recovery", async () => {
+    // Given a confirmed sale of mint-2 that PREDATES the terminal row — a
+    // recurring stranding (sold once, then stranded again) must stay visible.
+    testDirectory = mkdtempSync(join(tmpdir(), "prism-cli-autonomous-recurring-"));
+    const dbPath = join(testDirectory, "prism.db");
+    const walletKeypair = Keypair.generate();
+    const wallet = walletKeypair.publicKey.toBase58();
+    const agentInstanceId = "operator-test";
+    await seedAutonomousState(dbPath, wallet, agentInstanceId, { recurring: true });
+
+    // When
+    const result = runCli(["status"], {
+      SQLITE_DB_PATH: dbPath,
+      AGENT_INSTANCE_ID: agentInstanceId,
+      WALLET_PRIVATE_KEY: bs58.encode(walletKeypair.secretKey),
+    });
+
+    // Then the newer terminal record is reported as stranded.
+    expect(result.exitCode).toBe(0);
+    const text = decode(result.stdout);
+    expect(text).toContain("Stranded:    1 terminal settlement(s) with unspent balance");
   });
 
   it("marks the current wallet's active safety pause resolved without live execution", async () => {

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -819,6 +819,14 @@ describe("issue #166 settlement recovery", () => {
     // must not be classified transient (endless retry).
     expect(isTransientSettlementError(new Error("need 500 lamports"))).toBe(false);
     expect(isTransientSettlementError(new Error("amount 429 below minimum"))).toBe(false);
+    // Real HTTP-status formats without the `failed:` prefix stay transient.
+    expect(isTransientSettlementError(new Error("HTTP/1.1 500 Internal Server Error"))).toBe(
+      true,
+    );
+    expect(isTransientSettlementError(new Error("request failed with status code 429"))).toBe(
+      true,
+    );
+    expect(isTransientSettlementError(new Error("HTTP Error: Too Many Requests"))).toBe(true);
     expect(isTransientSettlementError(null)).toBe(false);
   });
 
@@ -1083,6 +1091,59 @@ describe("issue #166 settlement recovery", () => {
     // Then the paper-backed mint is still swept.
     expect(jobs).toHaveLength(1);
     expect(jobs[0]!.tokenMint).toBe("paper-leg-token");
+  });
+
+  it("does not revive terminal rows carrying a txSignature — spawns a fresh job instead", async () => {
+    // Given a terminal job terminalized via the not_found path (signature kept
+    // — the operator-reconciliation bucket). Reviving it would re-poll a dead
+    // signature forever, so the sweep must NOT revive it.
+    const holdings = new Map<string, { amountAtomic: bigint; decimals: number }>([
+      ["stranded-1", { amountAtomic: 15_413n, decimals: 6 }],
+    ]);
+    const adapter = {
+      hasWallet: () => true,
+      getWalletHoldings: () => Effect.succeed(holdings),
+      getPoolState: () => Effect.succeed(null),
+      getTokenPrices: (mints: string[]) =>
+        Effect.succeed(Object.fromEntries(mints.map((mint) => [mint, 1000]))),
+    } as unknown as AdapterApi;
+    const db = {
+      listSettlementJobs: () =>
+        Effect.succeed([
+          settlementJob({
+            id: "signed-terminal",
+            tokenMint: "stranded-1",
+            status: "terminal",
+            txSignature: "dead-sig",
+            error: "Swap signature not found until expiry — requires operator reconciliation",
+          }),
+        ]),
+      getAllPositions: () => Effect.succeed([]),
+    } as unknown as DbApi;
+
+    // When
+    const jobs = await Effect.runPromise(
+      sweepOrphanSettlements({
+        adapter,
+        db,
+        walletAddress: "wallet-1",
+        agentInstanceId: "primary",
+        settlementMaxPendingMs: 3_600_000,
+        settlementDustUsd: 0.1,
+        now: 10_000,
+      }),
+    );
+
+    // Then a FRESH signature-less job is created (not a revival of the row).
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toMatchObject({
+      id: expect.not.stringMatching(/^signed-terminal$/),
+      tokenMint: "stranded-1",
+      status: "pending",
+      attempts: 0,
+      txSignature: null,
+      positionId: expect.stringMatching(/^orphan:/),
+    });
   });
 
   it("fails open when the holdings read errors", async () => {

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -815,6 +815,10 @@ describe("issue #166 settlement recovery", () => {
     expect(isTransientSettlementError(new Error("ECONNRESET"))).toBe(true);
     expect(isTransientSettlementError(new Error("INSUFFICIENT_FUNDS"))).toBe(false);
     expect(isTransientSettlementError(new Error("invalid slippage param"))).toBe(false);
+    // A bare 3-digit number is NOT an HTTP status — deterministic failures
+    // must not be classified transient (endless retry).
+    expect(isTransientSettlementError(new Error("need 500 lamports"))).toBe(false);
+    expect(isTransientSettlementError(new Error("amount 429 below minimum"))).toBe(false);
     expect(isTransientSettlementError(null)).toBe(false);
   });
 
@@ -988,14 +992,20 @@ describe("issue #166 settlement recovery", () => {
       }),
     );
 
-    // Then only the stranded token gets a fresh job; the terminal job does not
-    // count as backing.
+    // Then only the stranded token gets a job: the terminal row is REVIVED in
+    // place (same id, attempts carried forward so backoff escalates across
+    // generations and the table stays one row per mint) — terminal jobs still
+    // do not count as backing.
     expect(jobs).toHaveLength(1);
     expect(jobs[0]).toMatchObject({
+      id: "dead",
       tokenMint: "stranded-1",
       amountAtomic: "15413",
       status: "pending",
-      attempts: 0,
+      attempts: 1,
+      nextRetryAt: 10_000,
+      expiresAt: 3_610_000,
+      error: null,
     });
   });
 

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -228,6 +228,7 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
                       ? null
                       : new Date(settlement.nextRetryAt).toISOString(),
                   expiresAt: new Date(settlement.expiresAt).toISOString(),
+                  createdAt: new Date(settlement.createdAt).toISOString(),
                   txSignature: settlement.txSignature,
                   error: settlement.error,
                 })),
@@ -301,18 +302,23 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
             : "agent overlay: off";
           // Issue #166: surface terminal settlements whose swap never
           // recovered the token so stranded capital stays visible until
-          // the orphan sweep re-queues it. A terminal record whose mint has
-          // since confirmed (sweep sold it) is historical, not stranded.
-          const confirmedMints = new Set(
-            autonomous.settlements
-              .filter((settlement) => settlement.status === "confirmed")
-              .map((settlement) => settlement.tokenMint),
-          );
+          // the orphan sweep re-queues it. A terminal record is historical
+          // only when a CONFIRMED settlement for the same mint is newer than
+          // it (the sweep sold the token) — a terminal record NEWER than any
+          // confirmed one is a recurring stranding and must stay visible.
+          const newestConfirmedAt = new Map<string, number>();
+          for (const settlement of autonomous.settlements) {
+            if (settlement.status !== "confirmed") continue;
+            const previous = newestConfirmedAt.get(settlement.tokenMint);
+            if (previous === undefined || settlement.createdAt > previous) {
+              newestConfirmedAt.set(settlement.tokenMint, settlement.createdAt);
+            }
+          }
           const strandedSettlements = autonomous.settlements.filter(
             (settlement) =>
               settlement.status === "terminal" &&
               settlement.confirmedOutputAtomic === null &&
-              !confirmedMints.has(settlement.tokenMint),
+              (newestConfirmedAt.get(settlement.tokenMint) ?? -1) < settlement.createdAt,
           );
 
           // Acceptance for issue #167: an active settlement_overdue pause

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -203,14 +203,17 @@ function atomicUsd(amountAtomic: bigint, decimals: number, priceUsd: number): nu
  * (insufficient funds, invalid params, malformed payloads) will not fix
  * itself by retrying.
  */
+const TRANSIENT_HTTP_STATUS =
+  /(?:failed|HTTP):?\s*(408|425|429|5\d{2})\b|HTTP\s+(408|425|429|5\d{2})\b/i;
+const TRANSIENT_NETWORK =
+  /fetch failed|timeout|timed out|timedout|aborted|ECONNRESET|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|socket hang up|connection refused|connection reset|network error/i;
+
 export function isTransientSettlementError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return (
-    /\b(408|425|429|5\d{2})\b/.test(message) ||
-    /fetch failed|timeout|timed out|timedout|aborted|ECONNRESET|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|socket hang up|connection refused|connection reset|network error/i.test(
-      message,
-    )
-  );
+  // Anchored to HTTP-status context — a bare \b\d{3}\b would classify
+  // deterministic messages like "need 500 lamports" as transient and retry
+  // them forever instead of terminalizing.
+  return TRANSIENT_HTTP_STATUS.test(message) || TRANSIENT_NETWORK.test(message);
 }
 
 function retryableJob(job: SettlementJobRecord, now: number, error: unknown): SettlementJobRecord {
@@ -592,6 +595,24 @@ export function sweepOrphanSettlements(
     const prices = yield* input.adapter
       .getTokenPrices(candidates.map(([mint]) => mint))
       .pipe(Effect.catch(() => Effect.succeed<Record<string, number>>({})));
+    // A terminal job for the mint is revived in place (upsert on id) rather
+    // than replaced by a fresh row: attempts carry over so backoff escalates
+    // across generations, and the settlements table stays one row per mint
+    // instead of growing ~1 row per max-pending window for a doomed token.
+    // Terminal rows carrying a txSignature are the operator-reconciliation
+    // bucket (swap signature never became visible) — reviving them would
+    // re-poll a dead signature forever, so only signature-less terminal rows
+    // are auto-revived; a signature terminal spawns a fresh job instead.
+    const terminalByMint = new Map<string, SettlementJobRecord>(
+      existingJobs
+        .filter(
+          (job) =>
+            job.status === "terminal" &&
+            job.confirmedOutputAtomic === null &&
+            job.txSignature === null,
+        )
+        .map((job) => [job.tokenMint, job]),
+    );
     const jobs: SettlementJobRecord[] = [];
     for (const [mint, holding] of holdings) {
       if (mint === SOL_MINT || holding.amountAtomic <= 0n) continue;
@@ -602,6 +623,21 @@ export function sweepOrphanSettlements(
         priceUsd > 0 &&
         atomicUsd(holding.amountAtomic, holding.decimals, priceUsd) < input.settlementDustUsd
       ) {
+        continue;
+      }
+      const terminal = terminalByMint.get(mint);
+      if (terminal) {
+        jobs.push({
+          ...terminal,
+          status: "pending",
+          attempts: terminal.attempts + 1,
+          // Sell what the wallet actually holds now, not the stale row amount.
+          amountAtomic: holding.amountAtomic.toString(),
+          nextRetryAt: input.now,
+          expiresAt: input.now + input.settlementMaxPendingMs,
+          error: null,
+          updatedAt: input.now,
+        });
         continue;
       }
       const id = randomUUID();

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -204,9 +204,9 @@ function atomicUsd(amountAtomic: bigint, decimals: number, priceUsd: number): nu
  * itself by retrying.
  */
 const TRANSIENT_HTTP_STATUS =
-  /(?:failed|HTTP):?\s*(408|425|429|5\d{2})\b|HTTP\s+(408|425|429|5\d{2})\b/i;
+  /(?:failed|HTTP):?\s*(408|425|429|5\d{2})\b|HTTP\/\d(?:\.\d)?\s+(408|425|429|5\d{2})\b|status code (408|425|429|5\d{2})\b/i;
 const TRANSIENT_NETWORK =
-  /fetch failed|timeout|timed out|timedout|aborted|ECONNRESET|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|socket hang up|connection refused|connection reset|network error/i;
+  /fetch failed|timeout|timed out|timedout|aborted|ECONNRESET|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|socket hang up|connection refused|connection reset|network error|too many requests/i;
 
 export function isTransientSettlementError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Follow-up addressing kilo-code-bot's post-merge review comments on #169:

1. **isTransientSettlementError anchored** (autonomous-runtime.ts:209) — the bare `\b(408|425|429|5\d{2})\b` matched any 3-digit number; "need 500 lamports" classified transient → endless retry. Now anchored to HTTP context (`failed:/HTTP <code>`) with the network-phrase list separate.
2. **Sweep revival instead of fresh rows** (autonomous-runtime.ts:618) — a terminal job's row is revived in place (same id, upsert): attempts carry forward so backoff escalates across generations, and the settlements table stays one row per mint (previously ~1 new terminal row per max-pending window for a doomed token). The revived row sells the current wallet holding amount.
3. **Order-aware Stranded dedupe** (cli/status.ts:311) — a terminal record is hidden only when a confirmed settlement for the same mint is NEWER than it; a terminal newer than any confirmed one (recurring stranding) stays visible. `createdAt` added to the settlements JSON.

Tests: negative transient cases (500 lamports / 429 amount), revival semantics (same id, attempts 1, current amount), recurring-stranding CLI test. Full suite 1554/1554, lint + format clean.

## Summary by Sourcery

Refine autonomous settlement error handling and stranded status reporting to avoid endless retries and keep recurring stranding visible.

Bug Fixes:
- Anchor transient HTTP status detection to actual HTTP-context phrases and separate network error matching so non-HTTP numeric messages are not retried indefinitely.
- Revive existing terminal settlement jobs in place on orphan sweeps so attempts and backoff carry forward while selling the current wallet balance.
- Make CLI stranded-settlement reporting order-aware so only terminal records older than a confirmed recovery are hidden, keeping newer recurring strandings visible.

Tests:
- Extend autonomous engine and CLI tests to cover non-transient numeric error messages, terminal job revival semantics, and recurring-stranding visibility in status output.