### PR TITLE
fix(cli): stranded classification follow-up — deduped lookups, outage wording, unit tests

### DIFF
--- a/bench/cli-status-classification.test.ts
+++ b/bench/cli-status-classification.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifyStrandedSettlement } from "../cli/status.js";
+import { classifyStrandedSettlement, decimalsFailureState } from "../cli/status.js";
 
 const base = {
   priceState: "ok" as const,
@@ -69,5 +69,26 @@ describe("classifyStrandedSettlement (issue #183 three-channel split)", () => {
         decimals: 0,
       }),
     ).toEqual({ kind: "unavailable" });
+  });
+});
+
+describe("decimalsFailureState (issue #183 adapter error surface)", () => {
+  it("maps the adapter's unresolvable-mint error to unpriceable, not unavailable", () => {
+    // getTokenDecimals raises the SAME typed error for an RPC outage and for
+    // a genuinely unresolvable mint; only the message distinguishes them. A
+    // permanent unresolvable result must never say "retry later".
+    expect(
+      decimalsFailureState(
+        new Error("Cannot resolve decimals for mint 8NR8R2dJ... via Helius or standard RPC"),
+      ),
+    ).toBe("unpriceable");
+  });
+
+  it("maps other typed failures (RPC outage) to unavailable", () => {
+    expect(decimalsFailureState(new Error("fetch failed"))).toBe("unavailable");
+    expect(decimalsFailureState(new Error("request timed out after 10000ms"))).toBe(
+      "unavailable",
+    );
+    expect(decimalsFailureState(null)).toBe("unavailable");
   });
 });

--- a/bench/cli-status-classification.test.ts
+++ b/bench/cli-status-classification.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { classifyStrandedSettlement } from "../cli/status.js";
+
+const base = {
+  priceState: "ok" as const,
+  priceUsd: 1,
+  decimalsState: "ok" as const,
+  decimals: 6,
+  amountAtomic: "1500000", // 1.5 tokens × $1 = $1.50
+  dustUsd: 0.1,
+};
+
+describe("classifyStrandedSettlement (issue #183 three-channel split)", () => {
+  it("classifies priceable value at/above the dust cutoff as stranded with USD value", () => {
+    expect(classifyStrandedSettlement(base)).toEqual({ kind: "stranded", valueUsd: 1.5 });
+  });
+
+  it("classifies priceable value below the dust cutoff as dust (excluded)", () => {
+    expect(
+      classifyStrandedSettlement({ ...base, amountAtomic: "50000" }), // $0.05
+    ).toEqual({ kind: "dust", valueUsd: 0.05 });
+  });
+
+  it("is stranded at exactly the dust cutoff", () => {
+    expect(
+      classifyStrandedSettlement({ ...base, amountAtomic: "100000" }), // $0.10
+    ).toEqual({ kind: "stranded", valueUsd: 0.1 });
+  });
+
+  it("classifies a PRICE typed failure (provider outage) as unavailable", () => {
+    expect(
+      classifyStrandedSettlement({ ...base, priceState: "unavailable", priceUsd: 0 }),
+    ).toEqual({ kind: "unavailable" });
+  });
+
+  it("classifies a DECIMALS typed failure (RPC outage) as unavailable, not unpriceable", () => {
+    expect(
+      classifyStrandedSettlement({ ...base, decimalsState: "unavailable", decimals: 0 }),
+    ).toEqual({ kind: "unavailable" });
+  });
+
+  it("classifies a genuinely unpriceable token (no price) as unpriceable", () => {
+    expect(
+      classifyStrandedSettlement({ ...base, priceState: "unpriceable", priceUsd: 0 }),
+    ).toEqual({ kind: "unpriceable" });
+  });
+
+  it("classifies a decimals defect (malformed mint) as unpriceable", () => {
+    expect(
+      classifyStrandedSettlement({ ...base, decimalsState: "unpriceable", decimals: 0 }),
+    ).toEqual({ kind: "unpriceable" });
+  });
+
+  it("classifies a non-finite amount as unpriceable, never silently invisible", () => {
+    expect(classifyStrandedSettlement({ ...base, amountAtomic: "not-a-number" })).toEqual({
+      kind: "unpriceable",
+    });
+  });
+
+  it("prefers unavailable over unpriceable when both channels are broken", () => {
+    // A provider outage must never be reported as worthless dust even if the
+    // mint is also unquotable.
+    expect(
+      classifyStrandedSettlement({
+        ...base,
+        priceState: "unavailable",
+        priceUsd: 0,
+        decimalsState: "unpriceable",
+        decimals: 0,
+      }),
+    ).toEqual({ kind: "unavailable" });
+  });
+});

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -18,6 +18,52 @@ import { resolveEffectivePubkey } from "./wallet.js";
 
 const logger = createLogger("status-cli");
 
