### PR TITLE
chore(release): bump version to 0.1.11, backfill changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,24 @@
 
 All notable changes to Prism are documented here.
 
-## [Unreleased]
+## [0.1.11] — 2026-08-08
+
+### Added
+
+- **Effect type-aware linting** via `@effect/tsgo`: the Effect LSP-derived rules now run in oxlint's type-aware mode (prepare-script patched, `effecttsgo` plugin, exact-pinned toolchain) (#185)
+- **Zero-warning sweep**: 1579 findings eliminated across 80 files — every Effect error channel typed (1464), stringification and floating-promise classes fixed (114) — and the five rules enforced as errors, so the type-aware lint gates every future change (#190)
 
 ### Fixed
 
-- The `execution_failures` safety pause is no longer a permanent one-way latch: each cycle auto-resolves when the failure counter is below `MAX_CONSECUTIVE_EXECUTION_FAILURES` (a fresh process starts at 0, so a restart alone clears a stale latch), and the counter decays to 0 after every quiet cycle (no execution failures) so a transient spike clears itself mid-run; the pause re-arms only when a cycle genuinely breaches again, and `prism resume` stays an operator override (#182)
-- Unpriceable wallet tokens are dust for the orphan sweep: a token with no resolvable USD price is value-unknown ⇒ $0, so the sweep skips it and the settlement processor dust-confirms existing jobs with a distinct "settlement dust skipped (no USD price)" error instead of quoting them — the Jupiter 400 no-route retry loop is gone, and tokens re-qualify automatically once a price resolves. `prism status` reconciles the Stranded line with the dust policy: sub-dust terminal settlements are excluded (they are intentionally never re-queued), priceable stranded capital shows its USD value, and unpriceable terminals get a separate Unpriceable line (#183)
-- `prism update` now detects a running agent after a successful update (dev lockfile or process scan, including the bundled `dist/cli/index.mjs dev` systemd pattern) and prints a prominent restart-required notice with the exact restart command, exiting non-zero (code 2, distinct from update-failure's 1) so scripts can tell "updated, restart needed" apart from "update failed" — the running agent keeps executing the old build until restarted (#184)
+- The `execution_failures` safety pause is no longer a permanent one-way latch: each cycle auto-resolves when the failure counter is below `MAX_CONSECUTIVE_EXECUTION_FAILURES` (a fresh process starts at 0, so a restart alone clears a stale latch), and the counter decays to 0 after every quiet cycle so a transient spike clears itself mid-run; the pause re-arms only when a cycle genuinely breaches again, and `prism resume` stays an operator override (#187)
+- Unpriceable wallet tokens are dust for the orphan sweep: a token with no resolvable USD price is value-unknown ⇒ $0, so the sweep skips it and the settlement processor dust-confirms existing jobs with a distinct "settlement dust skipped (no USD price)" error instead of quoting them — the Jupiter 400 no-route retry loop is gone, and tokens re-qualify automatically once a price resolves. `prism status` reconciles the Stranded line with the dust policy: sub-dust terminal settlements are excluded (intentionally never re-queued), priceable stranded capital shows its USD value, and unpriceable terminals get a separate Unpriceable line (#188)
+- `prism update` detects a running agent after a successful update (dev lockfile or process scan, including the bundled `dist/cli/index.mjs dev` systemd pattern) and prints a prominent restart-required notice with the exact restart command, exiting non-zero (code 2, distinct from update-failure's 1) so scripts can tell "updated, restart needed" apart from "update failed" — the running agent keeps executing the old build until restarted (#189)
+- Stranded settlement classification: deduplicated lookups and outage-specific wording for unreachable price feeds (#192), and no fabricated fallback prices in the stranded classification (#193)
+- Pinned the issue #191 settlement_overdue latch scenario with a regression test (#194)
+
+### Changed
+
+- Bumped version to 0.1.11.
 
 ## [0.1.10] — 2026-08-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-liquidity-agent",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Autonomous liquidity agent for Solana pools (currently Meteora DLMM)",
   "keywords": [
     "ai-agent",


### PR DESCRIPTION
Release 0.1.11: Effect type-aware lint enforcement (#185/#190), execution_failures pause auto-resolve (#187), dust-gated unpriceable tokens (#188), update restart notice (#189), stranded classification fixes (#192/#193/#194). After merge: tag v0.1.11.

## Summary by Sourcery

Prepare release 0.1.11 with updated changelog and version metadata.

New Features:
- Document effect type-aware linting and zero-warning sweep as part of the 0.1.11 release.

Bug Fixes:
- Document execution failure auto-resolve behavior, dust handling for unpriceable tokens, improved stranded settlement classification, and the settlement_overdue latch regression test for the 0.1.11 release.

Enhancements:
- Document improved update restart notices and behavior in the 0.1.11 changelog.

Build:
- Bump the package version from 0.1.10 to 0.1.11.