### PR TITLE
fix(cli): disable fabricated fallback prices in stranded classification

### DIFF
--- a/bench/adapter-prices.test.ts
+++ b/bench/adapter-prices.test.ts
@@ -323,3 +323,37 @@ describe("AdapterService wallet holdings seam (getWalletHoldings)", () => {
     expect(holdings.size).toBe(0);
   });
 });
+
+describe("AdapterService getTokenPrices fallback behavior", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function readTokenPrices(
+    mints: readonly string[],
+    useFallback: boolean,
+  ): Promise<Record<string, number>> {
+    const layer = buildAdapterLayerWithWallet();
+    const program = Effect.gen(function* () {
+      const adapter = yield* AdapterService;
+      return yield* adapter.getTokenPrices([...mints], { useFallback });
+    }).pipe(Effect.provide(layer));
+    return Effect.runPromise(program);
+  }
+
+  it("resolves unresolved mints to 0 with useFallback: false instead of fabricated fallback prices", async () => {
+    // All price sources fail (mockFetch 500s): fetchTokenPrices never fails —
+    // every source catches its own errors and returns {} — so an unresolved
+    // mint resolves to 0 with useFallback: false, and to the hardcoded
+    // fallback price with the default. The stranded-status classification
+    // passes useFallback: false precisely so a price-provider outage can
+    // never report stranded capital at a fabricated value.
+    const restore = mockFetch((async () => new Response("down", { status: 500 })) as unknown as typeof fetch);
+    try {
+      expect(await readTokenPrices([SOL_MINT], false)).toEqual({ [SOL_MINT]: 0 });
+      expect(await readTokenPrices([SOL_MINT], true)).toEqual({ [SOL_MINT]: 165 });
+    } finally {
+      restore();
+    }
+  });
+});

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -49,10 +49,16 @@ export function decimalsFailureState(err: unknown): StrandedLookupState {
  * Issue #183: pure classification of a stranded terminal settlement against
  * the sweep's dust policy. Priceable value at/above `dustUsd` is real
  * stranded capital; below the cutoff it is dust (intentionally never
- * re-queued, excluded from the report); an unavailable lookup (provider/RPC
- * outage) stays distinct from a genuinely unpriceable token (no price,
- * defect, or unresolvable amount). Exported for direct unit coverage of the
- * channel split (the CLI harness cannot inject adapter failures).
+ * re-queued, excluded from the report); an unavailable lookup stays distinct
+ * from a genuinely unpriceable token. Channel reality (adapter API): the
+ * PRICE channel can never reach "unavailable" — fetchTokenPrices never fails
+ * and unresolved mints are 0 — so a price-provider outage and a genuinely
+ * unquotable mint both classify as Unpriceable (a truthful point-in-time
+ * statement: no USD price resolved at query time; the next run re-checks).
+ * The "unavailable" state is driven by the decimals/RPC lookup, which does
+ * fail typed on outage (distinguished from the adapter's unresolvable-mint
+ * error by message). Exported for direct unit coverage of the channel split
+ * (the CLI harness cannot inject adapter failures).
  */
 export function classifyStrandedSettlement(input: {
   readonly priceState: StrandedLookupState;
@@ -73,9 +79,7 @@ export function classifyStrandedSettlement(input: {
     return { kind: "unpriceable" };
   }
   const valueUsd = (amountNum / 10 ** input.decimals) * input.priceUsd;
-  return valueUsd >= input.dustUsd
-    ? { kind: "stranded", valueUsd }
-    : { kind: "dust", valueUsd };
+  return valueUsd >= input.dustUsd ? { kind: "stranded", valueUsd } : { kind: "dust", valueUsd };
 }
 
 export interface StatusJsonOutput {
@@ -434,25 +438,28 @@ network; with no stranded settlements it is fully offline.`,
           const priceLookup = yield* adapter
             .getTokenPrices(candidateMints, { useFallback: false })
             .pipe(
-            Effect.map((prices) => {
-              const entries = candidateMints.map((mint) => {
-                const price = prices[mint] ?? 0;
-                return [
-                  mint,
-                  { state: (price > 0 ? "ok" : "unpriceable") as StrandedLookupState, value: price },
-                ] as const;
-              });
-              return new Map(entries);
-            }),
-            // Batch defect: one malformed mint must not label every candidate
-            // Unpriceable — fall back to per-mint fetches, deduplicated (one
-            // fetch per unique mint, not per settlement).
-            Effect.catchCause(() =>
-              Effect.all(candidateMints.map(resolvePriceForMint), { concurrency: 4 }).pipe(
-                Effect.map((results) => new Map(results.map((r) => [r.mint, r]))),
+              Effect.map((prices) => {
+                const entries = candidateMints.map((mint) => {
+                  const price = prices[mint] ?? 0;
+                  return [
+                    mint,
+                    {
+                      state: (price > 0 ? "ok" : "unpriceable") as StrandedLookupState,
+                      value: price,
+                    },
+                  ] as const;
+                });
+                return new Map(entries);
+              }),
+              // Batch defect: one malformed mint must not label every candidate
+              // Unpriceable — fall back to per-mint fetches, deduplicated (one
+              // fetch per unique mint, not per settlement).
+              Effect.catchCause(() =>
+                Effect.all(candidateMints.map(resolvePriceForMint), { concurrency: 4 }).pipe(
+                  Effect.map((results) => new Map(results.map((r) => [r.mint, r]))),
+                ),
               ),
-            ),
-          );
+            );
           // Decimals channel: getTokenDecimals DOES fail typed, and the error
           // message distinguishes an RPC outage (→ Unavailable) from the
           // adapter's "Cannot resolve decimals for mint X" unresolvable case
@@ -576,7 +583,7 @@ network; with no stranded settlements it is fully offline.`,
                 : []),
               ...(unpriceableStranded.length > 0
                 ? [
-                    `  Unpriceable: ${unpriceableStranded.length} terminal settlement(s) with no USD price — cannot value, left in wallet (${unpriceableStranded
+                    `  Unpriceable: ${unpriceableStranded.length} terminal settlement(s) with no USD price resolved at query time — cannot value, left in wallet (${unpriceableStranded
                       .map(
                         (entry) =>
                           `${(entry.settlement.poolAddress || "?").slice(0, 8)}/${entry.settlement.tokenMint.slice(0, 8)}`,

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -412,8 +412,13 @@ network; with no stranded settlements it is fully offline.`,
           // label is factual: no USD price resolved at query time). Only a
           // DEFECT (sync throw from a malformed mint) is caught here, with a
           // per-mint fallback so one bad mint cannot label every candidate.
+          // useFallback: false — the default serves the hardcoded fallback
+          // prices (SOL at $165, USDC/USDT/... at $1) as if measured during
+          // a total outage, which would report stranded capital at
+          // FABRICATED values (the wallet-reconciliation path avoids them
+          // for the same reason).
           const resolvePriceForMint = (mint: string) =>
-            adapter.getTokenPrices([mint]).pipe(
+            adapter.getTokenPrices([mint], { useFallback: false }).pipe(
               Effect.map((p) => {
                 const price = p[mint] ?? 0;
                 return {
@@ -426,7 +431,9 @@ network; with no stranded settlements it is fully offline.`,
                 Effect.succeed({ mint, state: "unpriceable" as const, value: 0 }),
               ),
             );
-          const priceLookup = yield* adapter.getTokenPrices(candidateMints).pipe(
+          const priceLookup = yield* adapter
+            .getTokenPrices(candidateMints, { useFallback: false })
+            .pipe(
             Effect.map((prices) => {
               const entries = candidateMints.map((mint) => {
                 const price = prices[mint] ?? 0;


### PR DESCRIPTION
Follow-up on the kilo comment left on #192 (merged before the comment landed).

**Problem**: `getTokenPrices` defaults to `useFallback: true`, so during a total price-provider outage the hardcoded fallback prices (SOL at $165, USDC/USDT/USDS/JitoSOL/JUP at $1.0) are served as if measured. A stranded SOL settlement during an outage was reported as real stranded capital at a fabricated $165/SOL — the same fabricated-price mislabel the wallet-reconciliation path explicitly avoids by passing `{ useFallback: false }`.

**Fix**: both price calls in the stranded classification (the batched lookup and the per-mint defect fallback) now pass `{ useFallback: false }` — an outage resolves to price 0 and classifies truthfully as Unpriceable (no USD price resolved at query time).

Verification: lint clean, full suite 121 files / 1579 tests.

## Summary by Sourcery

Bug Fixes:
- Disable fallback token prices in stranded settlement classification so outages no longer report stranded capital at hardcoded USD values.