### PR TITLE
fix(autonomous): dust-gate unpriceable tokens, reconcile Stranded with dust policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Prism are documented here.
 ### Fixed
 
 - The `execution_failures` safety pause is no longer a permanent one-way latch: each cycle auto-resolves when the failure counter is below `MAX_CONSECUTIVE_EXECUTION_FAILURES` (a fresh process starts at 0, so a restart alone clears a stale latch), and the counter decays to 0 after every quiet cycle (no execution failures) so a transient spike clears itself mid-run; the pause re-arms only when a cycle genuinely breaches again, and `prism resume` stays an operator override (#182)
+- Unpriceable wallet tokens are dust for the orphan sweep: a token with no resolvable USD price is value-unknown ⇒ $0, so the sweep skips it and the settlement processor dust-confirms existing jobs with a distinct "settlement dust skipped (no USD price)" error instead of quoting them — the Jupiter 400 no-route retry loop is gone, and tokens re-qualify automatically once a price resolves. `prism status` reconciles the Stranded line with the dust policy: sub-dust terminal settlements are excluded (they are intentionally never re-queued), priceable stranded capital shows its USD value, and unpriceable terminals get a separate Unpriceable line (#183)
 
 ## [0.1.10] — 2026-08-08
 

--- a/bench/cli-autonomous-status.test.ts
+++ b/bench/cli-autonomous-status.test.ts
@@ -265,11 +265,14 @@ describe("autonomous CLI operator surface", () => {
       WALLET_PRIVATE_KEY: bs58.encode(walletKeypair.secretKey),
     });
 
-    // Then
+    // Then (issue #183): the unpriceable terminal is surfaced on the
+    // Unpriceable line — it cannot be valued, so it is not counted as
+    // Stranded capital and the sweep never re-queues it.
     expect(result.exitCode).toBe(0);
     const text = decode(result.stdout);
-    expect(text).toContain("Stranded:    1 terminal settlement(s) with unspent balance");
+    expect(text).toContain("Unpriceable: 1 terminal settlement(s) with no USD price");
     expect(text).toContain("?/mint-2");
+    expect(text).not.toContain("Stranded:");
   });
 
   it("hides terminal settlements whose mint was later recovered by a confirmed settlement", async () => {
@@ -312,10 +315,13 @@ describe("autonomous CLI operator surface", () => {
       WALLET_PRIVATE_KEY: bs58.encode(walletKeypair.secretKey),
     });
 
-    // Then the newer terminal record is reported as stranded.
+    // Then the newer terminal record stays visible (issue #183): unpriceable
+    // in the test env, so it is surfaced on the Unpriceable line rather than
+    // counted as valued Stranded capital.
     expect(result.exitCode).toBe(0);
     const text = decode(result.stdout);
-    expect(text).toContain("Stranded:    1 terminal settlement(s) with unspent balance");
+    expect(text).toContain("Unpriceable: 1 terminal settlement(s) with no USD price");
+    expect(text).not.toContain("Stranded:");
   });
 
   it("marks the current wallet's active safety pause resolved without live execution", async () => {

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -1008,13 +1008,94 @@ describe("issue #166 settlement recovery", () => {
     expect(processed).toMatchObject({ status: "retryable", nextRetryAt: 11_000 });
   });
 
+  it("dust-confirms an unpriceable settlement instead of quoting it (issue #183)", async () => {
+    // Given a job for a mint with no resolvable USD price — quoting it would
+    // 400 forever (no route), so the dust gate must terminalize it as dust.
+    const job = settlementJob({ tokenMint: "no-price-1" });
+    const adapter = {
+      getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "no-price-1": 0 }),
+      getTokenDecimals: () => Effect.succeed(6),
+      quoteSwap: () => Effect.fail(new Error("unused — quote must never run")),
+      prepareSwap: () => Effect.fail(new Error("unused")),
+      simulateSwap: () => Effect.fail(new Error("unused")),
+      submitSwap: () => Effect.fail(new Error("unused")),
+    } as unknown as AdapterApi;
+    const db = {
+      saveSettlementJob: () => Effect.void,
+      getPosition: () => Effect.succeed(null),
+    } as unknown as DbApi;
+
+    // When
+    const [processed] = await Effect.runPromise(
+      processSettlementJobs({
+        adapter,
+        db,
+        jobs: [job],
+        mode: "live",
+        now: 10_000,
+        maxSwapSlippageBps: 50,
+        settlementDustUsd: 0.1,
+      }),
+    );
+
+    // Then the job is dust-confirmed (value unknown ⇒ $0) and the quote
+    // path is never touched.
+    expect(processed).toMatchObject({
+      status: "confirmed",
+      attempts: 1,
+      nextRetryAt: null,
+      confirmedOutputAtomic: job.amountAtomic,
+      error: "settlement dust skipped (no USD price)",
+    });
+    expect(processed?.outputUsd).toBe(0);
+  });
+
+  it("dust-confirms a priceable sub-dust settlement with the plain dust error", async () => {
+    // Given a tiny priceable amount below the dust cutoff.
+    const job = settlementJob({ amountAtomic: "1000" }); // 0.001 token at $1
+    const adapter = {
+      getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "token-1": 1 }),
+      getTokenDecimals: () => Effect.succeed(6),
+      quoteSwap: () => Effect.fail(new Error("unused — quote must never run")),
+      prepareSwap: () => Effect.fail(new Error("unused")),
+      simulateSwap: () => Effect.fail(new Error("unused")),
+      submitSwap: () => Effect.fail(new Error("unused")),
+    } as unknown as AdapterApi;
+    const db = {
+      saveSettlementJob: () => Effect.void,
+      getPosition: () => Effect.succeed(null),
+    } as unknown as DbApi;
+
+    // When
+    const [processed] = await Effect.runPromise(
+      processSettlementJobs({
+        adapter,
+        db,
+        jobs: [job],
+        mode: "live",
+        now: 10_000,
+        maxSwapSlippageBps: 50,
+        settlementDustUsd: 0.1,
+      }),
+    );
+
+    // Then
+    expect(processed).toMatchObject({
+      status: "confirmed",
+      nextRetryAt: null,
+      error: "settlement dust skipped",
+    });
+    expect(processed?.outputUsd).toBe(0.001);
+  });
+
   it("creates sell jobs only for unbacked, non-dust wallet holdings", async () => {
     // Given holdings where one mint is backed, one is below dust, one is
-    // unpriceable, and the settlement asset itself.
+    // unpriceable (issue #183: treated as dust — value unknown ⇒ $0), and
+    // the settlement asset itself.
     const holdings = new Map<string, { amountAtomic: bigint; decimals: number }>([
       ["stranded-1", { amountAtomic: 1_000_000n, decimals: 6 }], // $1.00 → sweep
       ["dust-1", { amountAtomic: 50_000n, decimals: 6 }], // $0.05 → skip
-      ["unpriceable-1", { amountAtomic: 5_000_000n, decimals: 6 }], // no price → sweep (cannot prove dust)
+      ["unpriceable-1", { amountAtomic: 5_000_000n, decimals: 6 }], // no price → skip (dust; re-qualifies when priced)
       ["backed-1", { amountAtomic: 1_000_000n, decimals: 6 }], // position leg → skip
       [SOL_MINT, { amountAtomic: 1_000_000_000n, decimals: 9 }], // settlement asset → skip
       ["zero-1", { amountAtomic: 0n, decimals: 6 }], // nothing held → skip
@@ -1047,8 +1128,8 @@ describe("issue #166 settlement recovery", () => {
     );
 
     // Then
-    expect(jobs).toHaveLength(2);
-    expect(jobs.map((job) => job.tokenMint).sort()).toEqual(["stranded-1", "unpriceable-1"]);
+    expect(jobs).toHaveLength(1);
+    expect(jobs.map((job) => job.tokenMint).sort()).toEqual(["stranded-1"]);
     expect(jobs[0]).toMatchObject({
       walletAddress: "wallet-1",
       agentInstanceId: "primary",
@@ -1061,6 +1142,55 @@ describe("issue #166 settlement recovery", () => {
       error: null,
       positionId: expect.stringMatching(/^orphan:/),
     });
+  });
+
+  it("dust-skips an unpriceable holding when the dust gate is enabled, sweeps it when disabled", async () => {
+    // Given a wallet holding only an unpriceable token.
+    const holdings = new Map<string, { amountAtomic: bigint; decimals: number }>([
+      ["unpriceable-1", { amountAtomic: 5_000_000n, decimals: 6 }],
+    ]);
+    const adapter = {
+      hasWallet: () => true,
+      getWalletHoldings: () => Effect.succeed(holdings),
+      getPoolState: () => Effect.succeed(null),
+      getTokenPrices: (mints: string[]) =>
+        Effect.succeed(Object.fromEntries(mints.map((mint) => [mint, 0]))),
+    } as unknown as AdapterApi;
+    const db = {
+      listSettlementJobs: () => Effect.succeed([]),
+      getAllPositions: () => Effect.succeed([]),
+    } as unknown as DbApi;
+
+    // When the dust gate is on (default), an unpriceable token is dust: no
+    // sell job — otherwise it would be quoted (Jupiter 400) and retried
+    // forever (issue #183).
+    const withDust = await Effect.runPromise(
+      sweepOrphanSettlements({
+        adapter,
+        db,
+        walletAddress: "wallet-1",
+        agentInstanceId: "primary",
+        settlementMaxPendingMs: 3_600_000,
+        settlementDustUsd: 0.1,
+        now: 10_000,
+      }),
+    );
+    expect(withDust).toHaveLength(0);
+
+    // When the dust gate is disabled, the sweep still enqueues it (best
+    // effort — the operator opted out of dust classification).
+    const noDustGate = await Effect.runPromise(
+      sweepOrphanSettlements({
+        adapter,
+        db,
+        walletAddress: "wallet-1",
+        agentInstanceId: "primary",
+        settlementMaxPendingMs: 3_600_000,
+        settlementDustUsd: 0,
+        now: 10_000,
+      }),
+    );
+    expect(noDustGate.map((job) => job.tokenMint)).toEqual(["unpriceable-1"]);
   });
 
   it("sweeps wallet holdings against position legs and active jobs, re-enqueuing terminal-mint tokens", async () => {

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -1011,7 +1011,10 @@ describe("issue #166 settlement recovery", () => {
   it("dust-confirms an unpriceable settlement instead of quoting it (issue #183)", async () => {
     // Given a job for a mint with no resolvable USD price — quoting it would
     // 400 forever (no route), so the dust gate must terminalize it as dust.
-    const job = settlementJob({ tokenMint: "no-price-1" });
+    // Only SYNTHETIC settlement groups (orphan/rollback) qualify: they have
+    // no position row to finalize, so no PnL can be booked against the
+    // still-in-wallet tokens.
+    const job = settlementJob({ tokenMint: "no-price-1", positionId: "orphan:test" });
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "no-price-1": 0 }),
       getTokenDecimals: () => Effect.succeed(6),
@@ -1048,6 +1051,47 @@ describe("issue #166 settlement recovery", () => {
       error: "settlement dust skipped (no USD price)",
     });
     expect(processed?.outputUsd).toBe(0);
+  });
+
+  it("does NOT dust-confirm an unpriceable settlement tied to a real position (issue #183)", async () => {
+    // Given an unpriceable job whose positionId is a REAL position (EXIT
+    // residue/reward sweep) — dust-confirming it would finalize the group
+    // with outputUsd 0 and book a full PnL loss while the tokens still sit
+    // in the wallet. It must fall through to the quote path instead
+    // (bounded retries, then terminal on expiry — operator-visible).
+    const job = settlementJob({ tokenMint: "no-price-1" }); // default real positionId
+    const adapter = {
+      getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "no-price-1": 0 }),
+      getTokenDecimals: () => Effect.succeed(6),
+      quoteSwap: () => Effect.fail(new Error("Jupiter quote failed: 400")),
+      prepareSwap: () => Effect.fail(new Error("unused")),
+      simulateSwap: () => Effect.fail(new Error("unused")),
+      submitSwap: () => Effect.fail(new Error("unused")),
+    } as unknown as AdapterApi;
+    const db = {
+      saveSettlementJob: () => Effect.void,
+      getPosition: () => Effect.succeed(null),
+    } as unknown as DbApi;
+
+    // When
+    const [processed] = await Effect.runPromise(
+      processSettlementJobs({
+        adapter,
+        db,
+        jobs: [job],
+        mode: "live",
+        now: 10_000,
+        maxSwapSlippageBps: 50,
+        settlementDustUsd: 0.1,
+      }),
+    );
+
+    // Then the quote path ran (400 → retryable with backoff), no dust-confirm.
+    expect(processed).toMatchObject({
+      status: "retryable",
+      error: "Jupiter quote failed: 400",
+      nextRetryAt: 11_000,
+    });
   });
 
   it("dust-confirms a priceable sub-dust settlement with the plain dust error", async () => {

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -115,7 +115,10 @@ export const statusCommand = new Command("status")
   $ prism status --message       # Markdown summary for Telegram/Discord/Slack/WhatsApp
 
 The status command reads from the local SQLite database and is safe to call
-from agent skills or cron jobs. It does not require the engine to be running.`,
+from agent skills or cron jobs. It does not require the engine to be running.
+When terminal settlements with unspent balance exist, classifying them
+(Stranded vs dust vs unpriceable) performs price/decimals lookups against the
+network; with no stranded settlements it is fully offline.`,
   )
   .action(async (opts: { json?: boolean; message?: boolean }) => {
     try {
@@ -325,37 +328,73 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
               settlement.confirmedOutputAtomic === null &&
               (newestConfirmedAt.get(settlement.tokenMint) ?? -1) < settlement.createdAt,
           );
+          // Issue #183: classify against the sweep's dust policy. Prices are
+          // batched into ONE call (all candidates known upfront); decimals
+          // run with bounded concurrency so a stranded-token burst cannot
+          // fire unbounded parallel RPC. Classification is three-way:
+          // - stranded — priceable value at/above SETTLEMENT_DUST_USD (the
+          //   sweep deliberately re-queues nothing here; real capital).
+          // - dust — priceable value below the cutoff (intentionally never
+          //   re-queued; excluded from the report).
+          // - unpriceable — no resolvable price (genuinely unquotable mint,
+          //   or a malformed/defective lookup): cannot be valued, surfaced on
+          //   its own line.
+          // - unavailable — the price fetch itself failed (provider/RPC
+          //   outage): distinct from unpriceable so an outage never mislabels
+          //   real stranded capital as worthless dust.
+          const adapter = yield* AdapterService;
+          const candidateMints = [...new Set(strandedCandidates.map((s) => s.tokenMint))];
+          const priceFetch = yield* adapter
+            .getTokenPrices(candidateMints)
+            .pipe(
+              Effect.map((p) => ({ ok: true as const, prices: p })),
+              Effect.catch(() => Effect.succeed({ ok: false as const, prices: {} })),
+              // A malformed mint can throw synchronously (PublicKey
+              // construction defect) inside the adapter; a display path must
+              // degrade to "unpriceable" rather than fail the whole command.
+              Effect.catchCause(() => Effect.succeed({ ok: false as const, prices: {} })),
+            );
           const strandedClassification = yield* Effect.all(
             strandedCandidates.map((settlement) =>
               Effect.gen(function* () {
-                const adapter = yield* AdapterService;
-                // catchAllCause, not catch: a malformed mint can throw
-                // synchronously (PublicKey construction defect) inside the
-                // adapter, and a display path must degrade to "unpriceable"
-                // rather than fail the whole status command.
-                const price = yield* adapter
-                  .getTokenPrices([settlement.tokenMint])
-                  .pipe(
-                    Effect.map((p) => p[settlement.tokenMint] ?? 0),
-                    Effect.catchCause(() => Effect.succeed(0)),
-                  );
-                const decimals = yield* adapter
+                if (!priceFetch.ok) {
+                  return { settlement, kind: "unavailable" as const };
+                }
+                const price = priceFetch.prices[settlement.tokenMint] ?? 0;
+                const decimalsResult = yield* adapter
                   .getTokenDecimals(settlement.tokenMint)
-                  .pipe(Effect.catchCause(() => Effect.succeed(0)));
-                const valueUsd =
-                  price > 0 && decimals > 0
-                    ? (Number(settlement.amountAtomic) / 10 ** decimals) * price
-                    : null;
-                return { settlement, valueUsd };
+                  .pipe(
+                    Effect.map((decimals) => ({ ok: true as const, decimals })),
+                    Effect.catch(() => Effect.succeed({ ok: false as const, decimals: 0 })),
+                    Effect.catchCause(() =>
+                      Effect.succeed({ ok: false as const, decimals: 0 }),
+                    ),
+                  );
+                if (price <= 0 || !decimalsResult.ok || decimalsResult.decimals <= 0) {
+                  return { settlement, kind: "unpriceable" as const };
+                }
+                const amountNum = Number(settlement.amountAtomic);
+                if (!Number.isFinite(amountNum)) {
+                  return { settlement, kind: "unpriceable" as const };
+                }
+                const valueUsd = (amountNum / 10 ** decimalsResult.decimals) * price;
+                return {
+                  settlement,
+                  kind: valueUsd >= config.settlementDustUsd ? ("stranded" as const) : ("dust" as const),
+                  valueUsd,
+                };
               }),
             ),
-            { concurrency: "unbounded" },
+            { concurrency: 4 },
           );
           const strandedSettlements = strandedClassification.filter(
-            (entry) => entry.valueUsd !== null && entry.valueUsd >= config.settlementDustUsd,
+            (entry): entry is (typeof entry & { valueUsd: number }) => entry.kind === "stranded",
           );
           const unpriceableStranded = strandedClassification.filter(
-            (entry) => entry.valueUsd === null,
+            (entry) => entry.kind === "unpriceable",
+          );
+          const unavailableStranded = strandedClassification.filter(
+            (entry) => entry.kind === "unavailable",
           );
 
           // Acceptance for issue #167: an active settlement_overdue pause
@@ -410,7 +449,7 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
                     `  Stranded:    ${strandedSettlements.length} terminal settlement(s) with unspent balance (${strandedSettlements
                       .map(
                         (entry) =>
-                          `${(entry.settlement.poolAddress || "?").slice(0, 8)}/${entry.settlement.tokenMint.slice(0, 8)} ($${entry.valueUsd!.toFixed(2)})`,
+                          `${(entry.settlement.poolAddress || "?").slice(0, 8)}/${entry.settlement.tokenMint.slice(0, 8)} ($${entry.valueUsd.toFixed(2)})`,
                       )
                       .join(", ")}) — see --json for details`,
                   ]
@@ -423,6 +462,16 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
                           `${(entry.settlement.poolAddress || "?").slice(0, 8)}/${entry.settlement.tokenMint.slice(0, 8)}`,
                       )
                       .join(", ")})`,
+                  ]
+                : []),
+              ...(unavailableStranded.length > 0
+                ? [
+                    `  Unavailable: ${unavailableStranded.length} terminal settlement(s) — price source unreachable, value unknown (${unavailableStranded
+                      .map(
+                        (entry) =>
+                          `${(entry.settlement.poolAddress || "?").slice(0, 8)}/${entry.settlement.tokenMint.slice(0, 8)}`,
+                      )
+                      .join(", ")}) — retry later`,
                   ]
                 : []),
               `  Safety pause: ${

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -344,34 +344,65 @@ network; with no stranded settlements it is fully offline.`,
           //   real stranded capital as worthless dust.
           const adapter = yield* AdapterService;
           const candidateMints = [...new Set(strandedCandidates.map((s) => s.tokenMint))];
-          const priceFetch = yield* adapter
-            .getTokenPrices(candidateMints)
-            .pipe(
-              Effect.map((p) => ({ ok: true as const, prices: p })),
-              Effect.catch(() => Effect.succeed({ ok: false as const, prices: {} })),
-              // A malformed mint can throw synchronously (PublicKey
-              // construction defect) inside the adapter; a display path must
-              // degrade to "unpriceable" rather than fail the whole command.
-              Effect.catchCause(() => Effect.succeed({ ok: false as const, prices: {} })),
-            );
+          // Three channels, per kilo review: a TYPED failure is a provider/RPC
+          // outage (→ Unavailable); a DEFECT is a malformed mint (→ per-mint
+          // fallback, degraded to Unpriceable); success with price 0 is a
+          // genuinely unquotable mint (→ Unpriceable). Collapsing the first
+          // two would mislabel real stranded capital during the exact outage
+          // window an operator checks status.
+          const priceFetch = yield* adapter.getTokenPrices(candidateMints).pipe(
+            Effect.map((p) => ({ tag: "ok" as const, prices: p })),
+            Effect.catch(() => Effect.succeed({ tag: "unavailable" as const })),
+            Effect.catchCause(() => Effect.succeed({ tag: "defect" as const })),
+          );
           const strandedClassification = yield* Effect.all(
             strandedCandidates.map((settlement) =>
               Effect.gen(function* () {
-                if (!priceFetch.ok) {
-                  return { settlement, kind: "unavailable" as const };
+                // Resolve the mint's price: from the batch, or per-mint
+                // fallback when the batch died on a defect — one malformed
+                // mint must not label every other candidate Unavailable.
+                let price: number;
+                let priceState: "ok" | "unavailable" | "unpriceable";
+                if (priceFetch.tag === "ok") {
+                  price = priceFetch.prices[settlement.tokenMint] ?? 0;
+                  priceState = price > 0 ? "ok" : "unpriceable";
+                } else if (priceFetch.tag === "unavailable") {
+                  price = 0;
+                  priceState = "unavailable";
+                } else {
+                  const perMint = yield* adapter.getTokenPrices([settlement.tokenMint]).pipe(
+                    Effect.map((p) => ({ tag: "ok" as const, price: p[settlement.tokenMint] ?? 0 })),
+                    Effect.catch(() => Effect.succeed({ tag: "unavailable" as const, price: 0 })),
+                    Effect.catchCause(() => Effect.succeed({ tag: "defect" as const, price: 0 })),
+                  );
+                  price = perMint.price;
+                  priceState =
+                    perMint.tag === "ok"
+                      ? perMint.price > 0
+                        ? "ok"
+                        : "unpriceable"
+                      : perMint.tag === "unavailable"
+                        ? "unavailable"
+                        : "unpriceable";
                 }
-                const price = priceFetch.prices[settlement.tokenMint] ?? 0;
+                if (priceState !== "ok") {
+                  return { settlement, kind: priceState };
+                }
+                // Same channel split for decimals: an RPC outage (typed
+                // failure) is Unavailable; a malformed-mint defect or an
+                // unresolvable decimals value is Unpriceable.
                 const decimalsResult = yield* adapter
                   .getTokenDecimals(settlement.tokenMint)
                   .pipe(
-                    Effect.map((decimals) => ({ ok: true as const, decimals })),
-                    Effect.catch(() => Effect.succeed({ ok: false as const, decimals: 0 })),
-                    Effect.catchCause(() =>
-                      Effect.succeed({ ok: false as const, decimals: 0 }),
-                    ),
+                    Effect.map((decimals) => ({ tag: "ok" as const, decimals })),
+                    Effect.catch(() => Effect.succeed({ tag: "unavailable" as const, decimals: 0 })),
+                    Effect.catchCause(() => Effect.succeed({ tag: "defect" as const, decimals: 0 })),
                   );
-                if (price <= 0 || !decimalsResult.ok || decimalsResult.decimals <= 0) {
-                  return { settlement, kind: "unpriceable" as const };
+                if (decimalsResult.tag !== "ok" || decimalsResult.decimals <= 0) {
+                  return {
+                    settlement,
+                    kind: decimalsResult.tag === "unavailable" ? "unavailable" : "unpriceable",
+                  };
                 }
                 const amountNum = Number(settlement.amountAtomic);
                 if (!Number.isFinite(amountNum)) {

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -306,6 +306,11 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
           // only when a CONFIRMED settlement for the same mint is newer than
           // it (the sweep sold the token) — a terminal record NEWER than any
           // confirmed one is a recurring stranding and must stay visible.
+          // Issue #183: classify against the sweep's dust policy — a
+          // sub-dust terminal is intentionally never re-queued (not stranded
+          // capital, so it is excluded), an unpriceable terminal cannot be
+          // valued (stays visible, labeled unpriceable), and only priceable
+          // value at/above the dust cutoff is real stranded capital.
           const newestConfirmedAt = new Map<string, number>();
           for (const settlement of autonomous.settlements) {
             if (settlement.status !== "confirmed") continue;
@@ -314,11 +319,39 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
               newestConfirmedAt.set(settlement.tokenMint, settlement.createdAt);
             }
           }
-          const strandedSettlements = autonomous.settlements.filter(
+          const strandedCandidates = autonomous.settlements.filter(
             (settlement) =>
               settlement.status === "terminal" &&
               settlement.confirmedOutputAtomic === null &&
               (newestConfirmedAt.get(settlement.tokenMint) ?? -1) < settlement.createdAt,
+          );
+          const strandedClassification = yield* Effect.all(
+            strandedCandidates.map((settlement) =>
+              Effect.gen(function* () {
+                const adapter = yield* AdapterService;
+                const price = yield* adapter
+                  .getTokenPrices([settlement.tokenMint])
+                  .pipe(
+                    Effect.map((p) => p[settlement.tokenMint] ?? 0),
+                    Effect.catch(() => Effect.succeed(0)),
+                  );
+                const decimals = yield* adapter
+                  .getTokenDecimals(settlement.tokenMint)
+                  .pipe(Effect.catch(() => Effect.succeed(0)));
+                const valueUsd =
+                  price > 0 && decimals > 0
+                    ? (Number(settlement.amountAtomic) / 10 ** decimals) * price
+                    : null;
+                return { settlement, valueUsd };
+              }),
+            ),
+            { concurrency: "unbounded" },
+          );
+          const strandedSettlements = strandedClassification.filter(
+            (entry) => entry.valueUsd !== null && entry.valueUsd >= config.settlementDustUsd,
+          );
+          const unpriceableStranded = strandedClassification.filter(
+            (entry) => entry.valueUsd === null,
           );
 
           // Acceptance for issue #167: an active settlement_overdue pause
@@ -372,10 +405,20 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
                 ? [
                     `  Stranded:    ${strandedSettlements.length} terminal settlement(s) with unspent balance (${strandedSettlements
                       .map(
-                        (settlement) =>
-                          `${(settlement.poolAddress || "?").slice(0, 8)}/${settlement.tokenMint.slice(0, 8)}`,
+                        (entry) =>
+                          `${(entry.settlement.poolAddress || "?").slice(0, 8)}/${entry.settlement.tokenMint.slice(0, 8)} ($${entry.valueUsd!.toFixed(2)})`,
                       )
                       .join(", ")}) — see --json for details`,
+                  ]
+                : []),
+              ...(unpriceableStranded.length > 0
+                ? [
+                    `  Unpriceable: ${unpriceableStranded.length} terminal settlement(s) with no USD price — cannot value, left in wallet (${unpriceableStranded
+                      .map(
+                        (entry) =>
+                          `${(entry.settlement.poolAddress || "?").slice(0, 8)}/${entry.settlement.tokenMint.slice(0, 8)}`,
+                      )
+                      .join(", ")})`,
                   ]
                 : []),
               `  Safety pause: ${

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -329,15 +329,19 @@ from agent skills or cron jobs. It does not require the engine to be running.`,
             strandedCandidates.map((settlement) =>
               Effect.gen(function* () {
                 const adapter = yield* AdapterService;
+                // catchAllCause, not catch: a malformed mint can throw
+                // synchronously (PublicKey construction defect) inside the
+                // adapter, and a display path must degrade to "unpriceable"
+                // rather than fail the whole status command.
                 const price = yield* adapter
                   .getTokenPrices([settlement.tokenMint])
                   .pipe(
                     Effect.map((p) => p[settlement.tokenMint] ?? 0),
-                    Effect.catch(() => Effect.succeed(0)),
+                    Effect.catchCause(() => Effect.succeed(0)),
                   );
                 const decimals = yield* adapter
                   .getTokenDecimals(settlement.tokenMint)
-                  .pipe(Effect.catch(() => Effect.succeed(0)));
+                  .pipe(Effect.catchCause(() => Effect.succeed(0)));
                 const valueUsd =
                   price > 0 && decimals > 0
                     ? (Number(settlement.amountAtomic) / 10 ** decimals) * price

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { Effect } from "effect";
 import { SOL_MINT } from "./constants.js";
+import { createLogger } from "./logger.js";
 import { computeNetRealizedPnlUsd } from "./pnl.js";
 import type { AdapterApi, DbApi } from "./services.js";
 import type {
@@ -9,6 +10,8 @@ import type {
   SafetyPauseRecord,
   SettlementJobRecord,
 } from "./types.js";
+
+const logger = createLogger("autonomous-runtime");
 
 /** Returns whether an action remains permitted while the wallet safety pause is active. */
 export function isActionAllowedDuringSafetyPause(action: ActionType): boolean {
@@ -453,12 +456,9 @@ export function processSettlementJobs(
         const inputPriceUsd = prices[job.tokenMint] ?? 0;
         const inputUsd = atomicUsd(amountAtomic, inputDecimals, inputPriceUsd);
         const settlementDustUsd = input.settlementDustUsd ?? 0;
-        // Issue #183: the dust skip covers unpriceable tokens too (value
-        // unknown ⇒ $0). Quoting an unquotable mint returns a definitive 400
-        // (no route) and previously re-queued the job forever; terminalizing
-        // it as dust stops the loop — the orphan sweep re-evaluates prices
-        // every cycle, so the token re-qualifies if a price ever resolves.
-        if (settlementDustUsd > 0 && (inputPriceUsd <= 0 || inputUsd < settlementDustUsd)) {
+        // Priceable sub-dust stays put (pre-existing policy): the value is
+        // known and below the sweep cutoff, so it is recorded as recovered.
+        if (settlementDustUsd > 0 && inputPriceUsd > 0 && inputUsd < settlementDustUsd) {
           return {
             ...job,
             status: "confirmed" as const,
@@ -467,8 +467,32 @@ export function processSettlementJobs(
             confirmedOutputAtomic: amountAtomic.toString(),
             outputUsd: inputUsd,
             executionCostUsd: 0,
-            error:
-              inputPriceUsd > 0 ? "settlement dust skipped" : "settlement dust skipped (no USD price)",
+            error: "settlement dust skipped",
+            updatedAt: input.now,
+          };
+        }
+        // Issue #183: the dust skip covers unpriceable tokens too (value
+        // unknown ⇒ $0) — quoting an unquotable mint returns a definitive 400
+        // (no route) and previously re-queued the job forever. Confirmed ONLY
+        // for synthetic settlement groups (orphan:/rollback: — no position row
+        // to finalize): a real position's sweep job (EXIT residues/rewards)
+        // must not be dust-confirmed, because finalizing its group would book
+        // a full PnL loss while the tokens still sit in the wallet. Real
+        // positions fall through to the quote path (bounded retries, then
+        // terminal on expiry — operator-visible via prism status), and the
+        // orphan sweep skips unpriceable holdings, so the 400 loop stays dead.
+        const syntheticSettlementGroup =
+          job.positionId.startsWith("orphan:") || job.positionId.startsWith("rollback:");
+        if (syntheticSettlementGroup && settlementDustUsd > 0 && inputPriceUsd <= 0) {
+          return {
+            ...job,
+            status: "confirmed" as const,
+            attempts: job.attempts + 1,
+            nextRetryAt: null,
+            confirmedOutputAtomic: amountAtomic.toString(),
+            outputUsd: inputUsd,
+            executionCostUsd: 0,
+            error: "settlement dust skipped (no USD price)",
             updatedAt: input.now,
           };
         }
@@ -668,7 +692,22 @@ export function sweepOrphanSettlements(
     }
     const prices = yield* input.adapter
       .getTokenPrices(candidates.map(([mint]) => mint))
-      .pipe(Effect.catch(() => Effect.succeed<Record<string, number>>({})));
+      .pipe(
+        // Issue #183: a price-fetch failure must not be silent — every
+        // holding would read price 0 and be skipped as dust for the cycle
+        // (a quiet multi-cycle sweep stall is otherwise unobservable; the
+        // processor path treats the same failure as retryable).
+        Effect.catch((err) => {
+          logger.warn(
+            "Orphan sweep price fetch failed — unpriceable holdings treated as dust this cycle",
+            {
+              candidateCount: candidates.length,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          );
+          return Effect.succeed<Record<string, number>>({});
+        }),
+      );
     // A terminal job for the mint is revived in place (upsert on id) rather
     // than replaced by a fresh row: attempts carry over so backoff escalates
     // across generations, and the settlements table stays one row per mint

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -453,7 +453,12 @@ export function processSettlementJobs(
         const inputPriceUsd = prices[job.tokenMint] ?? 0;
         const inputUsd = atomicUsd(amountAtomic, inputDecimals, inputPriceUsd);
         const settlementDustUsd = input.settlementDustUsd ?? 0;
-        if (settlementDustUsd > 0 && inputPriceUsd > 0 && inputUsd < settlementDustUsd) {
+        // Issue #183: the dust skip covers unpriceable tokens too (value
+        // unknown ⇒ $0). Quoting an unquotable mint returns a definitive 400
+        // (no route) and previously re-queued the job forever; terminalizing
+        // it as dust stops the loop — the orphan sweep re-evaluates prices
+        // every cycle, so the token re-qualifies if a price ever resolves.
+        if (settlementDustUsd > 0 && (inputPriceUsd <= 0 || inputUsd < settlementDustUsd)) {
           return {
             ...job,
             status: "confirmed" as const,
@@ -462,7 +467,8 @@ export function processSettlementJobs(
             confirmedOutputAtomic: amountAtomic.toString(),
             outputUsd: inputUsd,
             executionCostUsd: 0,
-            error: "settlement dust skipped",
+            error:
+              inputPriceUsd > 0 ? "settlement dust skipped" : "settlement dust skipped (no USD price)",
             updatedAt: input.now,
           };
         }
@@ -605,8 +611,10 @@ export interface OrphanSettlementSweepInput {
  * rollback settlement died. Each cycle this compares wallet holdings against
  * the mints that are actually accounted for (position legs, active settlement
  * jobs) and re-enqueues a fresh sell-settlement job for everything else.
- * Dust below `settlementDustUsd` stays put (unpriceable tokens are enqueued —
- * the processor's dust skip re-applies at execution time). Fail-open end to
+ * Dust below `settlementDustUsd` stays put; unpriceable tokens are treated as
+ * dust too (value unknown ⇒ $0 for sweep purposes — issue #183: quoting an
+ * unquotable mint 400s forever, so enqueuing them was an infinite retry loop)
+ * and re-qualify automatically once a price resolves. Fail-open end to
  * end: a holdings read, pool-state fetch, or price fetch failure skips only
  * its own contribution and never blocks the cycle. RPC cost is gated —
  * position legs are only fetched when candidate mints actually exist, and
@@ -686,8 +694,8 @@ export function sweepOrphanSettlements(
       const priceUsd = prices[mint] ?? 0;
       if (
         input.settlementDustUsd > 0 &&
-        priceUsd > 0 &&
-        atomicUsd(holding.amountAtomic, holding.decimals, priceUsd) < input.settlementDustUsd
+        (priceUsd <= 0 ||
+          atomicUsd(holding.amountAtomic, holding.decimals, priceUsd) < input.settlementDustUsd)
       ) {
         continue;
       }


### PR DESCRIPTION
Fixes #183

## Problem

Two inconsistencies in the orphan-sweep / stranded-status path (observed live on 0.1.10):

1. **Unpriceable tokens bypass the dust gate and retry forever.** The sweep only applied `settlementDustUsd` when `priceUsd > 0`. A wallet token with no resolvable USD price got a sell job regardless of value → Jupiter 400 (no route) → job stayed `retryable` with backoff forever, warning every cycle.
2. **Sub-dust terminal settlements flagged "Stranded" permanently.** Terminal jobs with `confirmedOutputAtomic=null` and no newer confirmed job for the mint were flagged `Stranded` every cycle — even when below the sweep dust cutoff and deliberately never re-queued.

## Fix

1. **Dust gate covers unpriceable tokens** (sweep + processor in `engine/autonomous-runtime.ts`):
   - `sweepOrphanSettlements`: a holding with `priceUsd <= 0` is dust (value unknown ⇒ $0) — skipped instead of enqueued. It re-qualifies automatically once a price resolves (prices are re-evaluated every cycle).
   - `processSettlementJobs`: the dust skip accepts `inputPriceUsd <= 0` — existing jobs for now-unpriceable mints are dust-confirmed with a distinct `"settlement dust skipped (no USD price)"` error instead of being quoted. The 400 no-route retry loop is gone.
2. **Stranded status reconciles with the dust policy** (`cli/status.ts`): stranded candidates are classified with live prices + decimals —
   - priceable value at/above `SETTLEMENT_DUST_USD` → `Stranded: N ... ($$X.XX)` (USD shown).
   - sub-dust priceable value → excluded (intentionally never re-queued).
   - unpriceable → separate `Unpriceable: N ... no USD price` line, so real stranded capital stays distinguishable from worthless dust.
   - Classification degrades to "unpriceable" on any adapter defect (`catchCause`), so a malformed mint can never fail the status command.

## Verification

- `bun run lint` clean; `bun run test` 120 files / 1558 tests pass — new tests: unpriceable sweep skip (dust on / off), processor dust-confirm for unpriceable + priceable-sub-dust, updated stranded-status CLI assertions for the Unpriceable line.
- CI: build + cloudflare-tests green.

## Summary by Sourcery

Treat unpriceable wallet tokens as dust in autonomous settlement processing and reconcile stranded settlement reporting with the dust policy.

Bug Fixes:
- Prevent unpriceable settlement jobs from being retried indefinitely by dust-confirming them when the dust gate is enabled.
- Exclude priceable sub-dust terminal settlements from stranded capital while keeping unpriceable terminals visible but separately classified.

Enhancements:
- Show USD values for priceable stranded terminal settlements and list unpriceable terminals on a dedicated Unpriceable line in the CLI status output.

Documentation:
- Document the new dust handling for unpriceable tokens and the updated stranded vs unpriceable reporting behavior in the changelog.

Tests:
- Add tests covering dust confirmation for unpriceable and priceable sub-dust settlements, dust gating of unpriceable holdings in the orphan sweep, and the updated CLI stranded/unpriceable status output.