### PR TITLE
fix(engine): Jupiter traffic gate — global pacing + escalating 429 cooldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to Prism are documented here.
 
 ### Fixed
 
-- Jupiter API traffic gate: every api.jup.ag request (swap quote/build, price, token search — one shared keyless rate-limit bucket at 0.5 RPS with a ~5-request burst cap) now routes through a process-wide gate that paces requests to a safe sustained rate and opens an escalating cooldown (1 min → 60 min) on 429, honoring the documented `x-ratelimit-reset` backoff target — a self-inflicted rate-limit ban can no longer be refreshed by retry loops and capital-lock the wallet (#196 follow-up)
-- Route-probe quote cache: the autonomous-candidate refresh's per-cycle fan-out (up to ~80 identical probe quotes — the dominant Jupiter traffic term) now caches successful probes for one scan interval, cutting steady-state probe traffic to ~zero (#196 follow-up)
+- Jupiter API traffic gate: every api.jup.ag request (swap quote/build, price, token search — one shared keyless rate-limit bucket at 0.5 RPS sustained with a ~5-request burst cap) now routes through a process-wide gate that paces requests to 0.4 RPS and opens an escalating cooldown (1 min → 60 min) on 429, honoring the documented `x-ratelimit-reset` backoff target — a self-inflicted rate-limit ban can no longer be refreshed by retry loops and capital-lock the wallet (#196 follow-up)
+- Route-probe quote cache: the autonomous-candidate refresh's per-cycle fan-out (up to ~80 identical probe quotes — the dominant Jupiter traffic term) now caches successful probes for at least one scan interval (10-minute minimum), cutting steady-state probe traffic to ~zero (#196 follow-up)
 
 ## [0.1.12] — 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Prism are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- Jupiter API traffic gate: every api.jup.ag request (swap quote/build, price, token search — one shared keyless rate-limit bucket at 0.5 RPS with a ~5-request burst cap) now routes through a process-wide gate that paces requests to a safe sustained rate and opens an escalating cooldown (1 min → 60 min) on 429, honoring the documented `x-ratelimit-reset` backoff target — a self-inflicted rate-limit ban can no longer be refreshed by retry loops and capital-lock the wallet (#196 follow-up)
+- Route-probe quote cache: the autonomous-candidate refresh's per-cycle fan-out (up to ~80 identical probe quotes — the dominant Jupiter traffic term) now caches successful probes for one scan interval, cutting steady-state probe traffic to ~zero (#196 follow-up)
+
 ## [0.1.12] — 2026-08-08
 
 ### Fixed

--- a/bench/jupiter-client.test.ts
+++ b/bench/jupiter-client.test.ts
@@ -161,6 +161,75 @@ describe("jupiterFetch traffic gate (issue #196 follow-up)", () => {
     expect(fetchCount).toBe(1);
   });
 
+  it("claims pacing slots synchronously — concurrent callers cannot burst (P1)", async () => {
+    setJupiterGateForTest({ intervalMs: 30 });
+    let fetchCount = 0;
+    mockFetchOnce(() => {
+      fetchCount += 1;
+      return okResponse();
+    });
+
+    // Three concurrent callers: each claims a distinct slot synchronously
+    // (0ms, 30ms, 60ms), so fetches are spaced by the interval instead of
+    // waking together and bursting.
+    const calls = [
+      jupiterFetch("https://api.jup.ag/swap/v1/quote?i=1"),
+      jupiterFetch("https://api.jup.ag/swap/v1/quote?i=2"),
+      jupiterFetch("https://api.jup.ag/swap/v1/quote?i=3"),
+    ];
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchCount).toBe(1);
+    await vi.advanceTimersByTimeAsync(30);
+    expect(fetchCount).toBe(2);
+    await vi.advanceTimersByTimeAsync(30);
+    await Promise.all(calls);
+    expect(fetchCount).toBe(3);
+  });
+
+  it("aborts the pacing wait with the caller's signal — no request past its timeout", async () => {
+    setJupiterGateForTest({ intervalMs: 10_000 });
+    let fetchCount = 0;
+    mockFetchOnce(() => {
+      fetchCount += 1;
+      return okResponse();
+    });
+    const controller = new AbortController();
+
+    // First call claims the free slot and completes immediately.
+    await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    expect(fetchCount).toBe(1);
+
+    // Second call waits for the next slot (10s out) — its abort signal must
+    // cut the pacing wait short and no request may hit the network.
+    const call = jupiterFetch("https://api.jup.ag/swap/v1/quote", {
+      signal: controller.signal,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort(new Error("timed out"));
+    await expect(call).rejects.toThrow("timed out");
+    expect(fetchCount).toBe(1);
+  });
+
+  it("clamps a far-future x-ratelimit-reset so the breaker can self-heal", async () => {
+    setJupiterGateForTest({ intervalMs: 0, baseCooldownMs: 10 });
+    // A malformed/far-future stamp (millisecond timestamp ≈ year 57k) must
+    // not wedge the breaker beyond the 60-minute cap.
+    const farFutureReset = Math.floor(Date.now() / 1000) + 10 * 365 * 24 * 3_600;
+    let fetchCount = 0;
+    mockFetchOnce(() => {
+      fetchCount += 1;
+      return fetchCount === 1 ? rateLimitedResponse(farFutureReset) : okResponse();
+    });
+
+    await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    // Past the 60-minute clamp (and the 10ms base cooldown): the gate allows
+    // a probe again, and the success clears the breaker.
+    await vi.advanceTimersByTimeAsync(3_600_000 + 1);
+    const recovered = await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    expect(recovered.status).toBe(200);
+    expect(fetchCount).toBe(2);
+  });
+
   it("returns the synthetic 429 with the gateway shape for existing error handling", async () => {
     setJupiterGateForTest({ intervalMs: 0, baseCooldownMs: 60_000 });
     mockFetchOnce(() => rateLimitedResponse());

--- a/bench/jupiter-client.test.ts
+++ b/bench/jupiter-client.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  jupiterFetch,
+  resetJupiterGateForTest,
+  setJupiterGateForTest,
+} from "../engine/jupiter-client.js";
+
+function mockFetchOnce(
+  impl: (url: string | URL | Request, init?: RequestInit) => Response | Promise<Response>,
+): void {
+  vi.spyOn(globalThis, "fetch").mockImplementation(impl as unknown as typeof fetch);
+}
+
+function okResponse(): Response {
+  return new Response(JSON.stringify({ data: [] }), { status: 200 });
+}
+
+function rateLimitedResponse(resetAtSeconds?: number): Response {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (resetAtSeconds !== undefined) headers["x-ratelimit-reset"] = String(resetAtSeconds);
+  return new Response(JSON.stringify({ code: 429, message: "[API Gateway] Too many requests" }), {
+    status: 429,
+    headers,
+  });
+}
+
+describe("jupiterFetch traffic gate (issue #196 follow-up)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetJupiterGateForTest();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    resetJupiterGateForTest();
+  });
+
+  it("paces requests to the configured interval (shared keyless bucket)", async () => {
+    setJupiterGateForTest({ intervalMs: 50 });
+    let fetchCount = 0;
+    mockFetchOnce(() => {
+      fetchCount += 1;
+      return okResponse();
+    });
+
+    const first = jupiterFetch(
+      "https://api.jup.ag/swap/v1/quote?inputMint=a&outputMint=b&amount=1",
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    await first;
+
+    // The second request waits for the slot reserved by the first (50ms).
+    const second = jupiterFetch(
+      "https://api.jup.ag/swap/v1/quote?inputMint=a&outputMint=b&amount=1",
+    );
+    await vi.advanceTimersByTimeAsync(25);
+    expect(fetchCount).toBe(1); // still waiting for the slot
+    await vi.advanceTimersByTimeAsync(25);
+    await second;
+
+    expect(fetchCount).toBe(2);
+  });
+
+  it("fails fast with a synthetic 429 while the breaker cooldown is open", async () => {
+    setJupiterGateForTest({ intervalMs: 0, baseCooldownMs: 60_000 });
+    let fetchCount = 0;
+    mockFetchOnce(() => {
+      fetchCount += 1;
+      return rateLimitedResponse();
+    });
+
+    const first = await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    expect(first.status).toBe(429);
+    expect(fetchCount).toBe(1);
+
+    // During the cooldown no network request is made — a ban can never be
+    // refreshed by retry loops.
+    await vi.advanceTimersByTimeAsync(5_000);
+    const second = await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    expect(second.status).toBe(429);
+    expect(fetchCount).toBe(1);
+  });
+
+  it("honors x-ratelimit-reset as the backoff target (no Retry-After exists)", async () => {
+    setJupiterGateForTest({ intervalMs: 0, baseCooldownMs: 10 });
+    const resetAt = Math.floor(Date.now() / 1000) + 120; // 2 min out
+    let fetchCount = 0;
+    mockFetchOnce(() => {
+      fetchCount += 1;
+      return rateLimitedResponse(resetAt);
+    });
+
+    await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    // The base cooldown (10ms) would have expired — but the reset header
+    // extends the fail-fast window to the documented backoff target.
+    await vi.advanceTimersByTimeAsync(30);
+    const duringResetWindow = await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    expect(duringResetWindow.status).toBe(429);
+    expect(fetchCount).toBe(1);
+  });
+
+  it("escalates the cooldown on repeated 429s and clears on half-open success", async () => {
+    setJupiterGateForTest({ intervalMs: 0, baseCooldownMs: 10 });
+    let fetchCount = 0;
+    mockFetchOnce(() => {
+      fetchCount += 1;
+      return fetchCount <= 2 ? rateLimitedResponse() : okResponse();
+    });
+
+    // First 429: cooldown 10ms.
+    await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    await vi.advanceTimersByTimeAsync(15);
+    // Allowed again (cooldown expired); second 429 escalates to 20ms.
+    await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    expect(fetchCount).toBe(2);
+    // Still within the escalated window → fail fast, no network.
+    await vi.advanceTimersByTimeAsync(15);
+    const duringEscalated = await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    expect(duringEscalated.status).toBe(429);
+    expect(fetchCount).toBe(2);
+    // After the escalated window a probe succeeds and clears the breaker.
+    await vi.advanceTimersByTimeAsync(10);
+    const recovered = await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    expect(recovered.status).toBe(200);
+    expect(fetchCount).toBe(3);
+    // The breaker is reset: a fresh 429 restarts from the base cooldown.
+    mockFetchOnce(() => {
+      fetchCount += 1;
+      return fetchCount === 4 ? rateLimitedResponse() : okResponse();
+    });
+    await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    await vi.advanceTimersByTimeAsync(15);
+    const afterReset = await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    expect(afterReset.status).toBe(200);
+    expect(fetchCount).toBe(5);
+  });
+
+  it("returns the synthetic 429 with the gateway shape for existing error handling", async () => {
+    setJupiterGateForTest({ intervalMs: 0, baseCooldownMs: 60_000 });
+    mockFetchOnce(() => rateLimitedResponse());
+    await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    const synthetic = await jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    expect(synthetic.status).toBe(429);
+    await expect(synthetic.json()).resolves.toEqual({
+      code: 429,
+      message: "[API Gateway] Too many requests",
+    });
+  });
+});

--- a/bench/jupiter-client.test.ts
+++ b/bench/jupiter-client.test.ts
@@ -136,6 +136,31 @@ describe("jupiterFetch traffic gate (issue #196 follow-up)", () => {
     expect(fetchCount).toBe(5);
   });
 
+  it("re-checks the breaker after the pacing wait — a queued request behind a 429 fails fast", async () => {
+    setJupiterGateForTest({ intervalMs: 30, baseCooldownMs: 60_000 });
+    let fetchCount = 0;
+    mockFetchOnce(() => {
+      fetchCount += 1;
+      return rateLimitedResponse();
+    });
+
+    // First request takes the slot and gets a 429 → breaker opens.
+    const first = jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    await vi.advanceTimersByTimeAsync(0);
+    await first;
+    expect(fetchCount).toBe(1);
+
+    // Second request starts while the breaker is open and waits for the slot
+    // reserved by the first. After the wait it must re-check the breaker and
+    // fail fast — the network must NOT see the request (a retry loop must not
+    // refresh the ban).
+    const second = jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    await vi.advanceTimersByTimeAsync(30);
+    const result = await second;
+    expect(result.status).toBe(429);
+    expect(fetchCount).toBe(1);
+  });
+
   it("returns the synthetic 429 with the gateway shape for existing error handling", async () => {
     setJupiterGateForTest({ intervalMs: 0, baseCooldownMs: 60_000 });
     mockFetchOnce(() => rateLimitedResponse());

--- a/bench/jupiter-client.test.ts
+++ b/bench/jupiter-client.test.ts
@@ -139,24 +139,29 @@ describe("jupiterFetch traffic gate (issue #196 follow-up)", () => {
   it("re-checks the breaker after the pacing wait — a queued request behind a 429 fails fast", async () => {
     setJupiterGateForTest({ intervalMs: 30, baseCooldownMs: 60_000 });
     let fetchCount = 0;
+    // The first request's 429 lands on a timer, so the second request is
+    // already IN the pacing wait when the breaker opens mid-wait — only the
+    // post-wait re-check can stop it from hitting the network (the entry
+    // guard cannot, because the breaker is still closed when it starts).
     mockFetchOnce(() => {
       fetchCount += 1;
-      return rateLimitedResponse();
+      return new Promise((resolve) => setTimeout(() => resolve(rateLimitedResponse()), 10));
     });
 
-    // First request takes the slot and gets a 429 → breaker opens.
     const first = jupiterFetch("https://api.jup.ag/swap/v1/quote");
-    await vi.advanceTimersByTimeAsync(0);
-    await first;
-    expect(fetchCount).toBe(1);
-
-    // Second request starts while the breaker is open and waits for the slot
-    // reserved by the first. After the wait it must re-check the breaker and
-    // fail fast — the network must NOT see the request (a retry loop must not
-    // refresh the ban).
     const second = jupiterFetch("https://api.jup.ag/swap/v1/quote");
-    await vi.advanceTimersByTimeAsync(30);
+    // t0: first claims the free slot and sends (429 lands at t0+10); second
+    // sees the slot t0+30 and waits.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchCount).toBe(1);
+    // t0+10: the first 429 opens the breaker while the second is still
+    // waiting for its slot.
+    await vi.advanceTimersByTimeAsync(10);
+    // t0+30: the second wakes — the post-wait re-check returns the synthetic
+    // 429 instead of fetching (fetchCount stays 1).
+    await vi.advanceTimersByTimeAsync(20);
     const result = await second;
+    await first;
     expect(result.status).toBe(429);
     expect(fetchCount).toBe(1);
   });
@@ -227,6 +232,36 @@ describe("jupiterFetch traffic gate (issue #196 follow-up)", () => {
     await vi.advanceTimersByTimeAsync(3_600_000 + 1);
     const recovered = await jupiterFetch("https://api.jup.ag/swap/v1/quote");
     expect(recovered.status).toBe(200);
+    expect(fetchCount).toBe(2);
+  });
+
+  it("an aborted waiter leaves no reservation — later callers are not queued behind it (P1)", async () => {
+    setJupiterGateForTest({ intervalMs: 30 });
+    let fetchCount = 0;
+    mockFetchOnce(() => {
+      fetchCount += 1;
+      return new Promise((resolve) => setTimeout(() => resolve(okResponse()), 10));
+    });
+    const controller = new AbortController();
+
+    // c1 claims the free slot and sends (resolves at t0+10).
+    const c1 = jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    // c2 waits for the next slot (t0+30) but aborts mid-wait.
+    const c2 = jupiterFetch("https://api.jup.ag/swap/v1/quote", {
+      signal: controller.signal,
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await c1;
+    controller.abort();
+    await expect(c2).rejects.toThrow();
+    expect(fetchCount).toBe(1);
+
+    // c3 starts after c2 aborted: it must wait only ONE interval (30ms) —
+    // the aborted waiter held no reservation, so there is no abandoned slot
+    // to queue behind.
+    const c3 = jupiterFetch("https://api.jup.ag/swap/v1/quote");
+    await vi.advanceTimersByTimeAsync(30);
+    await c3;
     expect(fetchCount).toBe(2);
   });
 

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -45,6 +45,7 @@ import { createLogger } from "./logger.js";
 import { getPrismUserConfigDir } from "./paths.js";
 import type { BinData, EntryDepositMode, EntryStrategyShape } from "./types.js";
 import { CircuitBreaker, isRpcNetworkError, retryEffectWithBackoff } from "./adapter-retry.js";
+import { jupiterFetch } from "./jupiter-client.js";
 import bs58 from "bs58";
 import fs from "fs";
 import path from "path";
@@ -883,7 +884,7 @@ export const AdapterLive = Layer.effect(
         const requestInit: RequestInit = { signal: AbortSignal.timeout(10_000) };
         if (jupiterApiKey) requestInit.headers = { "x-api-key": jupiterApiKey };
         const res = yield* Effect.tryPromise(() =>
-          fetch(`https://api.jup.ag/price/v3?ids=${ids}`, requestInit),
+          jupiterFetch(`https://api.jup.ag/price/v3?ids=${ids}`, requestInit),
         );
         if (!res.ok) return {};
         const json = (yield* Effect.tryPromise(() => res.json())) as Record<
@@ -1469,7 +1470,7 @@ export const AdapterLive = Layer.effect(
           );
         }
         const response = yield* Effect.tryPromise(() =>
-          fetch(
+          jupiterFetch(
             `https://api.jup.ag/swap/v1/quote?inputMint=${encodeURIComponent(request.inputMint)}&outputMint=${encodeURIComponent(request.outputMint)}&amount=${request.amountAtomic.toString()}&slippageBps=${request.slippageBps}&asLegacyTransaction=false`,
             { headers: jupiterHeaders(), signal: AbortSignal.timeout(10_000) },
           ),
@@ -1546,7 +1547,7 @@ export const AdapterLive = Layer.effect(
         yield* ensureFreshQuote(quote, "prepare");
         yield* validateQuotePayload(quote.request, quote.rawQuote, quote.quotedAt);
         const response = yield* Effect.tryPromise(() =>
-          fetch("https://api.jup.ag/swap/v1/swap", {
+          jupiterFetch("https://api.jup.ag/swap/v1/swap", {
             method: "POST",
             headers: jupiterHeaders(),
             body: JSON.stringify({

--- a/engine/jupiter-client.ts
+++ b/engine/jupiter-client.ts
@@ -84,45 +84,44 @@ export async function jupiterFetch(
   input: string | URL | Request,
   init?: RequestInit,
 ): Promise<Response> {
-  const now = Date.now();
+  const signal = init?.signal ?? undefined;
   // Fail fast while the 429 cooldown is open — no network traffic, so a ban
   // cannot be refreshed by retry loops.
-  if (now < breakerCooldownUntil) {
-    return syntheticRateLimitedResponse();
-  }
-  // Pace to the sustained keyless rate. The slot is claimed SYNCHRONOUSLY
-  // (single-threaded read-modify-write, the gecko pattern) BEFORE any await:
-  // N concurrent callers each reserve a distinct slot (k × interval apart),
-  // so they cannot all compute the same wait, wake together, and burst.
-  const slotStart = Date.now();
-  const reservedAt = Math.max(slotStart, nextJupiterSlotAt);
-  nextJupiterSlotAt = reservedAt + intervalMs();
-  let waitMs = Math.max(0, reservedAt - slotStart);
-  // A slot more than 5 minutes out is a clock anomaly (NTP jump back, or
-  // stale state across test isolation) — never sleep that long for pacing;
-  // a queue that deep is pathological and the 429 breaker should have opened
-  // long before it forms.
-  if (waitMs > MAX_JUPITER_SLOT_WAIT_MS) {
-    nextJupiterSlotAt = slotStart + intervalMs();
-    waitMs = 0;
-  }
-  if (waitMs > 0) {
-    const signal = init?.signal ?? undefined;
-    await sleepWithAbort(waitMs, signal);
-  }
-  // A request can wait for its pacing slot while an EARLIER request receives
-  // a 429 and opens the breaker — re-check after the wait, before calling
-  // fetch, so the waiting request fails fast instead of refreshing the ban.
   if (Date.now() < breakerCooldownUntil) {
     return syntheticRateLimitedResponse();
   }
-  // The caller's abort signal (e.g. AbortSignal.timeout) applies to the whole
-  // round trip, pacing included: if it fired while waiting, behave like fetch
-  // would — throw instead of sending a request that was already abandoned.
-  const signal = init?.signal ?? undefined;
-  if (signal !== undefined && signal.aborted) {
-    throw signal.reason ?? new Error("The operation was aborted");
+  // Pace to the sustained keyless rate. Waiting callers hold NO reservation:
+  // the loop sleeps in ≤interval chunks until the slot is free, then claims
+  // and sends atomically (single-threaded). Concurrent callers still end up
+  // interval-spaced — the first to wake claims and sends, the rest see the
+  // advanced counter and wait again — but an aborted waiter leaves nothing
+  // behind, so no abandoned slot can queue later callers behind dead
+  // reservations.
+  while (true) {
+    const now = Date.now();
+    let waitMs = nextJupiterSlotAt - now;
+    // A slot more than 5 minutes out is a clock anomaly (NTP jump back, or
+    // stale state across test isolation) — never sleep that long for pacing;
+    // a queue that deep is pathological and the 429 breaker should have
+    // opened long before it forms.
+    if (waitMs > MAX_JUPITER_SLOT_WAIT_MS) {
+      nextJupiterSlotAt = now + intervalMs();
+      waitMs = 0;
+    }
+    if (waitMs <= 0) break;
+    await sleepWithAbort(Math.min(waitMs, intervalMs()), signal);
+    // Re-check after every wake: an EARLIER request may have received a 429
+    // and opened the breaker mid-wait (the waiting request must fail fast
+    // instead of refreshing the ban), or the caller's signal may have fired.
+    if (Date.now() < breakerCooldownUntil) {
+      return syntheticRateLimitedResponse();
+    }
+    if (signal !== undefined && signal.aborted) {
+      throw signal.reason ?? new Error("The operation was aborted");
+    }
   }
+  const slotStart = Date.now();
+  nextJupiterSlotAt = slotStart + intervalMs();
   const response = await fetch(input, init);
   if (response.status === 429) {
     // Escalate the cooldown; x-ratelimit-reset (Unix seconds) is the

--- a/engine/jupiter-client.ts
+++ b/engine/jupiter-client.ts
@@ -1,0 +1,131 @@
+// ─── Jupiter API traffic gate (issue #196 follow-up) ─────────────────────────
+// Keyless api.jup.ag enforces ONE rate-limit bucket shared across every
+// endpoint (swap/v1/quote, swap/v1/swap, price/v3, tokens/v2): 0.5 RPS
+// sustained with an empirically observed ~5-request burst cap (librarian
+// verification, 2026-08-09). The agent's startup fan-out (route probes,
+// settlement/entry-prep quotes) blew through the burst cap and retry loops
+// kept every subsequent request failing — a self-inflicted >13h ban that
+// capital-locked the wallet. This gate:
+//   1. paces ALL Jupiter traffic to a safe sustained rate (slot
+//      reservation, same pattern as the GeckoTerminal 2.1s pacing), and
+//   2. opens a process-wide escalating cooldown on 429, honoring the
+//      documented x-ratelimit-reset backoff target (no Retry-After header
+//      exists). While the cooldown is open every Jupiter request fails fast
+//      with a synthetic 429 — zero network traffic, so a ban can never be
+//      refreshed by retry loops.
+
+// 0.4 RPS sustained — comfortably under the 0.5 RPS keyless refill rate.
+const MIN_JUPITER_REQUEST_INTERVAL_MS = 2_500;
+// Ceiling on any single pacing wait: beyond this the slot is treated as
+// stale (clock anomaly / cross-isolation state) and reset.
+const MAX_JUPITER_SLOT_WAIT_MS = 5 * 60_000;
+// Escalating 429 cooldown: 1 min, 2, 4, ... up to 60 min.
+const BREAKER_BASE_COOLDOWN_MS = 60_000;
+const BREAKER_MAX_COOLDOWN_MS = 60 * 60_000;
+
+let nextJupiterSlotAt = 0;
+let breakerCooldownUntil = 0;
+let breakerFailures = 0;
+// Test knobs (mirror the GeckoTerminal service's setGeckoRequestIntervalMsForTest).
+// Under the test environment (NODE_ENV=test / VITEST=true — repo precedent in
+// config-service) the interval defaults to 0: the suite mocks global fetch
+// and must not pay the pacing wait per call. The jupiter-client tests raise
+// it explicitly via setJupiterGateForTest.
+let testIntervalMs: number | undefined =
+  process.env.NODE_ENV === "test" || process.env.VITEST === "true" ? 0 : undefined;
+let testBaseCooldownMs: number | undefined;
+
+export interface JupiterGateTestOptions {
+  readonly intervalMs?: number;
+  readonly baseCooldownMs?: number;
+}
+
+/** Test hooks: zero the interval so unit tests are not serialized, and
+ *  shrink/expand the breaker cooldown. */
+export function setJupiterGateForTest(options: JupiterGateTestOptions): void {
+  if (options.intervalMs !== undefined) testIntervalMs = options.intervalMs;
+  if (options.baseCooldownMs !== undefined) testBaseCooldownMs = options.baseCooldownMs;
+}
+
+export function resetJupiterGateForTest(): void {
+  nextJupiterSlotAt = 0;
+  breakerCooldownUntil = 0;
+  breakerFailures = 0;
+  testIntervalMs = undefined;
+  testBaseCooldownMs = undefined;
+}
+
+function intervalMs(): number {
+  return testIntervalMs !== undefined ? testIntervalMs : MIN_JUPITER_REQUEST_INTERVAL_MS;
+}
+
+function baseCooldownMs(): number {
+  return testBaseCooldownMs !== undefined ? testBaseCooldownMs : BREAKER_BASE_COOLDOWN_MS;
+}
+
+function sleep(ms: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
+}
+
+function syntheticRateLimitedResponse(): Response {
+  return new Response(JSON.stringify({ code: 429, message: "[API Gateway] Too many requests" }), {
+    status: 429,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * The single choke point for every api.jup.ag request in the process.
+ * Replace `fetch(url, init)` with `jupiterFetch(url, init)` at Jupiter call
+ * sites so pacing and the 429 breaker apply process-wide (the bucket is
+ * shared across endpoints — per-site throttles would not protect it).
+ */
+export async function jupiterFetch(
+  input: string | URL | Request,
+  init?: RequestInit,
+): Promise<Response> {
+  const now = Date.now();
+  // Fail fast while the 429 cooldown is open — no network traffic, so a ban
+  // cannot be refreshed by retry loops.
+  if (now < breakerCooldownUntil) {
+    return syntheticRateLimitedResponse();
+  }
+  // Pace to the sustained keyless rate: slot reservation (gecko pattern).
+  // A slot more than 5 minutes out is a clock anomaly (NTP jump back, or
+  // stale state across test isolation) — never sleep that long for pacing;
+  // a queue that deep is pathological and the 429 breaker should have opened
+  // long before it forms.
+  const waitMs = Math.max(0, nextJupiterSlotAt - now);
+  if (waitMs > MAX_JUPITER_SLOT_WAIT_MS) {
+    nextJupiterSlotAt = now;
+  }
+  const effectiveWaitMs = Math.max(0, nextJupiterSlotAt - now);
+  if (effectiveWaitMs > 0) {
+    await sleep(effectiveWaitMs);
+  }
+  const slotStart = Date.now();
+  nextJupiterSlotAt = Math.max(slotStart, nextJupiterSlotAt) + intervalMs();
+  const response = await fetch(input, init);
+  if (response.status === 429) {
+    // Escalate the cooldown; x-ratelimit-reset (Unix seconds) is the
+    // documented backoff target when the oldest in-window request ages out.
+    breakerFailures += 1;
+    const cooldownMs = Math.min(
+      baseCooldownMs() * 2 ** (breakerFailures - 1),
+      BREAKER_MAX_COOLDOWN_MS,
+    );
+    const resetHeader = response.headers.get("x-ratelimit-reset");
+    const resetAtMs = resetHeader === null ? 0 : Number(resetHeader) * 1000;
+    breakerCooldownUntil = Math.max(
+      Date.now() + cooldownMs,
+      Number.isFinite(resetAtMs) && resetAtMs > 0 ? resetAtMs : 0,
+    );
+  } else if (response.ok && breakerFailures > 0) {
+    // Half-open recovery: a success after the cooldown clears the breaker.
+    breakerFailures = 0;
+    breakerCooldownUntil = 0;
+  }
+  return response;
+}

--- a/engine/jupiter-client.ts
+++ b/engine/jupiter-client.ts
@@ -109,6 +109,13 @@ export async function jupiterFetch(
   if (effectiveWaitMs > 0) {
     await sleep(effectiveWaitMs);
   }
+  // A request can wait for its pacing slot while an EARLIER request receives
+  // a 429 and opens the breaker — re-check before reserving the next slot or
+  // calling fetch, so the waiting request fails fast instead of refreshing
+  // the ban.
+  if (Date.now() < breakerCooldownUntil) {
+    return syntheticRateLimitedResponse();
+  }
   const slotStart = Date.now();
   nextJupiterSlotAt = Math.max(slotStart, nextJupiterSlotAt) + intervalMs();
   const response = await fetch(input, init);

--- a/engine/jupiter-client.ts
+++ b/engine/jupiter-client.ts
@@ -31,8 +31,9 @@ let breakerFailures = 0;
 // config-service) the interval defaults to 0: the suite mocks global fetch
 // and must not pay the pacing wait per call. The jupiter-client tests raise
 // it explicitly via setJupiterGateForTest.
-let testIntervalMs: number | undefined =
-  process.env.NODE_ENV === "test" || process.env.VITEST === "true" ? 0 : undefined;
+const TEST_ENV = process.env.NODE_ENV === "test" || process.env.VITEST === "true";
+const DEFAULT_TEST_INTERVAL_MS = TEST_ENV ? 0 : undefined;
+let testIntervalMs: number | undefined = DEFAULT_TEST_INTERVAL_MS;
 let testBaseCooldownMs: number | undefined;
 
 export interface JupiterGateTestOptions {
@@ -51,7 +52,10 @@ export function resetJupiterGateForTest(): void {
   nextJupiterSlotAt = 0;
   breakerCooldownUntil = 0;
   breakerFailures = 0;
-  testIntervalMs = undefined;
+  // Restore the environment-derived default (0 under the test env), not the
+  // production interval — a reset between tests must not re-serialize the
+  // mocked-fetch suite.
+  testIntervalMs = DEFAULT_TEST_INTERVAL_MS;
   testBaseCooldownMs = undefined;
 }
 

--- a/engine/jupiter-client.ts
+++ b/engine/jupiter-client.ts
@@ -67,12 +67,6 @@ function baseCooldownMs(): number {
   return testBaseCooldownMs !== undefined ? testBaseCooldownMs : BREAKER_BASE_COOLDOWN_MS;
 }
 
-function sleep(ms: number): Promise<void> {
-  const { promise, resolve } = Promise.withResolvers<void>();
-  setTimeout(resolve, ms);
-  return promise;
-}
-
 function syntheticRateLimitedResponse(): Response {
   return new Response(JSON.stringify({ code: 429, message: "[API Gateway] Too many requests" }), {
     status: 429,
@@ -96,32 +90,46 @@ export async function jupiterFetch(
   if (now < breakerCooldownUntil) {
     return syntheticRateLimitedResponse();
   }
-  // Pace to the sustained keyless rate: slot reservation (gecko pattern).
+  // Pace to the sustained keyless rate. The slot is claimed SYNCHRONOUSLY
+  // (single-threaded read-modify-write, the gecko pattern) BEFORE any await:
+  // N concurrent callers each reserve a distinct slot (k × interval apart),
+  // so they cannot all compute the same wait, wake together, and burst.
+  const slotStart = Date.now();
+  const reservedAt = Math.max(slotStart, nextJupiterSlotAt);
+  nextJupiterSlotAt = reservedAt + intervalMs();
+  let waitMs = Math.max(0, reservedAt - slotStart);
   // A slot more than 5 minutes out is a clock anomaly (NTP jump back, or
   // stale state across test isolation) — never sleep that long for pacing;
   // a queue that deep is pathological and the 429 breaker should have opened
   // long before it forms.
-  const waitMs = Math.max(0, nextJupiterSlotAt - now);
   if (waitMs > MAX_JUPITER_SLOT_WAIT_MS) {
-    nextJupiterSlotAt = now;
+    nextJupiterSlotAt = slotStart + intervalMs();
+    waitMs = 0;
   }
-  const effectiveWaitMs = Math.max(0, nextJupiterSlotAt - now);
-  if (effectiveWaitMs > 0) {
-    await sleep(effectiveWaitMs);
+  if (waitMs > 0) {
+    const signal = init?.signal ?? undefined;
+    await sleepWithAbort(waitMs, signal);
   }
   // A request can wait for its pacing slot while an EARLIER request receives
-  // a 429 and opens the breaker — re-check before reserving the next slot or
-  // calling fetch, so the waiting request fails fast instead of refreshing
-  // the ban.
+  // a 429 and opens the breaker — re-check after the wait, before calling
+  // fetch, so the waiting request fails fast instead of refreshing the ban.
   if (Date.now() < breakerCooldownUntil) {
     return syntheticRateLimitedResponse();
   }
-  const slotStart = Date.now();
-  nextJupiterSlotAt = Math.max(slotStart, nextJupiterSlotAt) + intervalMs();
+  // The caller's abort signal (e.g. AbortSignal.timeout) applies to the whole
+  // round trip, pacing included: if it fired while waiting, behave like fetch
+  // would — throw instead of sending a request that was already abandoned.
+  const signal = init?.signal ?? undefined;
+  if (signal !== undefined && signal.aborted) {
+    throw signal.reason ?? new Error("The operation was aborted");
+  }
   const response = await fetch(input, init);
   if (response.status === 429) {
     // Escalate the cooldown; x-ratelimit-reset (Unix seconds) is the
     // documented backoff target when the oldest in-window request ages out.
+    // Clamped: the escalated cooldown is bounded at 60 min, and the header
+    // override must be too — a malformed or far-future stamp would otherwise
+    // wedge the breaker (no self-heal) for hours or days.
     breakerFailures += 1;
     const cooldownMs = Math.min(
       baseCooldownMs() * 2 ** (breakerFailures - 1),
@@ -129,14 +137,39 @@ export async function jupiterFetch(
     );
     const resetHeader = response.headers.get("x-ratelimit-reset");
     const resetAtMs = resetHeader === null ? 0 : Number(resetHeader) * 1000;
-    breakerCooldownUntil = Math.max(
-      Date.now() + cooldownMs,
-      Number.isFinite(resetAtMs) && resetAtMs > 0 ? resetAtMs : 0,
-    );
+    const clampedResetAtMs =
+      Number.isFinite(resetAtMs) && resetAtMs > 0
+        ? Math.min(resetAtMs, Date.now() + BREAKER_MAX_COOLDOWN_MS)
+        : 0;
+    breakerCooldownUntil = Math.max(Date.now() + cooldownMs, clampedResetAtMs);
   } else if (response.ok && breakerFailures > 0) {
     // Half-open recovery: a success after the cooldown clears the breaker.
     breakerFailures = 0;
     breakerCooldownUntil = 0;
   }
   return response;
+}
+
+/** Sleeps for `ms` but resolves early (and re-checks) when `signal` aborts. */
+function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const onAbort = (): void => {
+    clearTimeout(timer);
+    resolve();
+  };
+  const timer = setTimeout(() => {
+    signal?.removeEventListener("abort", onAbort);
+    resolve();
+  }, ms);
+  if (signal !== undefined) {
+    if (signal.aborted) {
+      clearTimeout(timer);
+      return Promise.resolve();
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  }
+  return promise.finally(() => {
+    clearTimeout(timer);
+    signal?.removeEventListener("abort", onAbort);
+  });
 }

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -2398,6 +2398,14 @@ export const program = Effect.gen(function* () {
     routeProbeResults.delete(key);
     return null;
   };
+  const pruneRouteProbeCache = (): void => {
+    // Discovery keeps finding new mints; without a sweep, expired entries for
+    // old mints would accumulate for the process lifetime.
+    const now = Date.now();
+    for (const [key, entry] of routeProbeResults) {
+      if (entry.expiresAt <= now) routeProbeResults.delete(key);
+    }
+  };
   const writeRouteProbeCache = (key: string, available: boolean): void => {
     if (available) {
       routeProbeResults.set(key, { available, expiresAt: Date.now() + routeProbeCacheTtlMs });
@@ -2781,6 +2789,10 @@ export const program = Effect.gen(function* () {
             .pipe(Effect.catch(() => Effect.succeed(null)));
           if (decimals !== null) decimalsByMint.set(mint, decimals);
         }
+        // Sweep expired route-probe cache entries once per refresh: discovery
+        // keeps finding new mints, so without pruning expired keys would
+        // accumulate for the process lifetime.
+        pruneRouteProbeCache();
         const routeProbes = nonSolMints.map((mint) => {
           const tokenPrice = tokenPrices.get(mint) ?? 0;
           const decimals = decimalsByMint.get(mint);
@@ -2795,9 +2807,12 @@ export const program = Effect.gen(function* () {
             const key = `${direction}:${mint}`;
             const cached = readRouteProbeCache(key);
             if (cached !== null) return Effect.succeed(cached);
+            // catchCause, not catch: a defect (e.g. a sync throw from a
+            // malformed mint in the quote path) must degrade to "route
+            // unavailable" for this probe, never fail the whole refresh.
             return quote.pipe(
               Effect.as(true),
-              Effect.catch(() => Effect.succeed(false)),
+              Effect.catchCause(() => Effect.succeed(false)),
               Effect.tap((available) => Effect.sync(() => writeRouteProbeCache(key, available))),
             );
           };

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -2380,6 +2380,29 @@ export const program = Effect.gen(function* () {
     2,
   );
   const binHistory = new Map<string, number[]>();
+  // Issue #196 follow-up: route-probe results cache. The autonomous-candidate
+  // refresh probes every non-SOL candidate mint in both directions (SOL→token
+  // and token→SOL) with FIXED probe amounts — identical requests repeated
+  // every cycle, up to ~80 quote calls per cycle (the dominant Jupiter
+  // traffic term, ~70% of the self-inflicted keyless rate-limit pressure).
+  // Successful probes are cached for one scan interval (min 10 min): route
+  // availability is stable, and a miss only re-probes. Failures are NOT
+  // cached — during a Jupiter 429 cooldown the gate fails them fast with
+  // zero network, so a transient ban can never poison route availability.
+  const routeProbeResults = new Map<string, { available: boolean; expiresAt: number }>();
+  const routeProbeCacheTtlMs = Math.max(config.scanIntervalMs, 10 * 60_000);
+  const readRouteProbeCache = (key: string): boolean | null => {
+    const entry = routeProbeResults.get(key);
+    if (entry === undefined) return null;
+    if (entry.expiresAt > Date.now()) return entry.available;
+    routeProbeResults.delete(key);
+    return null;
+  };
+  const writeRouteProbeCache = (key: string, available: boolean): void => {
+    if (available) {
+      routeProbeResults.set(key, { available, expiresAt: Date.now() + routeProbeCacheTtlMs });
+    }
+  };
   const pushBinHistory = (poolAddress: string, activeBinId: number): void => {
     const arr = binHistory.get(poolAddress) ?? [];
     arr.push(activeBinId);
@@ -2765,25 +2788,38 @@ export const program = Effect.gen(function* () {
           const tokenAtomic =
             decimals === undefined ? 0n : routeProbeAmountAtomic(tokenPrice, decimals);
           if (solAtomic === 0n || tokenAtomic === 0n) return Effect.succeed(false);
+          const probeRoute = (
+            direction: "sol-to-token" | "token-to-sol",
+            quote: Effect.Effect<unknown, Error>,
+          ): Effect.Effect<boolean, never> => {
+            const key = `${direction}:${mint}`;
+            const cached = readRouteProbeCache(key);
+            if (cached !== null) return Effect.succeed(cached);
+            return quote.pipe(
+              Effect.as(true),
+              Effect.catch(() => Effect.succeed(false)),
+              Effect.tap((available) => Effect.sync(() => writeRouteProbeCache(key, available))),
+            );
+          };
           return Effect.all(
             [
-              quoteSwap({
-                inputMint: SOL_MINT,
-                outputMint: mint,
-                amountAtomic: solAtomic,
-                slippageBps: config.maxSwapSlippageBps,
-              }).pipe(
-                Effect.as(true),
-                Effect.catch(() => Effect.succeed(false)),
+              probeRoute(
+                "sol-to-token",
+                quoteSwap({
+                  inputMint: SOL_MINT,
+                  outputMint: mint,
+                  amountAtomic: solAtomic,
+                  slippageBps: config.maxSwapSlippageBps,
+                }),
               ),
-              quoteSwap({
-                inputMint: mint,
-                outputMint: SOL_MINT,
-                amountAtomic: tokenAtomic,
-                slippageBps: config.maxSwapSlippageBps,
-              }).pipe(
-                Effect.as(true),
-                Effect.catch(() => Effect.succeed(false)),
+              probeRoute(
+                "token-to-sol",
+                quoteSwap({
+                  inputMint: mint,
+                  outputMint: SOL_MINT,
+                  amountAtomic: tokenAtomic,
+                  slippageBps: config.maxSwapSlippageBps,
+                }),
               ),
             ],
             { concurrency: 4 },

--- a/engine/token-risk-service.ts
+++ b/engine/token-risk-service.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "./logger.js";
+import { jupiterFetch } from "./jupiter-client.js";
 
 /**
  * Token-risk overlay (Wave 18): smart freeze-authority / scam detection that
@@ -103,7 +104,13 @@ export async function fetchTokenRisks(
     readonly fetchImpl?: FetchLike;
   } = {},
 ): Promise<Map<string, TokenRiskSignal>> {
-  const fetchImpl = options.fetchImpl ?? fetch;
+  // The default fetch routes through the process-wide Jupiter traffic gate
+  // (pacing + 429 breaker — the tokens API shares the same keyless
+  // rate-limit bucket as quote/swap/price). Injected fakes (tests) bypass
+  // the gate.
+  const fetchImpl =
+    options.fetchImpl ??
+    ((url: string | URL | Request, init?: RequestInit) => jupiterFetch(url, init));
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const headers: Record<string, string> = {};
   // ONLY send the key when a non-empty value is configured — an empty


### PR DESCRIPTION
Addresses the residual root cause from the #196 verification comment (2026-08-09): the Jupiter 429 storm persists >13h because the client keeps itself banned; the 30-min backoff is not enough.

## Research (scout + live librarian verification, 2026-08-09)

- Keyless api.jup.ag: **ONE rate-limit bucket shared across all endpoints** (swap/v1/quote, swap/v1/swap, price/v3, tokens/v2) — 0.5 RPS sustained, 60s sliding window per docs; **empirically a ~5-request burst cap** (6th rapid request 429s), refill ~0.5 RPS.
- No Retry-After header; the documented backoff target is `x-ratelimit-reset` (Unix seconds, present on 429s).
- **Self-ban mechanics**: the autonomous-candidate refresh fires up to ~80 uncached route-probe quotes per cycle (70%+ of traffic, 429-blind); settlement/entry retries re-quote every backoff; a startup burst >5 trips the limit instantly and retry loops keep every subsequent request failing — the >13h ban.

## Fix

1. **`engine/jupiter-client.ts` — the single choke point for every api.jup.ag request:**
   - **Pacing**: 0.4 RPS sustained (slot reservation, mirroring the GeckoTerminal 2.1s pattern) — safe under the keyless 0.5 RPS refill.
   - **Escalating 429 cooldown**: 1 min → 60 min process-wide, honoring `x-ratelimit-reset` when present. While open, every request **fails fast with a synthetic 429 — zero network traffic**, so a ban can never be refreshed by retry loops. Half-open recovery: a success after the cooldown clears the breaker.
   - Stale pacing slots (clock anomaly / test isolation) are reset, not slept through.
2. **All four Jupiter sites route through the gate**: swap quote, swap build, price/v3 (adapter-service.ts), tokens/v2 search (token-risk-service.ts — injected test fakes bypass it).
3. **Route-probe quote cache** (program.ts): probes use fixed amounts — identical requests repeated every cycle. Successful probes are cached for one scan interval (min 10 min), cutting the dominant ~80-call/cycle fan-out to ~zero steady-state. Failures stay uncached: during a cooldown they fail fast for free.
4. Interval defaults to 0 under the test env (repo precedent), so the existing suite is not serialized; gate tests use fake timers.

## Verification

- New `bench/jupiter-client.test.ts` (5 tests, fake-timer driven): pacing, fail-fast during cooldown, `x-ratelimit-reset` honoring, escalation + half-open recovery, synthetic 429 shape.
- `bun run lint` clean; `bun run test` 122 files / 1589 tests pass.

## Summary by Sourcery

Introduce a global Jupiter API traffic gate with request pacing and an escalating 429 cooldown, and cache autonomous route-probe quotes to eliminate redundant traffic and prevent self-inflicted long-lived rate-limit bans.

Bug Fixes:
- Route-probe quote cache now prevents repeated identical probe requests each scan cycle, significantly reducing Jupiter quote traffic and avoiding sustained rate-limit pressure.
- All Jupiter endpoints (swap quote/build, price, token search) now share a process-wide traffic gate that paces requests and applies an escalating cooldown on 429s, so retry loops can no longer refresh a keyless rate-limit ban.

Enhancements:
- Add a dedicated Jupiter client wrapper as the single choke point for api.jup.ag calls, enforcing safe request pacing and centralized 429 handling across the engine.
- Wire adapter and token-risk services to use the shared Jupiter client, ensuring consistent rate-limit behavior across price, swap, and token APIs.

Documentation:
- Update the changelog to document the new Jupiter traffic gate behavior and route-probe quote caching as follow-up fixes for issue #196.

Tests:
- Add bench tests for the Jupiter client gate covering pacing behavior, fail-fast 429 responses during cooldown, x-ratelimit-reset honoring, cooldown escalation and recovery, and synthetic 429 response shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared traffic controls for Jupiter API requests, including pacing, burst protection, rate-limit cooldowns, and reset-aware backoff.
  * Added temporary caching for successful route probes to reduce repeated quote requests during a scan interval.

* **Bug Fixes**
  * Improved recovery after rate-limit responses with escalating cooldowns and successful-request reset behavior.

* **Tests**
  * Added coverage for request pacing, cooldowns, recovery, backoff handling, and gateway error responses.

* **Documentation**
  * Documented the Jupiter API traffic controls and route-probe caching in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->