### PR TITLE
test(autonomous): pin the issue #191 settlement_overdue latch scenario

### DIFF
--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -1132,6 +1132,125 @@ describe("issue #166 settlement recovery", () => {
     expect(processed?.outputUsd).toBe(0.001);
   });
 
+  it("does not revive an unpriceable terminal settlement (issue #191)", async () => {
+    // Given a wallet holding an unpriceable token with a signature-less
+    // TERMINAL job — the pre-#191 shape: the sweep used to revive it (the
+    // dust gate required a known price), the Jupiter 400/429 retry loop
+    // restarted, and the retryable job latched settlement_overdue forever
+    // (oldestActiveSettlementAgeMs counts non-terminal jobs; #168's
+    // auto-resolve only fires once everything is confirmed/terminal).
+    const holdings = new Map<string, { amountAtomic: bigint; decimals: number }>([
+      ["unpriceable-1", { amountAtomic: 1_000_000n, decimals: 6 }],
+    ]);
+    const terminalJob = settlementJob({
+      id: "terminal-1",
+      positionId: "orphan:old",
+      tokenMint: "unpriceable-1",
+      amountAtomic: "1000000",
+      status: "terminal",
+      attempts: 27,
+      nextRetryAt: null,
+      txSignature: null,
+      confirmedOutputAtomic: null,
+      expiresAt: 1_000,
+      error: "Jupiter quote failed: 400",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const adapter = {
+      hasWallet: () => true,
+      getWalletHoldings: () => Effect.succeed(holdings),
+      getPoolState: () => Effect.succeed(null),
+      getTokenPrices: () => Effect.succeed({ "unpriceable-1": 0 }),
+    } as unknown as AdapterApi;
+    const db = {
+      listSettlementJobs: () => Effect.succeed([terminalJob]),
+      getAllPositions: () => Effect.succeed([]),
+    } as unknown as DbApi;
+
+    // When
+    const jobs = await Effect.runPromise(
+      sweepOrphanSettlements({
+        adapter,
+        db,
+        walletAddress: "wallet-1",
+        agentInstanceId: "primary",
+        settlementMaxPendingMs: 3_600_000,
+        settlementDustUsd: 0.1,
+        now: 10_000,
+      }),
+    );
+
+    // Then the terminal row is NOT revived and no fresh sell job is created —
+    // the unpriceable holding is dust (value unknown ⇒ $0), so no retry loop
+    // can restart and nothing can latch settlement_overdue.
+    expect(jobs).toHaveLength(0);
+  });
+
+  it("unpriceable retryable jobs dust-confirm and cannot latch settlement_overdue (issue #191)", async () => {
+    // Given a retryable job for an unpriceable mint (the post-revival shape)
+    // that has been failing for 27h: without the dust path it would retry
+    // forever and — being non-terminal — keep settlement_overdue latched.
+    const job = settlementJob({
+      positionId: "rollback:entry-1",
+      tokenMint: "no-price-1",
+      status: "retryable",
+      attempts: 27,
+      nextRetryAt: 9_000,
+      expiresAt: 5_000,
+      createdAt: 1,
+      error: "Jupiter quote failed: 429",
+    });
+    const adapter = {
+      getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "no-price-1": 0 }),
+      getTokenDecimals: () => Effect.succeed(6),
+      quoteSwap: () => Effect.fail(new Error("unused — quote must never run")),
+      prepareSwap: () => Effect.fail(new Error("unused")),
+      simulateSwap: () => Effect.fail(new Error("unused")),
+      submitSwap: () => Effect.fail(new Error("unused")),
+    } as unknown as AdapterApi;
+    const db = {
+      saveSettlementJob: () => Effect.void,
+      getPosition: () => Effect.succeed(null),
+    } as unknown as DbApi;
+
+    // When
+    const [processed] = await Effect.runPromise(
+      processSettlementJobs({
+        adapter,
+        db,
+        jobs: [job],
+        mode: "live",
+        now: 10_000,
+        maxSwapSlippageBps: 50,
+        settlementDustUsd: 0.1,
+      }),
+    );
+
+    // Then the job is dust-confirmed — no more retries...
+    expect(processed).toMatchObject({
+      status: "confirmed",
+      nextRetryAt: null,
+      error: "settlement dust skipped (no USD price)",
+    });
+    // ...and, mirroring issue #167, a confirmed job contributes nothing to the
+    // overdue age, so settlement_overdue can neither arm nor stay latched on
+    // it (and #168's all-confirmed/terminal auto-resolve can fire).
+    const settledJobs = processed ? [processed] : [];
+    expect(oldestActiveSettlementAgeMs(settledJobs, 100_000)).toBe(0);
+    expect(
+      shouldTriggerSafetyPause({
+        dailyDrawdownPct: 0,
+        maxDailyDrawdownPct: 5,
+        consecutiveCoreDataFailures: 0,
+        consecutiveExecutionFailures: 0,
+        maxConsecutiveExecutionFailures: 3,
+        oldestSettlementAgeMs: oldestActiveSettlementAgeMs(settledJobs, 100_000),
+        settlementMaxPendingMs: 3_600_000,
+      }),
+    ).toBeNull();
+  });
+
   it("creates sell jobs only for unbacked, non-dust wallet holdings", async () => {
     // Given holdings where one mint is backed, one is below dust, one is
     // unpriceable (issue #183: treated as dust — value unknown ⇒ $0), and

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -1191,20 +1191,26 @@ describe("issue #166 settlement recovery", () => {
     // Given a retryable job for an unpriceable mint (the post-revival shape)
     // that has been failing for 27h: without the dust path it would retry
     // forever and — being non-terminal — keep settlement_overdue latched.
+    // The quote mock fails with a TRANSIENT 429 and expiresAt is far in the
+    // future on purpose: if the dust path regresses, the job stays retryable
+    // (per issue #175 a rate-limited settlement never terminalizes, even past
+    // expiry) and is older than settlementMaxPendingMs — so the latch
+    // assertions below would FAIL on the regression instead of passing
+    // vacuously via a terminalized job.
     const job = settlementJob({
       positionId: "rollback:entry-1",
       tokenMint: "no-price-1",
       status: "retryable",
       attempts: 27,
       nextRetryAt: 9_000,
-      expiresAt: 5_000,
+      expiresAt: 20_000_000,
       createdAt: 1,
       error: "Jupiter quote failed: 429",
     });
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "no-price-1": 0 }),
       getTokenDecimals: () => Effect.succeed(6),
-      quoteSwap: () => Effect.fail(new Error("unused — quote must never run")),
+      quoteSwap: () => Effect.fail(new Error("Jupiter quote failed: 429")),
       prepareSwap: () => Effect.fail(new Error("unused")),
       simulateSwap: () => Effect.fail(new Error("unused")),
       submitSwap: () => Effect.fail(new Error("unused")),
@@ -1235,9 +1241,13 @@ describe("issue #166 settlement recovery", () => {
     });
     // ...and, mirroring issue #167, a confirmed job contributes nothing to the
     // overdue age, so settlement_overdue can neither arm nor stay latched on
-    // it (and #168's all-confirmed/terminal auto-resolve can fire).
+    // it (and #168's all-confirmed/terminal auto-resolve can fire). The age is
+    // measured at 10_000_000 — past settlementMaxPendingMs — so a hypothetical
+    // still-retryable job (age ~9,999,999 ms) WOULD trip the pause while the
+    // dust-confirmed job still yields 0 (the assertion is discriminating).
     const settledJobs = processed ? [processed] : [];
-    expect(oldestActiveSettlementAgeMs(settledJobs, 100_000)).toBe(0);
+    const latchNow = 10_000_000;
+    expect(oldestActiveSettlementAgeMs(settledJobs, latchNow)).toBe(0);
     expect(
       shouldTriggerSafetyPause({
         dailyDrawdownPct: 0,
@@ -1245,7 +1255,7 @@ describe("issue #166 settlement recovery", () => {
         consecutiveCoreDataFailures: 0,
         consecutiveExecutionFailures: 0,
         maxConsecutiveExecutionFailures: 3,
-        oldestSettlementAgeMs: oldestActiveSettlementAgeMs(settledJobs, 100_000),
+        oldestSettlementAgeMs: oldestActiveSettlementAgeMs(settledJobs, latchNow),
         settlementMaxPendingMs: 3_600_000,
       }),
     ).toBeNull();


### PR DESCRIPTION
Fixes #191

## Context

Issue #191 (filed 2026-08-08T05:17Z, before the #183 dust-gate work merged): the orphan sweep re-queued terminal settlements for tokens with no resolvable USD price (the dust gate required `priceUsd > 0`), those jobs failed with Jupiter 400/429 forever, and as `retryable` they counted toward `oldestSettlementAgeMs` — latching `settlement_overdue` every cycle so `prism resume` never stuck. Evidence: `547d4a7f` (rollback, 27h of 429s) and `bf66bed9` (orphan, no price) latching the pause over ~$0.14 of dust.

## What already fixes it (merged #188)

- **Sweep** (`sweepOrphanSettlements`): an unpriceable holding (`priceUsd <= 0`) is dust — value unknown ⇒ $0 — so the terminal row is never revived and no fresh sell job is created; the token re-qualifies if a price ever resolves.
- **Processor** (`processSettlementJobs`): existing retryable/pending jobs for unpriceable mints with SYNTHETIC groups (`orphan:`/`rollback:`) are dust-confirmed with "settlement dust skipped (no USD price)" — no more quote attempts.
- Combined with #167/#168: confirmed/terminal jobs are excluded from `oldestActiveSettlementAgeMs`, so nothing can latch `settlement_overdue`, and the all-confirmed/terminal auto-resolve fires.

## This PR

Regression tests pinning the exact #191 scenario so it cannot return:

1. `does not revive an unpriceable terminal settlement (issue #191)` — sweep with an unpriceable holding + signature-less terminal job returns zero jobs.
2. `unpriceable retryable jobs dust-confirm and cannot latch settlement_overdue (issue #191)` — the 27h-retryable rollback job dust-confirms, contributes 0 to `oldestActiveSettlementAgeMs`, and `shouldTriggerSafetyPause` returns null.

## Verification

- `bun run lint` clean; `bun run test` 121 files / 1582 tests pass.

## Summary by Sourcery

Add regression coverage for the settlement dust-handling logic to prevent reintroduction of the issue #191 latch scenario.

Tests:
- Add tests verifying unpriceable terminal settlements are not revived into new sell jobs.
- Add tests verifying unpriceable retryable settlements are dust-confirmed, excluded from overdue age, and cannot latch safety pauses.