### PR TITLE
fix(autonomous): progressing settlements no longer latch settlement_overdue; 30-min backoff cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Prism are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- The `settlement_overdue` safety pause no longer latches on jobs that are progressing per policy: a settlement with a FUTURE `nextRetryAt` (e.g. a rate-limited 429 backing off) is excluded from the overdue-age computation, and the pause auto-resolves as soon as no genuinely stuck job remains (a job with NO scheduled retry, like the operator-reconciliation state, still latches). A sustained Jupiter rate limit can no longer halt the whole agent while the scheduled retry waits. `prism status` gains an `Overdue:` line listing settlements past the max-pending window that are not final, so prolonged rate-limit stalls stay operator-visible without halting trading (#196)
+- Settlement retry backoff caps at 30 minutes instead of 5: a sustained rate-limit ban outlasted the old cap, so capped retries re-429ed forever and added quote pressure to the ban; the exponential ramp still retries normal blips quickly (#196)
+
+
 ## [0.1.11] — 2026-08-08
 
 ### Added

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -6,6 +6,7 @@ import {
   loadDailyEquityBaseline,
   nextSettlementRetryAt,
   oldestActiveSettlementAgeMs,
+  settlementOverduePauseAction,
   persistDailyEquityBaseline,
   processSettlementJobs,
   safetyPauseBlockReason,
@@ -396,6 +397,77 @@ describe("autonomous token runtime policy", () => {
     // added quote pressure.
     expect(nextSettlementRetryAt(1_000, 20)).toBe(1_801_000);
     expect(nextSettlementRetryAt(1_000, 40)).toBe(1_801_000);
+  });
+
+  it("arm/resolves settlement_overdue per the cycle decision table (issue #166/#196)", () => {
+    const maxPending = 3_600_000;
+    // ARM: a genuinely stuck job (no scheduled retry) older than the window,
+    // with no active pause.
+    expect(
+      settlementOverduePauseAction({
+        oldestStuckAgeMs: maxPending + 1,
+        settlementMaxPendingMs: maxPending,
+        activePauseReason: null,
+        activePauseResolved: true,
+      }),
+    ).toEqual({ kind: "arm" });
+    // ARM: a resolved prior pause is re-armable on a fresh breach.
+    expect(
+      settlementOverduePauseAction({
+        oldestStuckAgeMs: maxPending + 1,
+        settlementMaxPendingMs: maxPending,
+        activePauseReason: "settlement_overdue",
+        activePauseResolved: true,
+      }),
+    ).toEqual({ kind: "arm" });
+    // No arm while the pause is ALREADY active (latched — stays latched).
+    expect(
+      settlementOverduePauseAction({
+        oldestStuckAgeMs: maxPending + 1,
+        settlementMaxPendingMs: maxPending,
+        activePauseReason: "settlement_overdue",
+        activePauseResolved: false,
+      }),
+    ).toEqual({ kind: "none" });
+
+    // RESOLVE mid-run: the active settlement_overdue pause's trigger is gone
+    // (e.g. the 429 job moved to a future nextRetryAt) — the #196 regression
+    // this pins: a rate-limited job must not halt trading while it waits.
+    expect(
+      settlementOverduePauseAction({
+        oldestStuckAgeMs: 0,
+        settlementMaxPendingMs: maxPending,
+        activePauseReason: "settlement_overdue",
+        activePauseResolved: false,
+      }),
+    ).toEqual({ kind: "resolve" });
+    // No resolve for other pause reasons (their own paths handle them).
+    expect(
+      settlementOverduePauseAction({
+        oldestStuckAgeMs: 0,
+        settlementMaxPendingMs: maxPending,
+        activePauseReason: "execution_failures",
+        activePauseResolved: false,
+      }),
+    ).toEqual({ kind: "none" });
+    // STAYS LATCHED while a stuck job remains (null/past nextRetryAt).
+    expect(
+      settlementOverduePauseAction({
+        oldestStuckAgeMs: maxPending + 1,
+        settlementMaxPendingMs: maxPending,
+        activePauseReason: "settlement_overdue",
+        activePauseResolved: false,
+      }),
+    ).toEqual({ kind: "none" });
+    // NONE with no pause and nothing stuck.
+    expect(
+      settlementOverduePauseAction({
+        oldestStuckAgeMs: 0,
+        settlementMaxPendingMs: maxPending,
+        activePauseReason: null,
+        activePauseResolved: true,
+      }),
+    ).toEqual({ kind: "none" });
   });
 
   it("excludes retryable jobs with a future nextRetryAt from the overdue age (issue #196)", () => {

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -391,7 +391,40 @@ describe("autonomous token runtime policy", () => {
   it("caps deterministic settlement retry backoff", () => {
     // Given / When / Then
     expect(nextSettlementRetryAt(1_000, 1)).toBe(2_000);
-    expect(nextSettlementRetryAt(1_000, 20)).toBe(301_000);
+    // Issue #196: the cap is 30 minutes — a sustained Jupiter rate-limit ban
+    // outlasted the old 5-minute cap, so short retries re-429ed forever and
+    // added quote pressure.
+    expect(nextSettlementRetryAt(1_000, 20)).toBe(1_801_000);
+    expect(nextSettlementRetryAt(1_000, 40)).toBe(1_801_000);
+  });
+
+  it("excludes retryable jobs with a future nextRetryAt from the overdue age (issue #196)", () => {
+    // Given a rate-limited job backing off per policy: it HAS a scheduled
+    // retry, so it is progressing — not overdue. Only jobs with NO scheduled
+    // retry (null or past nextRetryAt) count as genuinely stuck.
+    const backingOff = settlementJob({
+      id: "settlement-429",
+      status: "retryable",
+      createdAt: 1,
+      nextRetryAt: 200_000, // future
+    });
+    const pendingScheduled = settlementJob({
+      id: "settlement-pending",
+      status: "pending",
+      createdAt: 1,
+      nextRetryAt: 150_000, // future
+    });
+    expect(oldestActiveSettlementAgeMs([backingOff, pendingScheduled], 100_000)).toBe(0);
+
+    // A retryable job whose scheduled retry has PASSED (or is absent) is
+    // genuinely stuck — it counts.
+    const pastRetry = settlementJob({
+      id: "settlement-stuck",
+      status: "retryable",
+      createdAt: 1,
+      nextRetryAt: 50_000, // past
+    });
+    expect(oldestActiveSettlementAgeMs([backingOff, pastRetry], 100_000)).toBe(99_999);
   });
 
   it("subtracts settlement and execution costs from realized PnL", () => {

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -524,6 +524,21 @@ network; with no stranded settlements it is fully offline.`,
             (entry) => entry.kind === "unavailable",
           );
 
+          // Issue #196: settlements progressing per policy (retryable with a
+          // future nextRetryAt) no longer latch settlement_overdue — but a
+          // job retrying past the max-pending window still deserves operator
+          // visibility, so surface it on its own line (monitor, not halt).
+          const staleRetryingSettlements = autonomous.settlements
+            .filter(
+              (settlement) =>
+                settlement.status !== "confirmed" &&
+                settlement.status !== "terminal" &&
+                settlement.nextRetryAt !== null &&
+                settlement.nextRetryAt > Date.now() &&
+                Date.now() - settlement.createdAt > config.settlementMaxPendingMs,
+            )
+            .sort((a, b) => b.createdAt - a.createdAt);
+
           // Acceptance for issue #167: an active settlement_overdue pause
           // names the non-terminal jobs keeping it latched (oldest first).
           const latchedBySettlements = (() => {
@@ -571,6 +586,19 @@ network; with no stranded settlements it is fully offline.`,
               `  Candidates:  ${autonomous.candidates.length}`,
               `  Operations:  ${autonomous.operations.length}`,
               `  Settlements: ${autonomous.settlements.length}`,
+              ...(staleRetryingSettlements.length > 0
+                ? [
+                    `  Overdue:     ${staleRetryingSettlements.length} settlement(s) retrying past the max-pending window (${staleRetryingSettlements
+                      .slice(0, 3)
+                      .map(
+                        (settlement) =>
+                          `${settlement.id.slice(0, 8)} ${((Date.now() - settlement.createdAt) / 3_600_000).toFixed(1)}h`,
+                      )
+                      .join(
+                        ", ",
+                      )}) — progressing per policy, not latching the pause; monitor for recovery`,
+                  ]
+                : []),
               ...(strandedSettlements.length > 0
                 ? [
                     `  Stranded:    ${strandedSettlements.length} terminal settlement(s) with unspent balance (${strandedSettlements

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -525,19 +525,22 @@ network; with no stranded settlements it is fully offline.`,
           );
 
           // Issue #196: settlements progressing per policy (retryable with a
-          // future nextRetryAt) no longer latch settlement_overdue — but a
-          // job retrying past the max-pending window still deserves operator
-          // visibility, so surface it on its own line (monitor, not halt).
+          // scheduled nextRetryAt) no longer latch settlement_overdue — but a
+          // job past the max-pending window that is not final still deserves
+          // operator visibility, so surface it on its own line (monitor, not
+          // halt). No nextRetryAt freshness requirement: with the deliberately
+          // fast early backoff, a retry stamped at cycle start can already be
+          // in the past when status samples mid-cycle — the line must show
+          // the storm, not hide it. Oldest first so the longest-running
+          // stalls are the ones identified.
           const staleRetryingSettlements = autonomous.settlements
             .filter(
               (settlement) =>
                 settlement.status !== "confirmed" &&
                 settlement.status !== "terminal" &&
-                settlement.nextRetryAt !== null &&
-                settlement.nextRetryAt > Date.now() &&
                 Date.now() - settlement.createdAt > config.settlementMaxPendingMs,
             )
-            .sort((a, b) => b.createdAt - a.createdAt);
+            .sort((a, b) => a.createdAt - b.createdAt);
 
           // Acceptance for issue #167: an active settlement_overdue pause
           // names the non-terminal jobs keeping it latched (oldest first).
@@ -588,15 +591,13 @@ network; with no stranded settlements it is fully offline.`,
               `  Settlements: ${autonomous.settlements.length}`,
               ...(staleRetryingSettlements.length > 0
                 ? [
-                    `  Overdue:     ${staleRetryingSettlements.length} settlement(s) retrying past the max-pending window (${staleRetryingSettlements
+                    `  Overdue:     ${staleRetryingSettlements.length} settlement(s) past the max-pending window and not final (${staleRetryingSettlements
                       .slice(0, 3)
                       .map(
                         (settlement) =>
                           `${settlement.id.slice(0, 8)} ${((Date.now() - settlement.createdAt) / 3_600_000).toFixed(1)}h`,
                       )
-                      .join(
-                        ", ",
-                      )}) — progressing per policy, not latching the pause; monitor for recovery`,
+                      .join(", ")}) — monitor for recovery`,
                   ]
                 : []),
               ...(strandedSettlements.length > 0

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -212,6 +212,49 @@ export function oldestActiveSettlementAgeMs(
     .reduce((oldest, job) => Math.max(oldest, now - job.createdAt), 0);
 }
 
+export type SettlementOverduePauseAction =
+  | { readonly kind: "arm" }
+  | { readonly kind: "resolve" }
+  | { readonly kind: "none" };
+
+export interface SettlementOverduePauseInput {
+  /** Oldest STUCK settlement age (oldestActiveSettlementAgeMs). */
+  readonly oldestStuckAgeMs: number;
+  readonly settlementMaxPendingMs: number;
+  /** Reason of the current pause row (SafetyPauseRecord.reason), or null when no pause exists. */
+  readonly activePauseReason: string | null;
+  /** True when no pause row exists or the existing one is resolved. */
+  readonly activePauseResolved: boolean;
+}
+
+/**
+ * Issue #166/#196: the cycle-level arm/resolve decision for the
+ * `settlement_overdue` safety pause, extracted pure for unit coverage.
+ *
+ * - ARM when a genuinely stuck job (no scheduled retry) is older than the
+ *   max-pending window and no ACTIVE pause exists.
+ * - RESOLVE when the active `settlement_overdue` pause's trigger condition is
+ *   gone (no stuck job remains) — mid-run recovery, not just restart.
+ * - NONE otherwise; in particular a still-latched settlement_overdue pause
+ *   with a stuck job stays latched, and other pause reasons are handled by
+ *   their own paths.
+ */
+export function settlementOverduePauseAction(
+  input: SettlementOverduePauseInput,
+): SettlementOverduePauseAction {
+  if (input.oldestStuckAgeMs > input.settlementMaxPendingMs && input.activePauseResolved) {
+    return { kind: "arm" };
+  }
+  if (
+    input.activePauseReason === "settlement_overdue" &&
+    !input.activePauseResolved &&
+    input.oldestStuckAgeMs <= input.settlementMaxPendingMs
+  ) {
+    return { kind: "resolve" };
+  }
+  return { kind: "none" };
+}
+
 export interface SettlementProcessorInput {
   readonly adapter: AdapterApi;
   readonly db: DbApi;

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -179,21 +179,36 @@ export function shouldAutoResolveDailyDrawdownPause(input: DailyDrawdownAutoReso
 /** Computes the bounded retry timestamp for a settlement attempt. */
 export function nextSettlementRetryAt(now: number, attempts: number): number {
   const exponent = Math.max(0, Math.min(attempts - 1, 30));
-  return now + Math.min(2 ** exponent * 1_000, 300_000);
+  // Cap at 30 minutes (issue #196): a sustained Jupiter rate-limit ban can
+  // outlast the old 5-minute cap, so capped retries re-429ed forever AND
+  // added quote pressure to the ban. The exponential ramp still retries
+  // normal blips quickly (1s, 2s, 4s, ...); only long-running failures space
+  // out to the cap.
+  return now + Math.min(2 ** exponent * 1_000, 1_800_000);
 }
 
 /**
- * Age in ms of the oldest ACTIVE settlement job. `confirmed` and `terminal`
+ * Age in ms of the oldest STUCK settlement job. `confirmed` and `terminal`
  * are final states: a dead-end terminal job (e.g. a failed rollback) must not
  * keep the `settlement_overdue` safety pause latched forever after
- * `prism resume` (issue #167). Returns 0 when no active jobs remain.
+ * `prism resume` (issue #167). A job with a FUTURE `nextRetryAt` is also
+ * excluded (issue #196): it is progressing per policy — the engine has
+ * scheduled its retry (e.g. a rate-limited 429 backing off) — so it is not
+ * "overdue" and must not halt trading while the retry waits. Only jobs with
+ * NO scheduled retry (null or past `nextRetryAt`) are genuinely stuck.
+ * Returns 0 when no stuck jobs remain.
  */
 export function oldestActiveSettlementAgeMs(
   jobs: ReadonlyArray<SettlementJobRecord>,
   now: number,
 ): number {
   return jobs
-    .filter((job) => job.status !== "confirmed" && job.status !== "terminal")
+    .filter(
+      (job) =>
+        job.status !== "confirmed" &&
+        job.status !== "terminal" &&
+        (job.nextRetryAt === null || job.nextRetryAt <= now),
+    )
     .reduce((oldest, job) => Math.max(oldest, now - job.createdAt), 0);
 }
 
@@ -690,24 +705,22 @@ export function sweepOrphanSettlements(
         backedMints.add(state.tokenY);
       }
     }
-    const prices = yield* input.adapter
-      .getTokenPrices(candidates.map(([mint]) => mint))
-      .pipe(
-        // Issue #183: a price-fetch failure must not be silent — every
-        // holding would read price 0 and be skipped as dust for the cycle
-        // (a quiet multi-cycle sweep stall is otherwise unobservable; the
-        // processor path treats the same failure as retryable).
-        Effect.catch((err) => {
-          logger.warn(
-            "Orphan sweep price fetch failed — unpriceable holdings treated as dust this cycle",
-            {
-              candidateCount: candidates.length,
-              error: err instanceof Error ? err.message : String(err),
-            },
-          );
-          return Effect.succeed<Record<string, number>>({});
-        }),
-      );
+    const prices = yield* input.adapter.getTokenPrices(candidates.map(([mint]) => mint)).pipe(
+      // Issue #183: a price-fetch failure must not be silent — every
+      // holding would read price 0 and be skipped as dust for the cycle
+      // (a quiet multi-cycle sweep stall is otherwise unobservable; the
+      // processor path treats the same failure as retryable).
+      Effect.catch((err) => {
+        logger.warn(
+          "Orphan sweep price fetch failed — unpriceable holdings treated as dust this cycle",
+          {
+            candidateCount: candidates.length,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+        return Effect.succeed<Record<string, number>>({});
+      }),
+    );
     // A terminal job for the mint is revived in place (upsert on id) rather
     // than replaced by a fresh row: attempts carry over so backoff escalates
     // across generations, and the settlements table stays one row per mint

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -155,6 +155,7 @@ import {
   persistDailyEquityBaseline,
   processSettlementJobs,
   safetyPauseBlockReason,
+  settlementOverduePauseAction,
   shouldAutoResolveDailyDrawdownPause,
   shouldAutoResolveExecutionFailuresPause,
   decayExecutionFailureCounter,
@@ -4012,11 +4013,19 @@ export const program = Effect.gen(function* () {
           maxSwapSlippageBps: config.maxSwapSlippageBps,
           settlementDustUsd: autonomousExecution.settlementDustUsd,
         });
-        oldestSettlementAgeMs = oldestActiveSettlementAgeMs(processedJobs, Date.now());
-        if (
-          oldestSettlementAgeMs > config.settlementMaxPendingMs &&
-          activeSafetyPause?.resolvedAt !== null
-        ) {
+        // Issue #196 (clock skew): evaluate the overdue age against the SAME
+        // clock the retry scheduling used (settlementNow, captured before the
+        // sweep/processing pass) — a retry stamped this cycle (1s/2s/4s
+        // backoff for early attempts) must never read as already-past against
+        // a fresher Date.now() and classify a freshly backed-off job as stuck.
+        oldestSettlementAgeMs = oldestActiveSettlementAgeMs(processedJobs, settlementNow);
+        const pauseAction = settlementOverduePauseAction({
+          oldestStuckAgeMs: oldestSettlementAgeMs,
+          settlementMaxPendingMs: config.settlementMaxPendingMs,
+          activePauseReason: activeSafetyPause?.reason ?? null,
+          activePauseResolved: activeSafetyPause === null || activeSafetyPause.resolvedAt !== null,
+        });
+        if (pauseAction.kind === "arm") {
           activeSafetyPause = {
             walletAddress: autonomousExecution.walletAddress,
             agentInstanceId: autonomousExecution.agentInstanceId,
@@ -4025,11 +4034,7 @@ export const program = Effect.gen(function* () {
             resolvedAt: null,
           };
           yield* db.saveSafetyPause(activeSafetyPause).pipe(Effect.catch(() => Effect.void));
-        } else if (
-          activeSafetyPause?.resolvedAt === null &&
-          activeSafetyPause.reason === "settlement_overdue" &&
-          oldestSettlementAgeMs <= config.settlementMaxPendingMs
-        ) {
+        } else if (pauseAction.kind === "resolve" && activeSafetyPause !== null) {
           // Issue #166/#196: a settlement_overdue pause must not outlive the
           // settlements that raised it. #166: once nothing is in flight (429
           // retries finally sold the token, or the orphan sweep recovered

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -4028,12 +4028,18 @@ export const program = Effect.gen(function* () {
         } else if (
           activeSafetyPause?.resolvedAt === null &&
           activeSafetyPause.reason === "settlement_overdue" &&
-          processedJobs.every((job) => job.status === "confirmed" || job.status === "terminal")
+          oldestSettlementAgeMs <= config.settlementMaxPendingMs
         ) {
-          // Issue #166: a settlement_overdue pause must not outlive the
-          // settlements that raised it — once nothing is in flight (429
+          // Issue #166/#196: a settlement_overdue pause must not outlive the
+          // settlements that raised it. #166: once nothing is in flight (429
           // retries finally sold the token, or the orphan sweep recovered
           // it), auto-resolve instead of latching until `prism resume`.
+          // #196: a job still PROGRESSING per policy — retryable with a
+          // future nextRetryAt, which oldestActiveSettlementAgeMs now
+          // excludes — is not overdue either: a sustained rate limit must
+          // not halt trading while the scheduled retry waits. The pause
+          // stays latched only while a job with NO scheduled retry is
+          // genuinely stuck past the max-pending window.
           activeSafetyPause = { ...activeSafetyPause, resolvedAt: settlementNow };
           yield* db.saveSafetyPause(activeSafetyPause).pipe(Effect.catch(() => Effect.void));
         }


### PR DESCRIPTION
Fixes #196

## Problem

A clean EXIT of the SOL/USDC position split into two settlement legs: the SOL leg confirmed, the USDC leg (41,913,604 atomic ≈ $41.91) stalled on `Jupiter quote failed: 429` for 3.5h+. The job stayed `retryable` with a future `nextRetryAt` (correct per #166/#175), but `settlement_overdue` latched on its age and **never auto-resolved mid-run** — the whole agent halted for ~4h while only a rate limit was the problem. 204×429 in 4.5h: the 5-min backoff cap was shorter than the ban, so retries re-429ed forever and added quote pressure.

## Fix

1. **Progressing per policy is not overdue.** `oldestActiveSettlementAgeMs` now excludes jobs with a FUTURE `nextRetryAt` — a rate-limited job backing off has a scheduled retry. Only jobs with NO scheduled retry (null or past `nextRetryAt`, e.g. the operator-reconciliation `prepared` state) count as genuinely stuck and can arm/latch the pause.
2. **Mid-run auto-resolve.** The `settlement_overdue` auto-resolve fires when no stuck job remains (`oldestSettlementAgeMs <= settlementMaxPendingMs`) instead of requiring every job to be confirmed/terminal — a sustained 429 no longer halts trading while the retry waits; the pause stays latched only for genuinely stuck jobs (mirrors the #148/#182 pattern).
3. **30-minute backoff cap** (was 5): the exponential ramp still retries normal blips quickly (1s, 2s, 4s, ...); only long-running failures space out, cutting the 429 spiral's quote pressure.

## Verification

- New tests: retryable-with-future-nextRetryAt excluded from overdue age; past/null nextRetryAt counts; backoff cap at 1,801,000 (30 min).
- `bun run lint` clean; `bun run test` 121 files / 1583 tests pass.

## Summary by Sourcery

Prevent settlement_overdue safety pauses from latching on progressing settlements and align retry backoff with sustained rate-limit bans.

Bug Fixes:
- Exclude retryable and pending settlements with a future nextRetryAt from overdue-age calculations so rate-limited jobs backing off per policy no longer halt trading.
- Auto-resolve settlement_overdue pauses once no genuinely stuck settlement remains, rather than waiting for all jobs to reach confirmed or terminal states.
- Ensure unpriceable terminal settlements are not revived and unpriceable retryable settlements dust-confirm so they cannot keep settlement_overdue latched.

Enhancements:
- Increase the settlement retry backoff cap from 5 minutes to 30 minutes while retaining fast retries for transient failures.
- Clarify safety-pause behavior around settlement_overdue in the autonomous runtime to mirror other auto-resolve patterns.

Documentation:
- Document the updated settlement_overdue semantics and longer retry backoff cap in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settlement safety-pause handling so progressing settlements with future retries no longer trigger overdue alerts.
  * Safety pauses now resolve automatically when no genuinely stuck settlements remain.
  * Extended settlement retry backoff to a maximum of 30 minutes.
  * Prevented unpriceable terminal or retryable settlements from being incorrectly revived or flagged as overdue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->