### PR TITLE
fix: bundle effect into release bundles; keep recoverable previous install (#179)

### DIFF
--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -820,12 +820,8 @@ describe("issue #166 settlement recovery", () => {
     expect(isTransientSettlementError(new Error("need 500 lamports"))).toBe(false);
     expect(isTransientSettlementError(new Error("amount 429 below minimum"))).toBe(false);
     // Real HTTP-status formats without the `failed:` prefix stay transient.
-    expect(isTransientSettlementError(new Error("HTTP/1.1 500 Internal Server Error"))).toBe(
-      true,
-    );
-    expect(isTransientSettlementError(new Error("request failed with status code 429"))).toBe(
-      true,
-    );
+    expect(isTransientSettlementError(new Error("HTTP/1.1 500 Internal Server Error"))).toBe(true);
+    expect(isTransientSettlementError(new Error("request failed with status code 429"))).toBe(true);
     expect(isTransientSettlementError(new Error("HTTP Error: Too Many Requests"))).toBe(true);
     expect(isTransientSettlementError(null)).toBe(false);
   });

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -239,25 +239,48 @@ function atomicReplaceInstall(installDir: string, newDir: string): string {
 /**
  * Issue #179: the success path deleted the previous install immediately, so a
  * `--skip-smoke-test` update (or a smoke false-pass) installed a broken bundle
- * with no way back. Keep ONE persistent backup of the previous version next
- * to the install dir — it survives the update and is replaced by the next
- * update's backup, so the previous version is always recoverable by renaming
- * it back into place.
+ * with no way back. Keep ONE persistent backup of the previous version next to
+ * the install dir — it survives the update and is replaced by the next update's
+ * backup, so the previous version is always recoverable by renaming it back
+ * into place. The backup is named after the version it CONTAINS (the previous
+ * install), not the version being installed.
+ *
+ * Failure-safe replacement: stale backups are only removed AFTER the new backup
+ * is in place — never destroy the only recoverable previous install when there
+ * is nothing to replace it with. A rename failure throws and the caller's
+ * rollback restores the previous install.
  */
-function persistPreviousInstall(backupDir: string, installDir: string, version: string): void {
+function persistPreviousInstall(
+  backupDir: string,
+  installDir: string,
+  previousVersion: string,
+): void {
   const parent = dirname(installDir);
   const base = basename(installDir);
+  if (!existsSync(backupDir)) {
+    console.warn(
+      `No previous install backup found at ${backupDir} — leaving stale backups untouched`,
+    );
+    return;
+  }
+  const persistent = join(parent, `${base}.bak-${previousVersion}`);
+  // Idempotent re-run: replace a stale backup of the same version.
+  if (existsSync(persistent) && persistent !== backupDir) {
+    rmSync(persistent, { recursive: true, force: true });
+  }
+  renameSync(backupDir, persistent);
   const staleBackups = readdirSync(parent)
-    .filter((name) => name.startsWith(`${base}.bak-`))
+    .filter((name) => {
+      const full = join(parent, name);
+      if (full === persistent) return false;
+      return name.startsWith(`${base}.bak-`) || name.startsWith(".prism-update-backup-");
+    })
     .map((name) => join(parent, name));
   for (const stale of staleBackups) {
     rmSync(stale, { recursive: true, force: true });
   }
-  if (!existsSync(backupDir)) return;
-  const persistent = join(parent, `${base}.bak-${version}`);
-  renameSync(backupDir, persistent);
   console.log(
-    `Previous version preserved at ${persistent} — recoverable by renaming it to ${installDir}`,
+    `Previous version (${previousVersion}) preserved at ${persistent} — recoverable by renaming it to ${installDir}`,
   );
 }
 
@@ -521,11 +544,13 @@ async function updateFromSource(
 
   const wrapperBin = resolveWrapperBin();
   const isSymlink = isWrapperSymlink(wrapperBin);
+  const previousVersion = getCurrentVersion();
   const backupDir = atomicReplaceInstall(currentDir, sourceRoot);
 
   try {
     rewriteWrapperSymlink(wrapperBin, currentDir);
     smokeTest(wrapperBin, skipSmokeTest);
+    persistPreviousInstall(backupDir, currentDir, previousVersion);
   } catch (smokeErr) {
     console.error("Smoke test failed — rolling back");
     if (existsSync(currentDir)) {
@@ -542,8 +567,6 @@ async function updateFromSource(
         `Error: ${smokeErr instanceof Error ? smokeErr.message : String(smokeErr)}`,
     );
   }
-
-  persistPreviousInstall(backupDir, currentDir, release.version);
 }
 
 async function updateFromBundle(
@@ -574,6 +597,7 @@ async function updateFromBundle(
   preserveUserData(installDir, bundleRoot);
 
   console.log("Installing bundle...");
+  const previousVersion = getCurrentVersion();
   const backupDir = atomicReplaceInstall(installDir, bundleRoot);
 
   const wrapperBin = resolveWrapperBin();
@@ -582,6 +606,8 @@ async function updateFromBundle(
     rewriteBundleWrapper(wrapperBin, installDir);
     failedOperation = "smoke test";
     smokeTest(wrapperBin, skipSmokeTest);
+    failedOperation = "backup persistence";
+    persistPreviousInstall(backupDir, installDir, previousVersion);
   } catch (smokeErr) {
     console.error(`${failedOperation} failed — rolling back`);
     if (existsSync(installDir)) {
@@ -615,8 +641,6 @@ async function updateFromBundle(
         `Error: ${smokeErr instanceof Error ? smokeErr.message : String(smokeErr)}`,
     );
   }
-
-  persistPreviousInstall(backupDir, installDir, release.version);
 }
 
 export const updateCommand = new Command("update")

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -8,6 +8,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -15,7 +16,7 @@ import {
   writeFileSync,
 } from "fs";
 import { pipeline } from "stream/promises";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 import { tmpdir, homedir } from "os";
 import { createHash } from "crypto";
 import { getCurrentVersion } from "../engine/version.js";
@@ -233,6 +234,31 @@ function atomicReplaceInstall(installDir: string, newDir: string): string {
     throw err;
   }
   return backupDir;
+}
+
+/**
+ * Issue #179: the success path deleted the previous install immediately, so a
+ * `--skip-smoke-test` update (or a smoke false-pass) installed a broken bundle
+ * with no way back. Keep ONE persistent backup of the previous version next
+ * to the install dir — it survives the update and is replaced by the next
+ * update's backup, so the previous version is always recoverable by renaming
+ * it back into place.
+ */
+function persistPreviousInstall(backupDir: string, installDir: string, version: string): void {
+  const parent = dirname(installDir);
+  const base = basename(installDir);
+  const staleBackups = readdirSync(parent)
+    .filter((name) => name.startsWith(`${base}.bak-`))
+    .map((name) => join(parent, name));
+  for (const stale of staleBackups) {
+    rmSync(stale, { recursive: true, force: true });
+  }
+  if (!existsSync(backupDir)) return;
+  const persistent = join(parent, `${base}.bak-${version}`);
+  renameSync(backupDir, persistent);
+  console.log(
+    `Previous version preserved at ${persistent} — recoverable by renaming it to ${installDir}`,
+  );
 }
 
 function smokeTest(wrapperBin: string, skipSmokeTest: boolean): void {
@@ -517,9 +543,7 @@ async function updateFromSource(
     );
   }
 
-  if (existsSync(backupDir)) {
-    rmSync(backupDir, { recursive: true, force: true });
-  }
+  persistPreviousInstall(backupDir, currentDir, release.version);
 }
 
 async function updateFromBundle(
@@ -592,9 +616,7 @@ async function updateFromBundle(
     );
   }
 
-  if (existsSync(backupDir)) {
-    rmSync(backupDir, { recursive: true, force: true });
-  }
+  persistPreviousInstall(backupDir, installDir, release.version);
 }
 
 export const updateCommand = new Command("update")

--- a/tsdown.cli.config.ts
+++ b/tsdown.cli.config.ts
@@ -23,9 +23,24 @@ export default defineConfig({
   deps: {
     neverBundle: ["bun:sqlite"],
   },
-  // Release bundles ship without node_modules. sqlite-vec's JS must be inlined
-  // so its npm load() fails gracefully inside the load chain (caught, then
-  // PRISM_VEC0_PATH / embedded fallbacks run) instead of crashing the CLI on
-  // an unresolvable bare import.
-  noExternal: ["sqlite-vec"],
+  // Release bundles ship without node_modules and the runtime resolves bare
+  // imports from bun's global cache — which can hold the WRONG effect major
+  // (issue #179: v0.1.9 bundle called Context.Service against cached effect 3).
+  // Bundle every runtime dependency so the artifact is version-consistent and
+  // self-contained. @xenova/transformers stays external: it is only loaded for
+  // the optional ONNX embeddings backend and its import failure is already
+  // caught with a fallback to hash vectors.
+  noExternal: [
+    "sqlite-vec",
+    "effect",
+    "commander",
+    "chalk",
+    "dotenv",
+    "@clack/prompts",
+    "semver",
+    "bs58",
+    "@solana/web3.js",
+    "@solana/spl-token",
+    "@meteora-ag/dlmm",
+  ],
 });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -26,4 +26,22 @@ export default defineConfig({
   deps: {
     neverBundle: ["bun:sqlite"],
   },
+  // See tsdown.cli.config.ts: release bundles ship without node_modules and
+  // bare imports resolve from bun's global cache — which broke v0.1.9 (issue
+  // #179). Bundle every runtime dependency; @xenova/transformers stays
+  // external (optional ONNX backend, import failure falls back to hash
+  // vectors).
+  noExternal: [
+    "sqlite-vec",
+    "effect",
+    "commander",
+    "chalk",
+    "dotenv",
+    "@clack/prompts",
+    "semver",
+    "bs58",
+    "@solana/web3.js",
+    "@solana/spl-token",
+    "@meteora-ag/dlmm",
+  ],
 });


### PR DESCRIPTION
Closes #179

## Root cause
v0.1.9 crashed at startup (`Context.Service is not a function`) because tsdown externalizes package.json dependencies and the release tarball ships no node_modules — the installed bundle resolved `effect` from bun's global cache, which held 3.x. The CLI chunk called the v4 `Context.Service()` API against the v3 runtime. (Verified on the server: `import("effect")` resolves with `Context.Tag` present and `Context.Service` undefined, zero node_modules on disk.)

## Fixes
1. **Self-contained bundles**: bundle every runtime dependency (effect, @solana/web3.js, @meteora-ag/dlmm, commander, chalk, dotenv, @clack/prompts, semver, bs58, @solana/spl-token, sqlite-vec) into the engine and CLI bundles in both tsdown configs. @xenova/transformers stays external (optional ONNX backend; its import failure already falls back to hash vectors). Verified in a node_modules-less directory: `prism --version`, `--help`, and a full `prism status` (entire service stack boots).
2. **Update hardening**: `prism update` now keeps ONE persistent backup of the previous install (`<installDir>.bak-<version>`) instead of deleting it after the smoke test, so the previous version is always recoverable — including the `--skip-smoke-test` path that installed the broken bundle with no backup. The next update replaces the stale backup.

## Acceptance from the issue
- [x] `prism update` never leaves the install dir absent or non-bootable; previous version always recoverable (persistent backup)
- [x] Bundle boots: `--version`, `--help`, `status` verified in a node_modules-less sim

## Summary by Sourcery

Ensure release bundles are self-contained with pinned runtime dependencies and make CLI updates preserve a recoverable backup of the previous installation.

Enhancements:
- Bundle all runtime dependencies (except the optional @xenova/transformers) into both engine and CLI tsdown builds to avoid relying on Bun's global cache.
- Preserve a single persistent backup of the previous installed version during `prism update`, replacing older backups and logging its recovery path.
- Tidy a settlement recovery benchmark test assertion formatting without changing behavior.

Tests:
- Adjust formatting of transient settlement error benchmark expectations without modifying test coverage or logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Successful application updates now retain the previous installation in a versioned backup, remove outdated backups, and report the retained backup location for recovery.
- **Bug Fixes**
  - Improved CLI and application packaging ensures required runtime components are included, supporting more reliable operation.
  - Optional ONNX embedding support remains available with existing fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->