### PR TITLE
fix(autonomous): auto-resolve latched execution_failures safety pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Prism are documented here.
 
 ### Fixed
 
-- The `execution_failures` safety pause is no longer a permanent one-way latch: each cycle re-evaluates the current failure counter and auto-resolves when it is below `MAX_CONSECUTIVE_EXECUTION_FAILURES` (a fresh process starts at 0, so a restart alone clears a stale latch); the pause re-arms only when the counter genuinely breaches again, and `prism resume` stays an operator override (#182)
+- The `execution_failures` safety pause is no longer a permanent one-way latch: each cycle auto-resolves when the failure counter is below `MAX_CONSECUTIVE_EXECUTION_FAILURES` (a fresh process starts at 0, so a restart alone clears a stale latch), and the counter decays to 0 after every quiet cycle (no execution failures) so a transient spike clears itself mid-run; the pause re-arms only when a cycle genuinely breaches again, and `prism resume` stays an operator override (#182)
 
 ## [0.1.10] — 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Prism are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- The `execution_failures` safety pause is no longer a permanent one-way latch: each cycle re-evaluates the current failure counter and auto-resolves when it is below `MAX_CONSECUTIVE_EXECUTION_FAILURES` (a fresh process starts at 0, so a restart alone clears a stale latch); the pause re-arms only when the counter genuinely breaches again, and `prism resume` stays an operator override (#182)
+
 ## [0.1.10] — 2026-08-08
 
 ### Fixed

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -260,6 +260,7 @@ describe("autonomous token runtime policy", () => {
         mode: "live",
         consecutiveExecutionFailures: 99,
         maxConsecutiveExecutionFailures: 0,
+        executionFailuresThisCycle: 99,
       }),
     ).toBe(true);
 
@@ -269,6 +270,7 @@ describe("autonomous token runtime policy", () => {
         mode: "shadow",
         consecutiveExecutionFailures: 99,
         maxConsecutiveExecutionFailures: 3,
+        executionFailuresThisCycle: 99,
       }),
     ).toBe(true);
 
@@ -278,6 +280,7 @@ describe("autonomous token runtime policy", () => {
         mode: "live",
         consecutiveExecutionFailures: 0,
         maxConsecutiveExecutionFailures: 3,
+        executionFailuresThisCycle: 0,
       }),
     ).toBe(true);
 
@@ -287,6 +290,7 @@ describe("autonomous token runtime policy", () => {
         mode: "canary",
         consecutiveExecutionFailures: 2,
         maxConsecutiveExecutionFailures: 3,
+        executionFailuresThisCycle: 0,
       }),
     ).toBe(true);
     expect(
@@ -294,6 +298,20 @@ describe("autonomous token runtime policy", () => {
         mode: "live",
         consecutiveExecutionFailures: 2,
         maxConsecutiveExecutionFailures: 3,
+        executionFailuresThisCycle: 0,
+      }),
+    ).toBe(true);
+
+    // A QUIET cycle clears the latch even while the counter still sits at the
+    // breach level — during the pause ENTER/REBALANCE are blocked, so the
+    // counter cannot decay on its own; the absence of NEW failures is the
+    // mid-run recovery signal (issue #182 follow-up).
+    expect(
+      shouldAutoResolveExecutionFailuresPause({
+        mode: "live",
+        consecutiveExecutionFailures: 3,
+        maxConsecutiveExecutionFailures: 3,
+        executionFailuresThisCycle: 0,
       }),
     ).toBe(true);
 
@@ -303,6 +321,7 @@ describe("autonomous token runtime policy", () => {
         mode: "live",
         consecutiveExecutionFailures: 3,
         maxConsecutiveExecutionFailures: 3,
+        executionFailuresThisCycle: 3,
       }),
     ).toBe(false);
     expect(
@@ -310,6 +329,7 @@ describe("autonomous token runtime policy", () => {
         mode: "canary",
         consecutiveExecutionFailures: 4,
         maxConsecutiveExecutionFailures: 3,
+        executionFailuresThisCycle: 4,
       }),
     ).toBe(false);
   });

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -10,6 +10,7 @@ import {
   processSettlementJobs,
   safetyPauseBlockReason,
   shouldAutoResolveDailyDrawdownPause,
+  shouldAutoResolveExecutionFailuresPause,
   shouldTriggerSafetyPause,
   sweepOrphanSettlements,
 } from "../engine/autonomous-runtime.js";