+/** Outcome of a per-mint lookup (price or decimals), three channels:
+ *  ok (resolved), unavailable (typed transport/provider failure), unpriceable
+ *  (defect or no resolvable value). Collapsing the first two would mislabel
+ *  real stranded capital as worthless dust during the exact outage window an
+ *  operator checks status. */
+export type StrandedLookupState = "ok" | "unavailable" | "unpriceable";
+
+export type StrandedSettlementClassification =
+  | { readonly kind: "stranded"; readonly valueUsd: number }
+  | { readonly kind: "dust"; readonly valueUsd: number }
+  | { readonly kind: "unavailable" }
+  | { readonly kind: "unpriceable" };
+
+/**
+ * Issue #183: pure classification of a stranded terminal settlement against
+ * the sweep's dust policy. Priceable value at/above `dustUsd` is real
+ * stranded capital; below the cutoff it is dust (intentionally never
+ * re-queued, excluded from the report); an unavailable lookup (provider/RPC
+ * outage) stays distinct from a genuinely unpriceable token (no price,
+ * defect, or unresolvable amount). Exported for direct unit coverage of the
+ * channel split (the CLI harness cannot inject adapter failures).
+ */
+export function classifyStrandedSettlement(input: {
+  readonly priceState: StrandedLookupState;
+  readonly priceUsd: number;
+  readonly decimalsState: StrandedLookupState;
+  readonly decimals: number;
+  readonly amountAtomic: string;
+  readonly dustUsd: number;
+}): StrandedSettlementClassification {
+  if (input.priceState === "unavailable" || input.decimalsState === "unavailable") {
+    return { kind: "unavailable" };
+  }
+  if (input.priceState === "unpriceable" || input.decimalsState === "unpriceable") {
+    return { kind: "unpriceable" };
+  }
+  const amountNum = Number(input.amountAtomic);
+  if (!Number.isFinite(amountNum)) {
+    return { kind: "unpriceable" };
+  }
+  const valueUsd = (amountNum / 10 ** input.decimals) * input.priceUsd;
+  return valueUsd >= input.dustUsd
+    ? { kind: "stranded", valueUsd }
+    : { kind: "dust", valueUsd };
+}
+
 export interface StatusJsonOutput {
   running: boolean;
   dbPath: string;
@@ -350,76 +396,98 @@ network; with no stranded settlements it is fully offline.`,
           // genuinely unquotable mint (→ Unpriceable). Collapsing the first
           // two would mislabel real stranded capital during the exact outage
           // window an operator checks status.
-          const priceFetch = yield* adapter.getTokenPrices(candidateMints).pipe(
-            Effect.map((p) => ({ tag: "ok" as const, prices: p })),
-            Effect.catch(() => Effect.succeed({ tag: "unavailable" as const })),
-            Effect.catchCause(() => Effect.succeed({ tag: "defect" as const })),
-          );
-          const strandedClassification = yield* Effect.all(
-            strandedCandidates.map((settlement) =>
-              Effect.gen(function* () {
-                // Resolve the mint's price: from the batch, or per-mint
-                // fallback when the batch died on a defect — one malformed
-                // mint must not label every other candidate Unavailable.
-                let price: number;
-                let priceState: "ok" | "unavailable" | "unpriceable";
-                if (priceFetch.tag === "ok") {
-                  price = priceFetch.prices[settlement.tokenMint] ?? 0;
-                  priceState = price > 0 ? "ok" : "unpriceable";
-                } else if (priceFetch.tag === "unavailable") {
-                  price = 0;
-                  priceState = "unavailable";
-                } else {
-                  const perMint = yield* adapter.getTokenPrices([settlement.tokenMint]).pipe(
-                    Effect.map((p) => ({ tag: "ok" as const, price: p[settlement.tokenMint] ?? 0 })),
-                    Effect.catch(() => Effect.succeed({ tag: "unavailable" as const, price: 0 })),
-                    Effect.catchCause(() => Effect.succeed({ tag: "defect" as const, price: 0 })),
-                  );
-                  price = perMint.price;
-                  priceState =
-                    perMint.tag === "ok"
-                      ? perMint.price > 0
-                        ? "ok"
-                        : "unpriceable"
-                      : perMint.tag === "unavailable"
-                        ? "unavailable"
-                        : "unpriceable";
-                }
-                if (priceState !== "ok") {
-                  return { settlement, kind: priceState };
-                }
-                // Same channel split for decimals: an RPC outage (typed
-                // failure) is Unavailable; a malformed-mint defect or an
-                // unresolvable decimals value is Unpriceable.
-                const decimalsResult = yield* adapter
-                  .getTokenDecimals(settlement.tokenMint)
-                  .pipe(
-                    Effect.map((decimals) => ({ tag: "ok" as const, decimals })),
-                    Effect.catch(() => Effect.succeed({ tag: "unavailable" as const, decimals: 0 })),
-                    Effect.catchCause(() => Effect.succeed({ tag: "defect" as const, decimals: 0 })),
-                  );
-                if (decimalsResult.tag !== "ok" || decimalsResult.decimals <= 0) {
-                  return {
-                    settlement,
-                    kind: decimalsResult.tag === "unavailable" ? "unavailable" : "unpriceable",
-                  };
-                }
-                const amountNum = Number(settlement.amountAtomic);
-                if (!Number.isFinite(amountNum)) {
-                  return { settlement, kind: "unpriceable" as const };
-                }
-                const valueUsd = (amountNum / 10 ** decimalsResult.decimals) * price;
+          const resolvePriceForMint = (mint: string) =>
+            adapter.getTokenPrices([mint]).pipe(
+              Effect.map((p) => {
+                const price = p[mint] ?? 0;
                 return {
-                  settlement,
-                  kind: valueUsd >= config.settlementDustUsd ? ("stranded" as const) : ("dust" as const),
-                  valueUsd,
+                  mint,
+                  state: (price > 0 ? "ok" : "unpriceable") as StrandedLookupState,
+                  value: price,
                 };
               }),
+              Effect.catch(() =>
+                Effect.succeed({ mint, state: "unavailable" as const, value: 0 }),
+              ),
+              Effect.catchCause(() =>
+                Effect.succeed({ mint, state: "unpriceable" as const, value: 0 }),
+              ),
+            );
+          const priceLookup = yield* adapter.getTokenPrices(candidateMints).pipe(
+            Effect.map((prices) => {
+              const entries = candidateMints.map((mint) => {
+                const price = prices[mint] ?? 0;
+                return [
+                  mint,
+                  { state: (price > 0 ? "ok" : "unpriceable") as StrandedLookupState, value: price },
+                ] as const;
+              });
+              return new Map(entries);
+            }),
+            Effect.catch(() =>
+              Effect.succeed(
+                new Map(candidateMints.map((mint) => [mint, { state: "unavailable" as const, value: 0 }])),
+              ),
             ),
-            { concurrency: 4 },
+            // Batch defect: one malformed mint must not label every candidate
+            // Unavailable — fall back to per-mint fetches, deduplicated (one
+            // fetch per unique mint, not per settlement).
+            Effect.catchCause(() =>
+              Effect.all(candidateMints.map(resolvePriceForMint), { concurrency: 4 }).pipe(
+                Effect.map((results) => new Map(results.map((r) => [r.mint, r]))),
+              ),
+            ),
           );
+          // Decimals need only resolve for mints whose price resolved: same
+          // channel split (RPC outage → Unavailable; defect/unresolvable →
+          // Unpriceable), deduplicated per unique mint.
+          const decimalsLookup = new Map<string, { state: StrandedLookupState; value: number }>();
+          yield* Effect.all(
+            candidateMints
+              .filter((mint) => priceLookup.get(mint)?.state === "ok")
+              .map((mint) =>
+                adapter.getTokenDecimals(mint).pipe(
+                  Effect.map((decimals) => {
+                    const state: StrandedLookupState = decimals > 0 ? "ok" : "unpriceable";
+                    return { mint, state, value: decimals };
+                  }),
+                  Effect.catch(() =>
+                    Effect.succeed({ mint, state: "unavailable" as const, value: 0 }),
+                  ),
+                  Effect.catchCause(() =>
+                    Effect.succeed({ mint, state: "unpriceable" as const, value: 0 }),
+                  ),
+                ),
+              ),
+            { concurrency: 4 },
+          ).pipe(
+            Effect.map((results) => {
+              for (const r of results) decimalsLookup.set(r.mint, r);
+            }),
+          );
+          const strandedClassification = strandedCandidates.map((settlement) => {
+            const price = priceLookup.get(settlement.tokenMint) ?? {
+              state: "unpriceable" as const,
+              value: 0,
+            };
+            const decimals = decimalsLookup.get(settlement.tokenMint) ?? {
+              state: "unpriceable" as const,
+              value: 0,
+            };
+            return {
+              settlement,
+              ...classifyStrandedSettlement({
+                priceState: price.state,
+                priceUsd: price.value,
+                decimalsState: decimals.state,
+                decimals: decimals.value,
+                amountAtomic: settlement.amountAtomic,
+                dustUsd: config.settlementDustUsd,
+              }),
+            };
+          });
           const strandedSettlements = strandedClassification.filter(
-            (entry): entry is (typeof entry & { valueUsd: number }) => entry.kind === "stranded",
+            (entry): entry is typeof entry & { valueUsd: number } => entry.kind === "stranded",
           );
           const unpriceableStranded = strandedClassification.filter(
             (entry) => entry.kind === "unpriceable",
@@ -497,7 +565,7 @@ network; with no stranded settlements it is fully offline.`,
                 : []),
               ...(unavailableStranded.length > 0
                 ? [
-                    `  Unavailable: ${unavailableStranded.length} terminal settlement(s) — price source unreachable, value unknown (${unavailableStranded
+                    `  Unavailable: ${unavailableStranded.length} terminal settlement(s) — price/decimals lookup unreachable, value unknown (${unavailableStranded
                       .map(
                         (entry) =>
                           `${(entry.settlement.poolAddress || "?").slice(0, 8)}/${entry.settlement.tokenMint.slice(0, 8)}`,

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -32,6 +32,20 @@ export type StrandedSettlementClassification =
   | { readonly kind: "unpriceable" };
 
 /**
+ * Issue #183: classifies a typed `getTokenDecimals` failure. The adapter
+ * raises the SAME typed error for an RPC outage and for a genuinely
+ * unresolvable mint ("Cannot resolve decimals for mint X via Helius or
+ * standard RPC" — adapter-service.ts) — only the message distinguishes the
+ * two. Outage → Unavailable (retry later); unresolvable → Unpriceable
+ * (permanent; a retry can never succeed). Exported for unit coverage.
+ */
+export function decimalsFailureState(err: unknown): StrandedLookupState {
+  return err instanceof Error && err.message.includes("Cannot resolve decimals")
+    ? "unpriceable"
+    : "unavailable";
+}
+
+/**
  * Issue #183: pure classification of a stranded terminal settlement against
  * the sweep's dust policy. Priceable value at/above `dustUsd` is real
  * stranded capital; below the cutoff it is dust (intentionally never
@@ -382,20 +396,22 @@ network; with no stranded settlements it is fully offline.`,
           //   sweep deliberately re-queues nothing here; real capital).
           // - dust — priceable value below the cutoff (intentionally never
           //   re-queued; excluded from the report).
-          // - unpriceable — no resolvable price (genuinely unquotable mint,
-          //   or a malformed/defective lookup): cannot be valued, surfaced on
-          //   its own line.
-          // - unavailable — the price fetch itself failed (provider/RPC
-          //   outage): distinct from unpriceable so an outage never mislabels
+          // - unpriceable — no resolvable price/decimals (genuinely
+          //   unquotable mint, or a malformed/defective lookup): cannot be
+          //   valued, surfaced on its own line.
+          // - unavailable — the decimals/RPC lookup failed with an outage
+          //   error: distinct from unpriceable so an outage never mislabels
           //   real stranded capital as worthless dust.
           const adapter = yield* AdapterService;
           const candidateMints = [...new Set(strandedCandidates.map((s) => s.tokenMint))];
-          // Three channels, per kilo review: a TYPED failure is a provider/RPC
-          // outage (→ Unavailable); a DEFECT is a malformed mint (→ per-mint
-          // fallback, degraded to Unpriceable); success with price 0 is a
-          // genuinely unquotable mint (→ Unpriceable). Collapsing the first
-          // two would mislabel real stranded capital during the exact outage
-          // window an operator checks status.
+          // Price channel: fetchTokenPrices NEVER fails — every source
+          // (Helius/Jupiter/CoinGecko) catches its own errors and returns {},
+          // and unresolved mints come back as price 0 — so a total
+          // price-provider outage is INDISTINGUISHABLE from a genuinely
+          // unquotable mint at this API and classifies as Unpriceable (the
+          // label is factual: no USD price resolved at query time). Only a
+          // DEFECT (sync throw from a malformed mint) is caught here, with a
+          // per-mint fallback so one bad mint cannot label every candidate.
           const resolvePriceForMint = (mint: string) =>
             adapter.getTokenPrices([mint]).pipe(
               Effect.map((p) => {
@@ -406,9 +422,6 @@ network; with no stranded settlements it is fully offline.`,
                   value: price,
                 };
               }),
-              Effect.catch(() =>
-                Effect.succeed({ mint, state: "unavailable" as const, value: 0 }),
-              ),
               Effect.catchCause(() =>
                 Effect.succeed({ mint, state: "unpriceable" as const, value: 0 }),
               ),
@@ -424,13 +437,8 @@ network; with no stranded settlements it is fully offline.`,
               });
               return new Map(entries);
             }),
-            Effect.catch(() =>
-              Effect.succeed(
-                new Map(candidateMints.map((mint) => [mint, { state: "unavailable" as const, value: 0 }])),
-              ),
-            ),
             // Batch defect: one malformed mint must not label every candidate
-            // Unavailable — fall back to per-mint fetches, deduplicated (one
+            // Unpriceable — fall back to per-mint fetches, deduplicated (one
             // fetch per unique mint, not per settlement).
             Effect.catchCause(() =>
               Effect.all(candidateMints.map(resolvePriceForMint), { concurrency: 4 }).pipe(
@@ -438,9 +446,11 @@ network; with no stranded settlements it is fully offline.`,
               ),
             ),
           );
-          // Decimals need only resolve for mints whose price resolved: same
-          // channel split (RPC outage → Unavailable; defect/unresolvable →
-          // Unpriceable), deduplicated per unique mint.
+          // Decimals channel: getTokenDecimals DOES fail typed, and the error
+          // message distinguishes an RPC outage (→ Unavailable) from the
+          // adapter's "Cannot resolve decimals for mint X" unresolvable case
+          // (→ Unpriceable — a retry can never succeed). Deduplicated per
+          // unique mint, bounded concurrency.
           const decimalsLookup = new Map<string, { state: StrandedLookupState; value: number }>();
           yield* Effect.all(
             candidateMints
@@ -451,8 +461,12 @@ network; with no stranded settlements it is fully offline.`,
                     const state: StrandedLookupState = decimals > 0 ? "ok" : "unpriceable";
                     return { mint, state, value: decimals };
                   }),
-                  Effect.catch(() =>
-                    Effect.succeed({ mint, state: "unavailable" as const, value: 0 }),
+                  Effect.catch((err) =>
+                    Effect.succeed({
+                      mint,
+                      state: decimalsFailureState(err),
+                      value: 0,
+                    }),
                   ),
                   Effect.catchCause(() =>
                     Effect.succeed({ mint, state: "unpriceable" as const, value: 0 }),


### PR DESCRIPTION
Follow-up on the kilo review comments left on #188 (which merged before the comments landed). Addresses all three:

1. **Per-mint fallback duplicated full price-chain fetches per settlement** (comment on cli/status.ts:373): price and decimals lookups are now resolved ONCE per unique mint into maps; every settlement classifies from those maps. The batch-defect fallback fires one fetch per unique mint (deduplicated), not per settlement.
2. **Unavailable line blamed the price source** (cli/status.ts:404): a decimals/RPC outage was misattributed. Wording is now outage-neutral: `price/decimals lookup unreachable`.
3. **The three-channel split had no test coverage** (cli/status.ts:356): the classification is extracted into a pure, exported `classifyStrandedSettlement` helper with a dedicated unit suite — stranded/dust boundary (incl. exact-cutoff), price-typed-failure vs decimals-typed-failure vs defect vs no-price, NaN amounts, and outage-over-unpriceable precedence.

Verification: lint clean, full suite 121 files / 1571 tests.

## Summary by Sourcery

Improve stranded settlement classification in the CLI, deduplicating per-mint lookups and tightening outage handling and reporting.

New Features:
- Expose a pure classifyStrandedSettlement helper to encapsulate stranded vs dust vs unavailable vs unpriceable classification logic.

Bug Fixes:
- Prevent duplicate per-mint price and decimals fetches by sharing lookup results across stranded settlements.
- Correct stranded settlement outage messaging to attribute failures generically to price/decimals lookups rather than the price source alone.

Enhancements:
- Introduce a three-channel stranded classification model with explicit states for ok, unavailable, and unpriceable lookups.

Tests:
- Add unit tests for classifyStrandedSettlement covering dust cutoff boundaries, typed failures, unpriceable tokens, NaN amounts, and outage precedence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settlement status accuracy for balances near dust thresholds.
  * Clearly distinguishes unavailable price or decimals data from values that cannot be priced.
  * Handles malformed, non-finite, and adapter error responses more reliably.
  * Improved failure messages to identify whether price or decimals information is unavailable.
* **Performance**
  * Reduced redundant lookups and improved settlement valuation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->