### PR TITLE
fix(autonomous): auto-resolve latched execution_failures safety pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Prism are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- The `execution_failures` safety pause is no longer a permanent one-way latch: each cycle re-evaluates the current failure counter and auto-resolves when it is below `MAX_CONSECUTIVE_EXECUTION_FAILURES` (a fresh process starts at 0, so a restart alone clears a stale latch); the pause re-arms only when the counter genuinely breaches again, and `prism resume` stays an operator override (#182)
+- Unpriceable wallet tokens are dust for the orphan sweep: a token with no resolvable USD price is value-unknown ⇒ $0, so the sweep skips it and the settlement processor dust-confirms existing jobs with a distinct "settlement dust skipped (no USD price)" error instead of quoting them — the Jupiter 400 no-route retry loop is gone, and tokens re-qualify automatically once a price resolves. `prism status` reconciles the Stranded line with the dust policy: sub-dust terminal settlements are excluded (they are intentionally never re-queued), priceable stranded capital shows its USD value, and unpriceable terminals get a separate Unpriceable line (#183)
+- `prism update` now detects a running agent after a successful update (dev lockfile or process scan, including the bundled `dist/cli/index.mjs dev` systemd pattern) and prints a prominent restart-required notice with the exact restart command, exiting non-zero (code 2, distinct from update-failure's 1) so scripts can tell "updated, restart needed" apart from "update failed" — the running agent keeps executing the old build until restarted (#184)
+
 ## [0.1.10] — 2026-08-08
 
 ### Fixed

--- a/bench/cli-dev-lockfile.test.ts
+++ b/bench/cli-dev-lockfile.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
-import { acquireLock, releaseLock, isProcessAlive, readLockfile } from "../cli/lockfile.js";
+import {
+  acquireLock,
+  releaseLock,
+  isProcessAlive,
+  readLockfile,
+  findRunningEngineProcess,
+} from "../cli/lockfile.js";
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "prism-lockfile-"));
@@ -111,5 +117,32 @@ describe("cli/lockfile", () => {
 
   it("isProcessAlive returns false for impossible PID", () => {
     expect(isProcessAlive(99999999)).toBe(false);
+  });
+
+  it("findRunningEngineProcess detects the bundled CLI dev process (issue #184)", () => {
+    // Given a ps snapshot where the agent runs from the release bundle
+    // (`bun /root/.prism/dist/cli/index.mjs dev` — the systemd pattern), the
+    // source-path matchers alone miss it.
+    const spawner = () => ({
+      stdout: [
+        `${process.pid} some-unrelated-command`,
+        `${process.pid + 1} bun /root/.prism/dist/cli/index.mjs dev`,
+        `${process.pid + 2} bun install`,
+      ].join("\n"),
+    });
+    const found = findRunningEngineProcess(spawner);
+    expect(found).toEqual({ pid: process.pid + 1, command: `bun /root/.prism/dist/cli/index.mjs dev` });
+  });
+
+  it("findRunningEngineProcess ignores index.mjs runs without a dev argument", () => {
+    // Given a ps snapshot with a plain bundled entry (e.g. the Docker image
+    // runs `bun dist/index.mjs`) and an unrelated script.
+    const spawner = () => ({
+      stdout: [
+        `${process.pid + 1} bun /root/.prism/dist/index.mjs`,
+        `${process.pid + 2} bun tools/index.mjs build`,
+      ].join("\n"),
+    });
+    expect(findRunningEngineProcess(spawner)).toBeNull();
   });
 });

--- a/cli/lockfile.ts
+++ b/cli/lockfile.ts
@@ -102,7 +102,11 @@ export function findRunningEngineProcess(
       if (
         args.includes("engine/index.ts") ||
         args.includes("run dev") ||
-        args.includes("cli/dev.ts")
+        args.includes("cli/dev.ts") ||
+        // Bundled CLI dev process (e.g. `bun /root/.prism/dist/cli/index.mjs
+        // dev` under systemd): the source-path patterns above do not match
+        // the bundle, so match any `index.mjs` run with a `dev` argument.
+        (args.includes("index.mjs") && args.includes("dev"))
       ) {
         return { pid, command: args };
       }

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -31,6 +31,7 @@ import {
 } from "../engine/update-utils.js";
 import { Effect } from "effect";
 import { createLogger } from "../engine/logger.js";
+import { findRunningEngineProcess, isProcessAlive, readLockfile } from "./lockfile.js";
 
 if (typeof Bun === "undefined") {
   console.error("The prism update command requires the Bun runtime.");
@@ -718,6 +719,33 @@ export const updateCommand = new Command("update")
 
       logger.info(`Updated to ${latest} from ${release.source}`);
       console.log(`✓ Updated to ${latest}`);
+
+      // Issue #184: `prism update` replaces the bundle on disk, but the
+      // running agent keeps executing the OLD build in memory — there is no
+      // restart logic, and the success output used to give no hint that the
+      // fix is not live yet (an operator watching a broken release believed
+      // the update fixed it while the old code kept running for hours).
+      // Detect the running agent (dev lockfile or process scan) and surface
+      // a prominent restart-required notice; exit non-zero (2, distinct from
+      // update-failure's 1) so scripts/cron can tell "updated, restart
+      // needed" apart from "update failed".
+      const lock = readLockfile();
+      const runningEngine = findRunningEngineProcess();
+      const runningPid =
+        (lock !== null && isProcessAlive(lock.pid) ? lock.pid : null) ??
+        runningEngine?.pid ??
+        null;
+      if (runningPid !== null) {
+        console.log("");
+        console.log(
+          `RESTART REQUIRED — the running Prism agent (PID ${runningPid}) is still executing the OLD build.`,
+        );
+        console.log("  The new version is installed, verified, and will go live on the next restart.");
+        console.log("  Restart it with:");
+        console.log("    systemctl --user restart prism-agent.service   (systemd user service)");
+        console.log(`    kill ${runningPid} && prism dev                 (manual/foreground run)`);
+        process.exitCode = 2;
+      }
 
       // Reset version install timestamp for force-update tracking
       try {


### PR DESCRIPTION
Fixes #182

## Problem

The `execution_failures` safety pause was a permanent one-way latch: only `prism resume` cleared it, and the scan cycle never re-evaluated it. A single transient failure spike (rate limits, RPC blips, the pre-fix #170 wallet-drain batch) halted the agent forever — the latch even survived restarts, because the trigger counter is session-local and resets to 0 in a fresh process while the persisted pause stayed `active=true, resolvedAt=null`. Every cycle then blocked ENTER via `safetyPauseBlockReason`.

## Fix

Mirror the issue #148 `daily_drawdown` pattern:

- New pure helper `shouldAutoResolveExecutionFailuresPause` in `engine/autonomous-runtime.ts` (mode-aware, same contract as the daily-drawdown one):
  - `shadow` — informational-only pause, always auto-resolve.
  - `canary`/`live` — auto-resolve when the current `consecutiveExecutionFailures` is below `MAX_CONSECUTIVE_EXECUTION_FAILURES` (a fresh process starts at 0, so a restart alone clears a stale latch).
  - Non-positive threshold (breaker off) never latches.
- Wired into `runScanCycle` next to the existing arm block: each cycle, an active `execution_failures` pause is auto-resolved when the counter no longer breaches; the existing trigger block re-arms only when the counter genuinely breaches again.
- `prism resume` remains an operator override.

## Verification

- `bun run lint` clean; `bun run test` 120 files / 1556 tests pass, incl. new mode-table tests for the resolver.
- CI: build + cloudflare-tests green.

## Summary by Sourcery

Improve agent update and safety behavior by auto-resolving latched execution failure pauses and surfacing restart requirements after successful updates.

Bug Fixes:
- Make the `execution_failures` safety pause re-evaluate the current failure counter each cycle and auto-resolve instead of remaining permanently latched.
- Treat unpriceable wallet tokens as dust in orphan sweeps and settlement, avoiding repeated failed route attempts and clarifying stranded capital reporting.
- Ensure `prism update` detects a still-running agent after installing a new version and reports that a restart is required, exiting with a distinct non-zero code so automation can react appropriately.

Enhancements:
- Extend engine process detection to recognize bundled CLI dev runs such as `dist/cli/index.mjs dev` in addition to source-based patterns.

Documentation:
- Update the changelog with the new safety pause behavior, dust handling for unpriceable tokens, and the restart-required semantics of `prism update`.

Tests:
- Add lockfile tests that cover detection of bundled CLI dev processes and ensure non-dev `index.mjs` invocations are ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The update command now clearly indicates when a running agent must be restarted after updating.
  * Update results distinguish successful updates requiring a restart from update failures.

* **Bug Fixes**
  * Improved handling of execution-failure pause resolution.
  * Improved treatment and status reconciliation for unpriceable-token dust.
  * Enhanced detection of updates that require an agent restart.

* **Documentation**
  * Added unreleased changelog entries covering these improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->