@@ -248,6 +249,67 @@ describe("autonomous token runtime policy", () => {
         dailyDrawdownPct: 6,
         maxDailyDrawdownPct: 5,
         dayRolledOver: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("auto-resolves a latched execution_failures pause per the mode table (issue #182)", () => {
+    // Given a disabled threshold (breaker off) — a leftover pause never latches.
+    expect(
+      shouldAutoResolveExecutionFailuresPause({
+        mode: "live",
+        consecutiveExecutionFailures: 99,
+        maxConsecutiveExecutionFailures: 0,
+      }),
+    ).toBe(true);
+
+    // Shadow is informational only — always auto-resolve, never latch.
+    expect(
+      shouldAutoResolveExecutionFailuresPause({
+        mode: "shadow",
+        consecutiveExecutionFailures: 99,
+        maxConsecutiveExecutionFailures: 3,
+      }),
+    ).toBe(true);
+
+    // A fresh process starts the counter at 0 — a restart alone clears the latch.
+    expect(
+      shouldAutoResolveExecutionFailuresPause({
+        mode: "live",
+        consecutiveExecutionFailures: 0,
+        maxConsecutiveExecutionFailures: 3,
+      }),
+    ).toBe(true);
+
+    // Recovery below the threshold clears the latch mid-run.
+    expect(
+      shouldAutoResolveExecutionFailuresPause({
+        mode: "canary",
+        consecutiveExecutionFailures: 2,
+        maxConsecutiveExecutionFailures: 3,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAutoResolveExecutionFailuresPause({
+        mode: "live",
+        consecutiveExecutionFailures: 2,
+        maxConsecutiveExecutionFailures: 3,
+      }),
+    ).toBe(true);
+
+    // The pause stays latched while the counter genuinely breaches again.
+    expect(
+      shouldAutoResolveExecutionFailuresPause({
+        mode: "live",
+        consecutiveExecutionFailures: 3,
+        maxConsecutiveExecutionFailures: 3,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAutoResolveExecutionFailuresPause({
+        mode: "canary",
+        consecutiveExecutionFailures: 4,
+        maxConsecutiveExecutionFailures: 3,
       }),
     ).toBe(false);
   });

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -9,6 +9,7 @@ import {
   persistDailyEquityBaseline,
   processSettlementJobs,
   safetyPauseBlockReason,
+  decayExecutionFailureCounter,
   shouldAutoResolveDailyDrawdownPause,
   shouldAutoResolveExecutionFailuresPause,
   shouldTriggerSafetyPause,
@@ -260,7 +261,6 @@ describe("autonomous token runtime policy", () => {
         mode: "live",
         consecutiveExecutionFailures: 99,
         maxConsecutiveExecutionFailures: 0,
-        executionFailuresThisCycle: 99,
       }),
     ).toBe(true);
 
@@ -270,7 +270,6 @@ describe("autonomous token runtime policy", () => {
         mode: "shadow",
         consecutiveExecutionFailures: 99,
         maxConsecutiveExecutionFailures: 3,
-        executionFailuresThisCycle: 99,
       }),
     ).toBe(true);
 
@@ -280,7 +279,6 @@ describe("autonomous token runtime policy", () => {
         mode: "live",
         consecutiveExecutionFailures: 0,
         maxConsecutiveExecutionFailures: 3,
-        executionFailuresThisCycle: 0,
       }),
     ).toBe(true);
 
@@ -290,7 +288,6 @@ describe("autonomous token runtime policy", () => {
         mode: "canary",
         consecutiveExecutionFailures: 2,
         maxConsecutiveExecutionFailures: 3,
-        executionFailuresThisCycle: 0,
       }),
     ).toBe(true);
     expect(
@@ -298,20 +295,6 @@ describe("autonomous token runtime policy", () => {
         mode: "live",
         consecutiveExecutionFailures: 2,
         maxConsecutiveExecutionFailures: 3,
-        executionFailuresThisCycle: 0,
-      }),
-    ).toBe(true);
-
-    // A QUIET cycle clears the latch even while the counter still sits at the
-    // breach level — during the pause ENTER/REBALANCE are blocked, so the
-    // counter cannot decay on its own; the absence of NEW failures is the
-    // mid-run recovery signal (issue #182 follow-up).
-    expect(
-      shouldAutoResolveExecutionFailuresPause({
-        mode: "live",
-        consecutiveExecutionFailures: 3,
-        maxConsecutiveExecutionFailures: 3,
-        executionFailuresThisCycle: 0,
       }),
     ).toBe(true);
 
@@ -321,7 +304,6 @@ describe("autonomous token runtime policy", () => {
         mode: "live",
         consecutiveExecutionFailures: 3,
         maxConsecutiveExecutionFailures: 3,
-        executionFailuresThisCycle: 3,
       }),
     ).toBe(false);
     expect(
@@ -329,9 +311,55 @@ describe("autonomous token runtime policy", () => {
         mode: "canary",
         consecutiveExecutionFailures: 4,
         maxConsecutiveExecutionFailures: 3,
-        executionFailuresThisCycle: 4,
       }),
     ).toBe(false);
+  });
+
+  it("a quiet cycle decays the failure counter so a stale breach cannot re-arm (issue #182 review)", () => {
+    // Cycle N: a spike of 3 execution failures arms the pause.
+    let counter = decayExecutionFailureCounter(3, 3);
+    expect(
+      shouldTriggerSafetyPause({
+        dailyDrawdownPct: 0,
+        maxDailyDrawdownPct: 5,
+        consecutiveCoreDataFailures: 0,
+        consecutiveExecutionFailures: counter,
+        maxConsecutiveExecutionFailures: 3,
+        oldestSettlementAgeMs: 0,
+        settlementMaxPendingMs: 3_600_000,
+      }),
+    ).toBe("execution_failures");
+
+    // Cycle N+1: quiet (0 failures). The end-of-cycle decay zeroes the
+    // counter BEFORE the arm block evaluates, so the stale breach cannot
+    // re-arm the pause in the same pass the resolver cleared it.
+    counter = decayExecutionFailureCounter(counter, 0);
+    expect(counter).toBe(0);
+    expect(
+      shouldTriggerSafetyPause({
+        dailyDrawdownPct: 0,
+        maxDailyDrawdownPct: 5,
+        consecutiveCoreDataFailures: 0,
+        consecutiveExecutionFailures: counter,
+        maxConsecutiveExecutionFailures: 3,
+        oldestSettlementAgeMs: 0,
+        settlementMaxPendingMs: 3_600_000,
+      }),
+    ).toBeNull();
+
+    // Cycle N+2: the resolver sees the decayed counter and clears the latch.
+    expect(
+      shouldAutoResolveExecutionFailuresPause({
+        mode: "live",
+        consecutiveExecutionFailures: counter,
+        maxConsecutiveExecutionFailures: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it("a breaching cycle keeps its counter so the pause stays armed", () => {
+    expect(decayExecutionFailureCounter(4, 1)).toBe(4);
+    expect(decayExecutionFailureCounter(4, 3)).toBe(4);
   });
 
   it("excludes confirmed and terminal jobs from the overdue settlement age (issue #167)", () => {

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -56,7 +56,10 @@ export function shouldTriggerSafetyPause(
     return "daily_drawdown";
   }
   if (input.consecutiveCoreDataFailures >= 2) return "core_data_unavailable";
-  if (input.consecutiveExecutionFailures >= input.maxConsecutiveExecutionFailures) {
+  if (
+    input.maxConsecutiveExecutionFailures > 0 &&
+    input.consecutiveExecutionFailures >= input.maxConsecutiveExecutionFailures
+  ) {
     return "execution_failures";
   }
   if (input.oldestSettlementAgeMs > input.settlementMaxPendingMs) {
@@ -76,6 +79,8 @@ export interface ExecutionFailuresAutoResolveInput {
   readonly mode: AutonomousTokenMode;
   readonly consecutiveExecutionFailures: number;
   readonly maxConsecutiveExecutionFailures: number;
+  /** Execution failures recorded in the CURRENT scan cycle (0 = quiet cycle). */
+  readonly executionFailuresThisCycle: number;
 }
 
 /**
@@ -89,11 +94,15 @@ export interface ExecutionFailuresAutoResolveInput {
  *
  * - `shadow` — informational only: the pause never blocks and never requires
  *   a manual resume, so always auto-resolve.
- * - `canary` / `live` — re-evaluate fresh every cycle: auto-resolve as soon
- *   as the current failure counter is below the configured threshold (a
- *   fresh process starts at 0, so a restart alone clears the latch). The
- *   trigger block re-arms the pause only when the counter genuinely
- *   breaches again.
+ * - `canary` / `live` — re-evaluate fresh every cycle: auto-resolve when the
+ *   current failure counter is below the configured threshold (a fresh
+ *   process starts at 0, so a restart alone clears the latch) OR when the
+ *   current cycle recorded no execution failures at all (the spike passed).
+ *   The latter is required for mid-run recovery: while the pause is active,
+ *   ENTER/REBALANCE are blocked, so the counter cannot drop back below the
+ *   threshold on its own — without the quiet-cycle clause only a restart or
+ *   an allowed EXIT could clear the latch. The trigger block re-arms the
+ *   pause only when a cycle genuinely breaches again.
  *
  * A non-positive threshold means the breaker is off, so a leftover pause from
  * when it was enabled should not latch either.
@@ -110,9 +119,12 @@ export function shouldAutoResolveExecutionFailuresPause(
     case "canary":
     case "live":
     case "off":
-      return input.consecutiveExecutionFailures < input.maxConsecutiveExecutionFailures;
+      return (
+        input.consecutiveExecutionFailures < input.maxConsecutiveExecutionFailures ||
+        input.executionFailuresThisCycle === 0
+      );
     default:
-      throw new Error(`Unhandled autonomous token mode: ${input.mode}`);
+      throw new Error(`Unhandled autonomous token mode: ${String(input.mode)}`);
   }
 }
 

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -79,29 +79,42 @@ export interface ExecutionFailuresAutoResolveInput {
   readonly mode: AutonomousTokenMode;
   readonly consecutiveExecutionFailures: number;
   readonly maxConsecutiveExecutionFailures: number;
-  /** Execution failures recorded in the CURRENT scan cycle (0 = quiet cycle). */
-  readonly executionFailuresThisCycle: number;
+}
+
+/**
+ * Issue #182: a cycle with no execution failures is a QUIET cycle — the
+ * consecutive-failure counter decays to 0 (true consecutive semantics,
+ * mirroring `consecutiveCoreDataFailures`). Without the decay the counter
+ * only reset on a successful execution, so after a failure spike the stale
+ * breach re-armed the pause in the same pass the resolver cleared it
+ * (resolve → re-arm toggle every cycle, latch never stayed cleared).
+ * Runs at the end of every cycle (including skipped/empty cycles) BEFORE
+ * the arm block evaluates.
+ */
+export function decayExecutionFailureCounter(
+  consecutiveExecutionFailures: number,
+  executionFailuresThisCycle: number,
+): number {
+  return executionFailuresThisCycle === 0 ? 0 : consecutiveExecutionFailures;
 }
 
 /**
  * Auto-resolution for a latched `execution_failures` safety pause
  * (issue #182). The trigger is a session-local counter that resets on
- * restart and on every successful execution — but an armed pause was a
- * permanent one-way latch that only `prism resume` could clear, so a single
- * transient failure spike (rate limits, RPC blips, a pre-fix batch of doomed
- * entries) halted the agent forever, surviving restarts (fresh counter) and
- * fixed releases. Mirrors the issue #148 daily_drawdown autonomy contract:
+ * restart, on every successful execution, and (via
+ * decayExecutionFailureCounter) after every quiet cycle — but an armed
+ * pause was a permanent one-way latch that only `prism resume` could
+ * clear, so a single transient failure spike (rate limits, RPC blips, a
+ * pre-fix batch of doomed entries) halted the agent forever, surviving
+ * restarts (fresh counter) and fixed releases. Mirrors the issue #148
+ * daily_drawdown autonomy contract:
  *
  * - `shadow` — informational only: the pause never blocks and never requires
  *   a manual resume, so always auto-resolve.
- * - `canary` / `live` — re-evaluate fresh every cycle: auto-resolve when the
- *   current failure counter is below the configured threshold (a fresh
- *   process starts at 0, so a restart alone clears the latch) OR when the
- *   current cycle recorded no execution failures at all (the spike passed).
- *   The latter is required for mid-run recovery: while the pause is active,
- *   ENTER/REBALANCE are blocked, so the counter cannot drop back below the
- *   threshold on its own — without the quiet-cycle clause only a restart or
- *   an allowed EXIT could clear the latch. The trigger block re-arms the
+ * - `canary` / `live` — re-evaluate fresh every cycle: auto-resolve as soon
+ *   as the current failure counter is below the configured threshold (a
+ *   fresh process starts at 0, so a restart alone clears the latch; the
+ *   quiet-cycle decay clears it mid-run). The trigger block re-arms the
  *   pause only when a cycle genuinely breaches again.
  *
  * A non-positive threshold means the breaker is off, so a leftover pause from
@@ -119,10 +132,7 @@ export function shouldAutoResolveExecutionFailuresPause(
     case "canary":
     case "live":
     case "off":
-      return (
-        input.consecutiveExecutionFailures < input.maxConsecutiveExecutionFailures ||
-        input.executionFailuresThisCycle === 0
-      );
+      return input.consecutiveExecutionFailures < input.maxConsecutiveExecutionFailures;
     default:
       throw new Error(`Unhandled autonomous token mode: ${String(input.mode)}`);
   }

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -72,6 +72,50 @@ export interface DailyDrawdownAutoResolveInput {
   readonly dayRolledOver: boolean;
 }
 
+export interface ExecutionFailuresAutoResolveInput {
+  readonly mode: AutonomousTokenMode;
+  readonly consecutiveExecutionFailures: number;
+  readonly maxConsecutiveExecutionFailures: number;
+}
+
+/**
+ * Auto-resolution for a latched `execution_failures` safety pause
+ * (issue #182). The trigger is a session-local counter that resets on
+ * restart and on every successful execution — but an armed pause was a
+ * permanent one-way latch that only `prism resume` could clear, so a single
+ * transient failure spike (rate limits, RPC blips, a pre-fix batch of doomed
+ * entries) halted the agent forever, surviving restarts (fresh counter) and
+ * fixed releases. Mirrors the issue #148 daily_drawdown autonomy contract:
+ *
+ * - `shadow` — informational only: the pause never blocks and never requires
+ *   a manual resume, so always auto-resolve.
+ * - `canary` / `live` — re-evaluate fresh every cycle: auto-resolve as soon
+ *   as the current failure counter is below the configured threshold (a
+ *   fresh process starts at 0, so a restart alone clears the latch). The
+ *   trigger block re-arms the pause only when the counter genuinely
+ *   breaches again.
+ *
+ * A non-positive threshold means the breaker is off, so a leftover pause from
+ * when it was enabled should not latch either.
+ *
+ * Returns true when the caller should clear the active pause (`resolvedAt`).
+ */
+export function shouldAutoResolveExecutionFailuresPause(
+  input: ExecutionFailuresAutoResolveInput,
+): boolean {
+  if (input.maxConsecutiveExecutionFailures <= 0) return true;
+  switch (input.mode) {
+    case "shadow":
+      return true;
+    case "canary":
+    case "live":
+    case "off":
+      return input.consecutiveExecutionFailures < input.maxConsecutiveExecutionFailures;
+    default:
+      throw new Error(`Unhandled autonomous token mode: ${input.mode}`);
+  }
+}
+
 /**
  * Mode-aware auto-resolution for a latched `daily_drawdown` safety pause
  * (issue #148). The daily equity baseline re-seeds every day, but nothing

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -2315,6 +2315,12 @@ export const program = Effect.gen(function* () {
           .pipe(Effect.catch(() => Effect.succeed(null)));
   let consecutiveCoreDataFailures = 0;
   let consecutiveExecutionFailures = 0;
+  // Execution failures recorded in the CURRENT scan cycle (reset at cycle
+  // start) — the recovery signal for the issue #182 execution_failures
+  // pause auto-resolution: while the pause blocks ENTER/REBALANCE the
+  // consecutive counter cannot decay on its own, so a quiet cycle is what
+  // proves the spike passed.
+  let executionFailuresThisCycle = 0;
   let coreDataFailuresThisCycle = 0;
   const dailyBaselineScope = {
     walletAddress: executionWalletAddress ?? "paper",
@@ -2361,6 +2367,7 @@ export const program = Effect.gen(function* () {
     config.autonomousTokenMode === "canary" || config.autonomousTokenMode === "live";
   const recordExecutionOutcome = (executed: boolean): void => {
     consecutiveExecutionFailures = executed ? 0 : consecutiveExecutionFailures + 1;
+    if (!executed) executionFailuresThisCycle++;
   };
   let lastSnapshotPruneAt = 0;
 
@@ -4034,6 +4041,33 @@ export const program = Effect.gen(function* () {
           .pipe(Effect.catch(() => Effect.succeed(activeSafetyPause)));
       }
 
+      // Issue #182: an armed execution_failures pause must not outlive the
+      // failure spike that raised it. Runs at the TOP of the cycle, before
+      // any pool is decided — a resolved latch must not block the very cycle
+      // that clears it (the daily_drawdown analog resolves per-pool before
+      // that pool's decisions for the same reason). Recovery signals: the
+      // session-local counter dropped below the threshold (fresh process, or
+      // a successful execution reset it) OR the PREVIOUS cycle recorded no
+      // execution failures (the spike passed — while the pause blocks
+      // ENTER/REBALANCE the consecutive counter cannot decay on its own).
+      // The end-of-cycle arm block re-arms only when a cycle genuinely
+      // breaches again. `prism resume` remains an operator override.
+      if (
+        autonomousExecution &&
+        activeSafetyPause !== null &&
+        activeSafetyPause.resolvedAt === null &&
+        activeSafetyPause.reason === "execution_failures" &&
+        shouldAutoResolveExecutionFailuresPause({
+          mode: autonomousExecution.mode,
+          consecutiveExecutionFailures,
+          maxConsecutiveExecutionFailures: config.maxConsecutiveExecutionFailures,
+          executionFailuresThisCycle,
+        })
+      ) {
+        activeSafetyPause = { ...activeSafetyPause, resolvedAt: Date.now() };
+        yield* db.saveSafetyPause(activeSafetyPause).pipe(Effect.catch(() => Effect.void));
+      }
+
       if (poolsToScan.length === 0) {
         console.info("No pools configured — skipping cycle");
         cycle.completedAt = Date.now();
@@ -4177,6 +4211,10 @@ export const program = Effect.gen(function* () {
       // excludes these so an exit can never be followed by a same-cycle re-entry
       // — the no-exit-and-reenter invariant (AGENTS.md §multiple-positions).
       const executedExitPools = new Set<string>();
+      // Reset AFTER the issue #182 resolve block above: the resolver reads the
+      // PREVIOUS cycle's failure count, and this cycle's failures start counting
+      // from here (recordExecutionOutcome increments it during the pool loop).
+      executionFailuresThisCycle = 0;
 
       for (const poolAddress of poolsToScan) {
         // A pool yields one decision per held position plus at most one ENTER.
@@ -4231,27 +4269,6 @@ export const program = Effect.gen(function* () {
         cycle.poolsScanned > 0 && coreDataFailuresThisCycle >= cycle.poolsScanned
           ? consecutiveCoreDataFailures + 1
           : 0;
-      // Issue #182: an armed execution_failures pause must not outlive the
-      // failure spike that raised it — the trigger counter is session-local
-      // (resets on restart and on every successful execution), so once the
-      // current cycle's counter is below the threshold the pause is stale.
-      // Auto-resolve it mode-aware; the arm block below re-arms only when
-      // the counter genuinely breaches again. `prism resume` remains an
-      // operator override.
-      if (
-        autonomousExecution &&
-        activeSafetyPause !== null &&
-        activeSafetyPause.resolvedAt === null &&
-        activeSafetyPause.reason === "execution_failures" &&
-        shouldAutoResolveExecutionFailuresPause({
-          mode: autonomousExecution.mode,
-          consecutiveExecutionFailures,
-          maxConsecutiveExecutionFailures: config.maxConsecutiveExecutionFailures,
-        })
-      ) {
-        activeSafetyPause = { ...activeSafetyPause, resolvedAt: Date.now() };
-        yield* db.saveSafetyPause(activeSafetyPause).pipe(Effect.catch(() => Effect.void));
-      }
       if (autonomousExecution && activeSafetyPause?.resolvedAt !== null) {
         const pauseReason = shouldTriggerSafetyPause({
           dailyDrawdownPct,

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -156,6 +156,7 @@ import {
   processSettlementJobs,
   safetyPauseBlockReason,
   shouldAutoResolveDailyDrawdownPause,
+  shouldAutoResolveExecutionFailuresPause,
   shouldTriggerSafetyPause,
   sweepOrphanSettlements,
 } from "./autonomous-runtime.js";
@@ -4230,6 +4231,27 @@ export const program = Effect.gen(function* () {
         cycle.poolsScanned > 0 && coreDataFailuresThisCycle >= cycle.poolsScanned
           ? consecutiveCoreDataFailures + 1
           : 0;
+      // Issue #182: an armed execution_failures pause must not outlive the
+      // failure spike that raised it — the trigger counter is session-local
+      // (resets on restart and on every successful execution), so once the
+      // current cycle's counter is below the threshold the pause is stale.
+      // Auto-resolve it mode-aware; the arm block below re-arms only when
+      // the counter genuinely breaches again. `prism resume` remains an
+      // operator override.
+      if (
+        autonomousExecution &&
+        activeSafetyPause !== null &&
+        activeSafetyPause.resolvedAt === null &&
+        activeSafetyPause.reason === "execution_failures" &&
+        shouldAutoResolveExecutionFailuresPause({
+          mode: autonomousExecution.mode,
+          consecutiveExecutionFailures,
+          maxConsecutiveExecutionFailures: config.maxConsecutiveExecutionFailures,
+        })
+      ) {
+        activeSafetyPause = { ...activeSafetyPause, resolvedAt: Date.now() };
+        yield* db.saveSafetyPause(activeSafetyPause).pipe(Effect.catch(() => Effect.void));
+      }
       if (autonomousExecution && activeSafetyPause?.resolvedAt !== null) {
         const pauseReason = shouldTriggerSafetyPause({
           dailyDrawdownPct,

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -157,6 +157,7 @@ import {
   safetyPauseBlockReason,
   shouldAutoResolveDailyDrawdownPause,
   shouldAutoResolveExecutionFailuresPause,
+  decayExecutionFailureCounter,
   shouldTriggerSafetyPause,
   sweepOrphanSettlements,
 } from "./autonomous-runtime.js";
@@ -4045,13 +4046,11 @@ export const program = Effect.gen(function* () {
       // failure spike that raised it. Runs at the TOP of the cycle, before
       // any pool is decided — a resolved latch must not block the very cycle
       // that clears it (the daily_drawdown analog resolves per-pool before
-      // that pool's decisions for the same reason). Recovery signals: the
-      // session-local counter dropped below the threshold (fresh process, or
-      // a successful execution reset it) OR the PREVIOUS cycle recorded no
-      // execution failures (the spike passed — while the pause blocks
-      // ENTER/REBALANCE the consecutive counter cannot decay on its own).
-      // The end-of-cycle arm block re-arms only when a cycle genuinely
-      // breaches again. `prism resume` remains an operator override.
+      // that pool's decisions for the same reason). The counter is decayed
+      // to 0 after every quiet cycle (see the end-of-cycle decay below), so
+      // "below the threshold" is the recovery signal for restarts AND
+      // mid-run spikes; the end-of-cycle arm block re-arms only when a cycle
+      // genuinely breaches again. `prism resume` remains an operator override.
       if (
         autonomousExecution &&
         activeSafetyPause !== null &&
@@ -4061,7 +4060,6 @@ export const program = Effect.gen(function* () {
           mode: autonomousExecution.mode,
           consecutiveExecutionFailures,
           maxConsecutiveExecutionFailures: config.maxConsecutiveExecutionFailures,
-          executionFailuresThisCycle,
         })
       ) {
         activeSafetyPause = { ...activeSafetyPause, resolvedAt: Date.now() };
@@ -4070,6 +4068,14 @@ export const program = Effect.gen(function* () {
 
       if (poolsToScan.length === 0) {
         console.info("No pools configured — skipping cycle");
+        // Issue #182: a skipped cycle is a quiet cycle — no execution failure
+        // was possible, so the consecutive counter decays like any other
+        // quiet cycle (otherwise recovery lags behind skipped cycles).
+        executionFailuresThisCycle = 0;
+        consecutiveExecutionFailures = decayExecutionFailureCounter(
+          consecutiveExecutionFailures,
+          executionFailuresThisCycle,
+        );
         cycle.completedAt = Date.now();
         return;
       }
@@ -4269,6 +4275,15 @@ export const program = Effect.gen(function* () {
         cycle.poolsScanned > 0 && coreDataFailuresThisCycle >= cycle.poolsScanned
           ? consecutiveCoreDataFailures + 1
           : 0;
+      // Issue #182: quiet-cycle decay BEFORE the arm evaluates — a cycle with
+      // no execution failures resets the consecutive counter, so a stale
+      // breach from a previous spike can never re-arm the pause in the same
+      // pass the cycle-top resolver cleared it (which would toggle the latch
+      // every cycle instead of letting it stay resolved).
+      consecutiveExecutionFailures = decayExecutionFailureCounter(
+        consecutiveExecutionFailures,
+        executionFailuresThisCycle,
+      );
       if (autonomousExecution && activeSafetyPause?.resolvedAt !== null) {
         const pauseReason = shouldTriggerSafetyPause({
           dailyDrawdownPct,


### PR DESCRIPTION
Fixes #182

## Problem

The `execution_failures` safety pause was a permanent one-way latch: only `prism resume` cleared it, and the scan cycle never re-evaluated it. A single transient failure spike (rate limits, RPC blips, the pre-fix #170 wallet-drain batch) halted the agent forever — the latch even survived restarts, because the trigger counter is session-local and resets to 0 in a fresh process while the persisted pause stayed `active=true, resolvedAt=null`. Every cycle then blocked ENTER via `safetyPauseBlockReason`.

## Fix

Mirror the issue #148 `daily_drawdown` pattern:

- New pure helper `shouldAutoResolveExecutionFailuresPause` in `engine/autonomous-runtime.ts` (mode-aware, same contract as the daily-drawdown one):
  - `shadow` — informational-only pause, always auto-resolve.
  - `canary`/`live` — auto-resolve when the current `consecutiveExecutionFailures` is below `MAX_CONSECUTIVE_EXECUTION_FAILURES` (a fresh process starts at 0, so a restart alone clears a stale latch).
  - Non-positive threshold (breaker off) never latches.
- Wired into `runScanCycle` next to the existing arm block: each cycle, an active `execution_failures` pause is auto-resolved when the counter no longer breaches; the existing trigger block re-arms only when the counter genuinely breaches again.
- `prism resume` remains an operator override.

## Verification

- `bun run lint` clean; `bun run test` 120 files / 1556 tests pass, incl. new mode-table tests for the resolver.
- CI: build + cloudflare-tests green.

## Summary by Sourcery

Auto-resolve latched execution_failures safety pauses based on autonomous mode and current failure counters to prevent permanent halts after transient spikes.

Bug Fixes:
- Ensure the execution_failures safety pause is re-evaluated each cycle and automatically resolved when the consecutive failure count drops below the configured threshold, so it no longer persists indefinitely across restarts.

Enhancements:
- Introduce a mode-aware helper for execution_failures pause auto-resolution that aligns with the existing daily_drawdown autonomy contract.

Documentation:
- Update the changelog to document the new execution_failures safety pause auto-resolution behavior and reference issue #182.

Tests:
- Add mode-table tests covering execution_failures safety pause auto-resolution behavior across shadow, canary, and live modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for execution-failure safety pauses when failures fall below the configured threshold or a cycle completes without failures.
  * Safety pauses now re-arm if execution failures breach the threshold again.
  * Added support for disabled thresholds and shadow mode without triggering or retaining pauses.
  * Manual recovery remains available through `prism resume`.

* **Documentation**
  * Updated the unreleased changelog with the revised safety-pause behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->