### PR TITLE
chore(lint): wire Effect type-aware oxlint rules via @effect/tsgo

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,14 +3,18 @@
   "options": {
     "typeAware": true
   },
-  "plugins": ["effecttsgo"],
+  "plugins": ["effecttsgo", "typescript", "unicorn", "oxc"],
   "categories": {
     "correctness": "error"
   },
   "rules": {
     "no-unused-vars": "off",
     "require-yield": "off",
-    "effecttsgo/any-unknown-in-error-context": "warn"
+    "effecttsgo/any-unknown-in-error-context": "warn",
+    "typescript/no-base-to-string": "warn",
+    "typescript/no-floating-promises": "warn",
+    "typescript/unbound-method": "warn",
+    "typescript/restrict-template-expressions": "warn"
   },
   "env": {
     "builtin": true

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,16 +1,16 @@
 {
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": [
-    "typescript",
-    "unicorn",
-    "oxc"
-  ],
+  "$schema": "./node_modules/@effect/tsgo/oxlint-schema.json",
+  "options": {
+    "typeAware": true
+  },
+  "plugins": ["effecttsgo"],
   "categories": {
     "correctness": "error"
   },
   "rules": {
     "no-unused-vars": "off",
-    "require-yield": "off"
+    "require-yield": "off",
+    "effecttsgo/any-unknown-in-error-context": "warn"
   },
   "env": {
     "builtin": true

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "sqlite-vec": "^0.1.9",
       },
       "devDependencies": {
-        "@effect/tsgo": "^0.35.0",
+        "@effect/tsgo": "0.35.0",
         "@types/node": "^26.1.2",
         "@types/semver": "^7.8.0",
         "@vitest/coverage-istanbul": "^4.1.10",
@@ -26,7 +26,7 @@
         "fast-check": "^4.9.0",
         "oxfmt": "^0.62.0",
         "oxlint": "^1.77.0",
-        "oxlint-tsgolint": "^7.0.2001",
+        "oxlint-tsgolint": "7.0.2001",
         "tsdown": "^0.22.14",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10",

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "sqlite-vec": "^0.1.9",
       },
       "devDependencies": {
+        "@effect/tsgo": "^0.35.0",
         "@types/node": "^26.1.2",
         "@types/semver": "^7.8.0",
         "@vitest/coverage-istanbul": "^4.1.10",
@@ -25,6 +26,7 @@
         "fast-check": "^4.9.0",
         "oxfmt": "^0.62.0",
         "oxlint": "^1.77.0",
+        "oxlint-tsgolint": "^7.0.2001",
         "tsdown": "^0.22.14",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10",
@@ -78,6 +80,22 @@
     "@coral-xyz/anchor-errors": ["@coral-xyz/anchor-errors@0.31.1", "", {}, "sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ=="],
 
     "@coral-xyz/borsh": ["@coral-xyz/borsh@0.31.0", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.69.0" } }, "sha512-DwdQ5fuj+rGQCTKRnxnW1W2lvcpBaFc9m9M1TcGGlm+bwCcggmDgbLKLgF+LjIrKnc7Nd+bCACx5RA9YTK2I4Q=="],
+
+    "@effect/tsgo": ["@effect/tsgo@0.35.0", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.35.0", "@effect/tsgo-darwin-x64": "0.35.0", "@effect/tsgo-linux-arm": "0.35.0", "@effect/tsgo-linux-arm64": "0.35.0", "@effect/tsgo-linux-x64": "0.35.0", "@effect/tsgo-win32-arm64": "0.35.0", "@effect/tsgo-win32-x64": "0.35.0" }, "bin": { "effect-tsgo": "dist/effect-tsgo.cjs" } }, "sha512-10UWtAhbl/AlMSXKwo2xp9HkNtrzXpxgeWTH8vWKo7Ir6DAsOIYAJjTjDxud3sCb2vJtxi2zHg6Qq3/i/MKxzQ=="],
+
+    "@effect/tsgo-darwin-arm64": ["@effect/tsgo-darwin-arm64@0.35.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zp1nnKYPyl8Us+1igPePPEkbIElCu5yrr5NyQf/nxqxZkniohMtm4hJXA5BDwz0Tv7IvWPCsHuJ8ISg6i8LkxA=="],
+
+    "@effect/tsgo-darwin-x64": ["@effect/tsgo-darwin-x64@0.35.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-6lNk1j0o/ReXihhiqQdhzvJll/ClrkEJwUtPpMBcUtlmH+8svSH50+S84GOzJMwp2ghw/hyJld6Lc8wzzry0Jw=="],
+
+    "@effect/tsgo-linux-arm": ["@effect/tsgo-linux-arm@0.35.0", "", { "os": "linux", "cpu": "arm" }, "sha512-BmDz9FGnGLy8HIzWx2VPdRCKbFXpbCCJFzSnkMMYYHHkNP+6CRqETW7x4HFbxuIFxxiGRXfxiE5ui2lomCBWZA=="],
+
+    "@effect/tsgo-linux-arm64": ["@effect/tsgo-linux-arm64@0.35.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-DsSBnE5LGWvxKUZrhvtQL0H9nDQcOyef0ct7c5Rws46tgBM9nssEj/Q45GAD+JTVwBKcEvvzPEgDSLY+fFYtvw=="],
+
+    "@effect/tsgo-linux-x64": ["@effect/tsgo-linux-x64@0.35.0", "", { "os": "linux", "cpu": "x64" }, "sha512-mq++Fyn4T/0FSviRrGcOAE1FKnXHFeQLtfOEJgfAEZw4/yiE7JLV0akJgFw3wjaEQx8bmbRb20UBcAI84zQ5AA=="],
+
+    "@effect/tsgo-win32-arm64": ["@effect/tsgo-win32-arm64@0.35.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-o76O+JMa1KAJnd3QVDLmeBGTt23VE5IBbuzUhYWHG6UQ0YQynSMo0vZXOmrrPH0KARD7uJAgEMaJu/SReYDObA=="],
+
+    "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.35.0", "", { "os": "win32", "cpu": "x64" }, "sha512-IC4nRkMZBCwCdGsqjQQnw7vE6aQFP0jkhkD/rQwb40m6AQN8mqrgq6jXm2WHVxsslrqWu4DXPC3ZHZQjJO50lg=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
@@ -158,6 +176,18 @@
     "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw=="],
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ=="],
+
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@7.0.2001", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w=="],
+
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@7.0.2001", "", { "os": "darwin", "cpu": "x64" }, "sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw=="],
+
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@7.0.2001", "", { "os": "linux", "cpu": "arm64" }, "sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A=="],
+
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@7.0.2001", "", { "os": "linux", "cpu": "x64" }, "sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ=="],
+
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@7.0.2001", "", { "os": "win32", "cpu": "arm64" }, "sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q=="],
+
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
 
     "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.77.0", "", { "os": "android", "cpu": "arm" }, "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ=="],
 
@@ -760,6 +790,8 @@
     "oxfmt": ["oxfmt@0.62.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.62.0", "@oxfmt/binding-android-arm64": "0.62.0", "@oxfmt/binding-darwin-arm64": "0.62.0", "@oxfmt/binding-darwin-x64": "0.62.0", "@oxfmt/binding-freebsd-x64": "0.62.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.62.0", "@oxfmt/binding-linux-arm-musleabihf": "0.62.0", "@oxfmt/binding-linux-arm64-gnu": "0.62.0", "@oxfmt/binding-linux-arm64-musl": "0.62.0", "@oxfmt/binding-linux-ppc64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-musl": "0.62.0", "@oxfmt/binding-linux-s390x-gnu": "0.62.0", "@oxfmt/binding-linux-x64-gnu": "0.62.0", "@oxfmt/binding-linux-x64-musl": "0.62.0", "@oxfmt/binding-openharmony-arm64": "0.62.0", "@oxfmt/binding-win32-arm64-msvc": "0.62.0", "@oxfmt/binding-win32-ia32-msvc": "0.62.0", "@oxfmt/binding-win32-x64-msvc": "0.62.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ=="],
 
     "oxlint": ["oxlint@1.77.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.77.0", "@oxlint/binding-android-arm64": "1.77.0", "@oxlint/binding-darwin-arm64": "1.77.0", "@oxlint/binding-darwin-x64": "1.77.0", "@oxlint/binding-freebsd-x64": "1.77.0", "@oxlint/binding-linux-arm-gnueabihf": "1.77.0", "@oxlint/binding-linux-arm-musleabihf": "1.77.0", "@oxlint/binding-linux-arm64-gnu": "1.77.0", "@oxlint/binding-linux-arm64-musl": "1.77.0", "@oxlint/binding-linux-ppc64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-musl": "1.77.0", "@oxlint/binding-linux-s390x-gnu": "1.77.0", "@oxlint/binding-linux-x64-gnu": "1.77.0", "@oxlint/binding-linux-x64-musl": "1.77.0", "@oxlint/binding-openharmony-arm64": "1.77.0", "@oxlint/binding-win32-arm64-msvc": "1.77.0", "@oxlint/binding-win32-ia32-msvc": "1.77.0", "@oxlint/binding-win32-x64-msvc": "1.77.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg=="],
+
+    "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
     "pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
 

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -7680,5 +7680,5 @@ export const program = Effect.gen(function* () {
   process.on("SIGINT", () => gracefulShutdown("SIGINT"));
   process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
 
-  yield* Fiber.join(schedulerFiber);
+  return yield* Fiber.join(schedulerFiber);
 });

--- a/engine/update-check.ts
+++ b/engine/update-check.ts
@@ -91,7 +91,7 @@ export function checkForAutoUpdate(config: AppConfig, db: DbApi): Effect.Effect<
           `is ${daysSinceInstall} days old (threshold: ${config.forceUpdateAfterDays} days). ` +
           `Shutting down to enforce update. Run "prism update" to apply.`,
       );
-      yield* Effect.sync(() => {
+      return yield* Effect.sync(() => {
         process.exit(1);
       });
     } else if (config.forceUpdateEnabled && daysUntilForce <= 1) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lint": "tsc --noEmit && oxlint engine ops bench cli scripts",
     "format": "oxfmt --write engine ops bench cli scripts",
     "format:check": "oxfmt --check engine ops bench cli scripts",
-    "coverage": "bun --bun vitest run --coverage"
+    "coverage": "bun --bun vitest run --coverage",
+    "prepare": "effect-tsgo patch --oxlint"
   },
   "dependencies": {
     "@clack/prompts": "^1.7.0",
@@ -48,6 +49,7 @@
     "sqlite-vec": "^0.1.9"
   },
   "devDependencies": {
+    "@effect/tsgo": "^0.35.0",
     "@types/node": "^26.1.2",
     "@types/semver": "^7.8.0",
     "@vitest/coverage-istanbul": "^4.1.10",
@@ -55,6 +57,7 @@
     "fast-check": "^4.9.0",
     "oxfmt": "^0.62.0",
     "oxlint": "^1.77.0",
+    "oxlint-tsgolint": "^7.0.2001",
     "tsdown": "^0.22.14",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format": "oxfmt --write engine ops bench cli scripts",
     "format:check": "oxfmt --check engine ops bench cli scripts",
     "coverage": "bun --bun vitest run --coverage",
-    "prepare": "effect-tsgo patch --oxlint"
+    "prepare": "effect-tsgo patch --oxlint || echo \"warning: effect-tsgo patch failed (unsupported platform or version mismatch) — type-aware effect lint disabled\""
   },
   "dependencies": {
     "@clack/prompts": "^1.7.0",
@@ -49,7 +49,7 @@
     "sqlite-vec": "^0.1.9"
   },
   "devDependencies": {
-    "@effect/tsgo": "^0.35.0",
+    "@effect/tsgo": "0.35.0",
     "@types/node": "^26.1.2",
     "@types/semver": "^7.8.0",
     "@vitest/coverage-istanbul": "^4.1.10",
@@ -57,7 +57,7 @@
     "fast-check": "^4.9.0",
     "oxfmt": "^0.62.0",
     "oxlint": "^1.77.0",
-    "oxlint-tsgolint": "^7.0.2001",
+    "oxlint-tsgolint": "7.0.2001",
     "tsdown": "^0.22.14",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"


### PR DESCRIPTION
From the EffectTS announcement — the LSP-derived rules now run in oxlint type-aware mode.

- Adds `@effect/tsgo` + `oxlint-tsgolint`; `prepare` script runs `effect-tsgo patch --oxlint` so the patch is reapplied after every install (validated version match).
- `.oxlintrc.json` uses the tsgo schema, `typeAware: true`, `effecttsgo` plugin.
- **Fixed the 2 real findings** (`missing-return-yield-star`): force-update shutdown in update-check and the scheduler-fiber join in program now end their generators with `return yield*` — a definitive exit point for type narrowing.
- `effecttsgo/any-unknown-in-error-context` (1464 findings) is **warn-level**: the repo deliberately types service/IO boundaries as `Effect<A, unknown>` and narrows at consumers; erroring would force a repo-wide TaggedError refactor. Visible in lint output, non-blocking.

Verified: tsc clean, 1555/1555 tests, lint passes with 0 errors.

## Summary by Sourcery

Integrate EffectTS type-aware linting via tsgo into the project and address the resulting generator exit-point issues.

New Features:
- Add EffectTS tsgo integration and oxlint tsgo plugin to enable type-aware linting.

Bug Fixes:
- Ensure engine program scheduler fiber join generator has a definitive return point.
- Ensure update-check force-update shutdown generator exits via a returned effect for clearer control flow.

Enhancements:
- Configure oxlint to use the tsgo schema with type-aware mode and the effecttsgo plugin, treating any-unknown-in-error-context as a warning.

Build:
- Add a prepare script that reapplies the effect-tsgo oxlint patch after installations.