### PR TITLE
feat(engine): launch-mode radar — hot-pool discovery + screening (v1)

### DIFF
--- a/bench/adapter-prices.test.ts
+++ b/bench/adapter-prices.test.ts
@@ -348,7 +348,9 @@ describe("AdapterService getTokenPrices fallback behavior", () => {
     // fallback price with the default. The stranded-status classification
     // passes useFallback: false precisely so a price-provider outage can
     // never report stranded capital at a fabricated value.
-    const restore = mockFetch((async () => new Response("down", { status: 500 })) as unknown as typeof fetch);
+    const restore = mockFetch(
+      (async () => new Response("down", { status: 500 })) as unknown as typeof fetch,
+    );
     try {
       expect(await readTokenPrices([SOL_MINT], false)).toEqual({ [SOL_MINT]: 0 });
       expect(await readTokenPrices([SOL_MINT], true)).toEqual({ [SOL_MINT]: 165 });

--- a/bench/cli-dev-lockfile.test.ts
+++ b/bench/cli-dev-lockfile.test.ts
@@ -133,7 +133,10 @@ describe("cli/lockfile", () => {
       ].join("\n"),
     });
     const found = findRunningEngineProcess(spawner);
-    expect(found).toEqual({ pid: process.pid + 1, command: `bun /root/.prism/dist/cli/index.mjs dev` });
+    expect(found).toEqual({
+      pid: process.pid + 1,
+      command: `bun /root/.prism/dist/cli/index.mjs dev`,
+    });
   });
 
   it("findRunningEngineProcess ignores index.mjs runs without a dev argument", () => {

--- a/bench/cli-status-classification.test.ts
+++ b/bench/cli-status-classification.test.ts
@@ -28,9 +28,9 @@ describe("classifyStrandedSettlement (issue #183 three-channel split)", () => {
   });
 
   it("classifies a PRICE typed failure (provider outage) as unavailable", () => {
-    expect(
-      classifyStrandedSettlement({ ...base, priceState: "unavailable", priceUsd: 0 }),
-    ).toEqual({ kind: "unavailable" });
+    expect(classifyStrandedSettlement({ ...base, priceState: "unavailable", priceUsd: 0 })).toEqual(
+      { kind: "unavailable" },
+    );
   });
 
   it("classifies a DECIMALS typed failure (RPC outage) as unavailable, not unpriceable", () => {
@@ -40,9 +40,9 @@ describe("classifyStrandedSettlement (issue #183 three-channel split)", () => {
   });
 
   it("classifies a genuinely unpriceable token (no price) as unpriceable", () => {
-    expect(
-      classifyStrandedSettlement({ ...base, priceState: "unpriceable", priceUsd: 0 }),
-    ).toEqual({ kind: "unpriceable" });
+    expect(classifyStrandedSettlement({ ...base, priceState: "unpriceable", priceUsd: 0 })).toEqual(
+      { kind: "unpriceable" },
+    );
   });
 
   it("classifies a decimals defect (malformed mint) as unpriceable", () => {
@@ -86,9 +86,7 @@ describe("decimalsFailureState (issue #183 adapter error surface)", () => {
 
   it("maps other typed failures (RPC outage) to unavailable", () => {
     expect(decimalsFailureState(new Error("fetch failed"))).toBe("unavailable");
-    expect(decimalsFailureState(new Error("request timed out after 10000ms"))).toBe(
-      "unavailable",
-    );
+    expect(decimalsFailureState(new Error("request timed out after 10000ms"))).toBe("unavailable");
     expect(decimalsFailureState(null)).toBe("unavailable");
   });
 });

--- a/bench/launch-gate.test.ts
+++ b/bench/launch-gate.test.ts
@@ -1,0 +1,182 @@
+/** Launch-gate unit tests: hot-young admission, fail-closed rejections,
+ * fee-yield ranking. */
+import { describe, it, expect } from "vitest";
+import {
+  gateAndRankLaunchPools,
+  type LaunchGateConfig,
+  type LaunchGateResult,
+  type LaunchPoolRank,
+} from "../engine/launch-gate.js";
+import type { DiscoveredPool } from "../engine/services.js";
+
+const SOL = "So11111111111111111111111111111111111111112";
+const USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const USDT = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
+
+const NOW = 1_800_000_000_000;
+
+function makePool(overrides: Partial<DiscoveredPool> & { address: string }): DiscoveredPool {
+  const { address, ...rest } = overrides;
+  return {
+    address,
+    tvlUsd: 100_000,
+    volume24hUsd: 800_000,
+    fees24hUsd: 1_500,
+    apr: 2.5,
+    binStep: 100,
+    tokenX: SOL,
+    tokenY: USDC,
+    tokenXSymbol: "SOL",
+    tokenYSymbol: "USDC",
+    tokenXVerified: true,
+    tokenYVerified: true,
+    tokenXFreezeDisabled: true,
+    tokenYFreezeDisabled: true,
+    tokenXHolders: 3_000_000,
+    tokenYHolders: 2_000_000,
+    createdAtMs: NOW - 60 * 60_000, // 1h old
+    volume1hUsd: 300_000,
+    fees1hUsd: 6_000,
+    feeYield1hPct: 12,
+    baseFeePct: 2.5,
+    ...rest,
+  };
+}
+
+const config: LaunchGateConfig = {
+  minTvlUsd: 5_000,
+  maxTvlUsd: 1_000_000,
+  maxAgeHours: 6,
+  minVolume1hUsd: 50_000,
+  minBaseFeePct: 1,
+  minBinStep: 50,
+  maxBinStep: 200,
+  maxVolumeTurnover: 50,
+  minHolders: 1000,
+  stablecoinMints: new Set([USDC, USDT]),
+  now: NOW,
+};
+
+function rejectedFor(result: LaunchGateResult, address: string): string[] {
+  const reasons: string[] = [];
+  for (const r of result.rejected) {
+    if (r.address === address) reasons.push(r.reason);
+  }
+  return reasons;
+}
+
+describe("gateAndRankLaunchPools", () => {
+  it("admits a hot young pool and reports its rank fields", () => {
+    const result = gateAndRankLaunchPools([makePool({ address: "p1" })], config);
+    expect(result.ranked).toHaveLength(1);
+    expect(result.rejected).toHaveLength(0);
+    const rank = result.ranked[0]!;
+    expect(rank.feeYield1hPct).toBe(12);
+    expect(rank.volume1hUsd).toBe(300_000);
+    expect(rank.score).toBe(12);
+    expect(rank.notes.join(" ")).toContain("age");
+  });
+
+  it("rejects a pool older than maxAgeHours", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "old", createdAtMs: NOW - 7 * 60 * 60_000 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "old")[0]).toContain("age");
+  });
+
+  it("rejects a pool with missing createdAt", () => {
+    const { createdAtMs: _omit, ...noCreatedAt } = makePool({ address: "nocreated" });
+    const result = gateAndRankLaunchPools([noCreatedAt], config);
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "nocreated")[0]).toContain("createdAt");
+  });
+
+  it("rejects a pool below min TVL", () => {
+    const result = gateAndRankLaunchPools([makePool({ address: "lowtvl", tvlUsd: 1_000 })], config);
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "lowtvl")[0]).toContain("tvl");
+  });
+
+  it("rejects a pool above max TVL (established, not a launch)", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "hightvl", tvlUsd: 2_000_000 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "hightvl")[0]).toContain("tvl");
+  });
+
+  it("rejects a pool with low 1h volume", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "lowvol", volume1hUsd: 10_000 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "lowvol")[0]).toContain("1h volume");
+  });
+
+  it("rejects a pool with low base fee", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "lowfee", baseFeePct: 0.5 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "lowfee")[0]).toContain("base fee");
+  });
+
+  it("rejects a pool with missing 1h fee yield (hotness is the point)", () => {
+    const { feeYield1hPct: _omit, ...noYield } = makePool({ address: "noyield" });
+    const result = gateAndRankLaunchPools([noYield], config);
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "noyield")[0]).toContain("fee yield");
+  });
+
+  it("rejects binStep outside the band (both sides)", () => {
+    const fine = makePool({ address: "fine", binStep: 10 });
+    const wide = makePool({ address: "wide", binStep: 300 });
+    const result = gateAndRankLaunchPools([fine, wide], config);
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "fine")[0]).toContain("binStep");
+    expect(rejectedFor(result, "wide")[0]).toContain("binStep");
+  });
+
+  it("rejects wash turnover (24h volume/TVL above the ceiling)", () => {
+    // 100_000_000 / 100_000 = 1000 > 50
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "wash", volume24hUsd: 100_000_000 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "wash")[0]).toContain("wash");
+  });
+
+  it("rejects a risky (unverified, low-holder) token leg", () => {
+    const result = gateAndRankLaunchPools(
+      [
+        makePool({
+          address: "risky",
+          tokenY: "Risky111111111111111111111111111111111111111",
+          tokenYSymbol: "RUG",
+          tokenYVerified: false,
+          tokenYFreezeDisabled: false,
+          tokenYHolders: 10,
+        }),
+      ],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "risky")[0]).toContain("token safety");
+  });
+
+  it("ranks admitted pools by 1h fee yield, highest first", () => {
+    const low = makePool({ address: "low", feeYield1hPct: 5 });
+    const hot = makePool({ address: "hot", feeYield1hPct: 20 });
+    const mid = makePool({ address: "mid", feeYield1hPct: 12 });
+    const result = gateAndRankLaunchPools([low, hot, mid], config);
+    const rankedAddresses = result.ranked.map((r: LaunchPoolRank) => r.pool.address);
+    expect(rankedAddresses).toEqual(["hot", "mid", "low"]);
+    expect(result.rejected).toHaveLength(0);
+  });
+});

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -736,15 +736,15 @@ export const updateCommand = new Command("update")
       // process (the lockfile is only liveness-checked). The lockfile is the
       // fallback for `prism dev` runs the scan misses.
       const runningPid =
-        runningEngine?.pid ??
-        (lock !== null && isProcessAlive(lock.pid) ? lock.pid : null) ??
-        null;
+        runningEngine?.pid ?? (lock !== null && isProcessAlive(lock.pid) ? lock.pid : null) ?? null;
       if (runningPid !== null) {
         console.log("");
         console.log(
           `RESTART REQUIRED — the running Prism agent (PID ${runningPid}) is still executing the OLD build.`,
         );
-        console.log("  The new version is installed, verified, and will go live on the next restart.");
+        console.log(
+          "  The new version is installed, verified, and will go live on the next restart.",
+        );
         console.log("  Restart it with:");
         console.log("    systemctl --user restart prism-agent.service   (systemd user service)");
         console.log(`    kill ${runningPid} && prism dev                 (manual/foreground run)`);

--- a/engine/adapter-retry.ts
+++ b/engine/adapter-retry.ts
@@ -208,7 +208,7 @@ export function retryWithBackoff<T>(
           cause !== null &&
           "message" in cause &&
           typeof (cause as { message?: unknown }).message === "string"
-            ? ((cause as { message: string }).message)
+            ? (cause as { message: string }).message
             : String(cause);
         const normalized = new Error(message, { cause });
         // The retry loop reads rate-limit metadata (headers/response/status)

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -336,6 +336,22 @@ function toDiscoveredPool(p: MeteoraPool): DiscoveredPool {
           createdAtMs: p.created_at > 1_000_000_000_000 ? p.created_at : p.created_at * 1000,
         }
       : {}),
+    // 1h fee-yield radar fields (launch mode): optional so pools where the
+    // Data API reports no 1h window (brand-new, zero-activity) stay admitted
+    // to the discovery feed and the launch gate rejects them fail-closed.
+    ...(typeof p.volume?.["1h"] === "number" && Number.isFinite(p.volume["1h"])
+      ? { volume1hUsd: p.volume["1h"] }
+      : {}),
+    ...(typeof p.fees?.["1h"] === "number" && Number.isFinite(p.fees["1h"])
+      ? { fees1hUsd: p.fees["1h"] }
+      : {}),
+    ...(typeof p.fee_tvl_ratio?.["1h"] === "number" && Number.isFinite(p.fee_tvl_ratio["1h"])
+      ? { feeYield1hPct: p.fee_tvl_ratio["1h"] }
+      : {}),
+    ...(typeof p.pool_config?.base_fee_pct === "number" &&
+    Number.isFinite(p.pool_config.base_fee_pct)
+      ? { baseFeePct: p.pool_config.base_fee_pct }
+      : {}),
     tokenXSymbol: tokenX.symbol,
     tokenYSymbol: tokenY.symbol,
     tokenXVerified: tokenX.is_verified,
@@ -3481,6 +3497,44 @@ export const AdapterLive = Layer.effect(
           }
           return merged;
         }),
+
+      // Launch-mode radar: the top fee-yield pools (24h fee/TVL ratio desc)
+      // in ONE page, with the Data API's token-safety metadata attached for
+      // the launch gate. Never fails: any network/parse problem logs a
+      // warning and yields [] — the radar keeps its last ranked snapshot.
+      discoverHotPools: (limit) =>
+        Effect.gen(function* () {
+          const baseUrl =
+            config.meteoraPoolsUrl ||
+            "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=fee_tvl_ratio_24h:desc";
+          const url = new URL(baseUrl);
+          url.searchParams.set("page", "1");
+          url.searchParams.set("page_size", String(Math.min(Math.max(Math.floor(limit), 1), 1000)));
+          url.searchParams.set("filter_by", "is_blacklisted=false");
+          url.searchParams.set("sort_by", "fee_tvl_ratio_24h:desc");
+          const res = yield* Effect.tryPromise({
+            try: () => fetch(url.toString(), { signal: AbortSignal.timeout(15_000) }),
+            catch: (cause) => cause as Error,
+          });
+          if (!res.ok) {
+            logger.warn("Launch radar: hot-pool fetch non-OK", { status: res.status });
+            return [];
+          }
+          const parsed: unknown = yield* Effect.tryPromise({
+            try: () => res.json(),
+            catch: (cause) => cause as Error,
+          });
+          if (!isPoolsEnvelope(parsed)) return [];
+          const valid = parsed.data.filter(isValidPoolShape);
+          return valid.filter((p) => !p.launchpad).map(toDiscoveredPool);
+        }).pipe(
+          Effect.catch((cause) => {
+            logger.warn("Launch radar: hot-pool fetch failed", {
+              error: underlyingErrorMessage(cause),
+            });
+            return Effect.succeed([] as ReadonlyArray<DiscoveredPool>);
+          }),
+        ),
 
       quoteSwapUSDCForToken: (outputMint: string, amountAtomic: bigint) =>
         quoteSwapUSDCForToken(outputMint, amountAtomic).pipe(

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -3502,14 +3502,30 @@ export const AdapterLive = Layer.effect(
       // in ONE page, with the Data API's token-safety metadata attached for
       // the launch gate. Never fails: any network/parse problem logs a
       // warning and yields [] — the radar keeps its last ranked snapshot.
-      discoverHotPools: (limit) =>
+      discoverHotPools: (candidateLimit) =>
         Effect.gen(function* () {
           const baseUrl =
             config.meteoraPoolsUrl ||
             "https://dlmm.datapi.meteora.ag/pools?page=1&page_size=1000&filter_by=is_blacklisted=false&sort_by=fee_tvl_ratio_24h:desc";
-          const url = new URL(baseUrl);
+          let url: URL;
+          try {
+            url = new URL(baseUrl);
+          } catch (cause) {
+            // A malformed METEORA_POOLS_URL must fail open, not become a
+            // sync defect that escapes the fail-open catch below.
+            logger.warn("Launch radar: malformed pools URL", {
+              error: underlyingErrorMessage(cause),
+            });
+            return [];
+          }
           url.searchParams.set("page", "1");
-          url.searchParams.set("page_size", String(Math.min(Math.max(Math.floor(limit), 1), 1000)));
+          // candidateLimit is the UNIVERSE to gate, not the logged top-K —
+          // the launch gate rejects most candidates (age/TVL/safety), so the
+          // radar fetches a wide candidate set and slices top-K after gating.
+          url.searchParams.set(
+            "page_size",
+            String(Math.min(Math.max(Math.floor(candidateLimit), 1), 1000)),
+          );
           url.searchParams.set("filter_by", "is_blacklisted=false");
           url.searchParams.set("sort_by", "fee_tvl_ratio_24h:desc");
           const res = yield* Effect.tryPromise({

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -192,6 +192,9 @@ export interface AppConfig {
   readonly launchScanRefreshIntervalMs?: number;
   /** Top-N launch pools logged per refresh. Default 30 (1..200). */
   readonly launchScanTopK?: number;
+  /** Candidate universe fetched per refresh BEFORE gating (the gate rejects
+   *  most candidates, so fetch wide then slice top-K). Default 500 (1..1000). */
+  readonly launchScanUniverseSize?: number;
   /** Minimum TVL for a launch pool. Default $5K. */
   readonly launchScanMinTvlUsd?: number;
   /** Maximum TVL — above this the pool is established, not a launch. Default $1M. */
@@ -1333,6 +1336,12 @@ const loadConfig = Effect.gen(function* () {
     120_000,
   );
   const launchScanTopK = yield* validatedNumber("LAUNCH_SCAN_TOP_K", 1, 30, 200);
+  const launchScanUniverseSize = yield* validatedNumber(
+    "LAUNCH_SCAN_UNIVERSE_SIZE",
+    1,
+    500,
+    1000,
+  );
   const launchScanMinTvlUsd = yield* validatedNumber("LAUNCH_SCAN_MIN_TVL_USD", 0, 5_000);
   const launchScanMaxTvlUsd = yield* validatedNumber("LAUNCH_SCAN_MAX_TVL_USD", 0, 1_000_000);
   const launchScanMaxAgeHours = yield* validatedNumber("LAUNCH_SCAN_MAX_AGE_HOURS", 1, 6, 72);
@@ -1508,6 +1517,7 @@ const loadConfig = Effect.gen(function* () {
     launchScanEnabled,
     launchScanRefreshIntervalMs,
     launchScanTopK,
+    launchScanUniverseSize,
     launchScanMinTvlUsd,
     launchScanMaxTvlUsd,
     launchScanMaxAgeHours,

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -181,6 +181,31 @@ export interface AppConfig {
   readonly marketScanMinBinStep?: number;
   /** Skip pools with bin step above this. Default 200. */
   readonly marketScanMaxBinStep?: number;
+
+  // ─── Launch-scan mode (hot-DLMM-pool launch radar) ─────────────────────
+  // When enabled, the engine refreshes a discovery snapshot of the hottest
+  // YOUNG DLMM pools (fee-yield-ranked) and runs them through the pure
+  // launch gate. Radar/screening only in v1 — no execution wiring.
+  readonly launchScanEnabled?: boolean;
+  /** How often the launch radar re-discovers and re-gates. Default 2 min;
+   *  minimum 10 s. */
+  readonly launchScanRefreshIntervalMs?: number;
+  /** Top-N launch pools logged per refresh. Default 30 (1..200). */
+  readonly launchScanTopK?: number;
+  /** Minimum TVL for a launch pool. Default $5K. */
+  readonly launchScanMinTvlUsd?: number;
+  /** Maximum TVL — above this the pool is established, not a launch. Default $1M. */
+  readonly launchScanMaxTvlUsd?: number;
+  /** Maximum pool age in hours (from pool creation). Default 6 (1..72). */
+  readonly launchScanMaxAgeHours?: number;
+  /** Minimum 1h volume (USD) for a launch pool. Default $50K. */
+  readonly launchScanMinVolume1hUsd?: number;
+  /** Minimum base fee percent (pool_config.base_fee_pct). Default 1%. */
+  readonly launchScanMinBaseFeePct?: number;
+  /** Skip pools with bin step below this. Default 50. */
+  readonly launchScanMinBinStep?: number;
+  /** Skip pools with bin step above this. Default 200. */
+  readonly launchScanMaxBinStep?: number;
   readonly deployerBlacklistPath: string;
   readonly tokenBlacklistPath: string;
   readonly sqliteDbPath: string;
@@ -1299,6 +1324,26 @@ const loadConfig = Effect.gen(function* () {
   const marketScanMinHolders = yield* validatedNumber("MARKET_SCAN_MIN_HOLDERS", 0, 1000);
   const marketScanMinBinStep = yield* validatedNumber("MARKET_SCAN_MIN_BIN_STEP", 0, 2, 100);
   const marketScanMaxBinStep = yield* validatedNumber("MARKET_SCAN_MAX_BIN_STEP", 1, 200, 2000);
+  const launchScanEnabled = yield* Config.boolean("LAUNCH_SCAN_ENABLED").pipe(
+    Effect.orElseSucceed(() => false),
+  );
+  const launchScanRefreshIntervalMs = yield* validatedNumber(
+    "LAUNCH_SCAN_REFRESH_INTERVAL_MS",
+    10_000,
+    120_000,
+  );
+  const launchScanTopK = yield* validatedNumber("LAUNCH_SCAN_TOP_K", 1, 30, 200);
+  const launchScanMinTvlUsd = yield* validatedNumber("LAUNCH_SCAN_MIN_TVL_USD", 0, 5_000);
+  const launchScanMaxTvlUsd = yield* validatedNumber("LAUNCH_SCAN_MAX_TVL_USD", 0, 1_000_000);
+  const launchScanMaxAgeHours = yield* validatedNumber("LAUNCH_SCAN_MAX_AGE_HOURS", 1, 6, 72);
+  const launchScanMinVolume1hUsd = yield* validatedNumber(
+    "LAUNCH_SCAN_MIN_VOLUME_1H_USD",
+    0,
+    50_000,
+  );
+  const launchScanMinBaseFeePct = yield* validatedNumber("LAUNCH_SCAN_MIN_BASE_FEE_PCT", 0, 1);
+  const launchScanMinBinStep = yield* validatedNumber("LAUNCH_SCAN_MIN_BIN_STEP", 0, 50);
+  const launchScanMaxBinStep = yield* validatedNumber("LAUNCH_SCAN_MAX_BIN_STEP", 1, 200);
   const deployerBlacklistPath = yield* Config.string("DEPLOYER_BLACKLIST_PATH").pipe(
     Effect.orElseSucceed(() => "./engine/data/deployer-blacklist.json"),
   );
@@ -1460,6 +1505,16 @@ const loadConfig = Effect.gen(function* () {
     marketScanMinHolders,
     marketScanMinBinStep,
     marketScanMaxBinStep,
+    launchScanEnabled,
+    launchScanRefreshIntervalMs,
+    launchScanTopK,
+    launchScanMinTvlUsd,
+    launchScanMaxTvlUsd,
+    launchScanMaxAgeHours,
+    launchScanMinVolume1hUsd,
+    launchScanMinBaseFeePct,
+    launchScanMinBinStep,
+    launchScanMaxBinStep,
     deployerBlacklistPath,
     tokenBlacklistPath,
     sqliteDbPath,

--- a/engine/launch-gate.ts
+++ b/engine/launch-gate.ts
@@ -1,0 +1,179 @@
+/** @file Launch gate: turns a hot-DLMM-pool discovery snapshot into a
+ * ranked launch candidate set. Pure and unit-testable — no Effect, no
+ * network.
+ *
+ * v1 is radar/screening only: this gate decides WHICH young pools are hot
+ * enough to surface on the launch radar, ranked by 1h fee yield. It fails
+ * CLOSED on missing launch-critical data (createdAt, 1h fee yield, 1h
+ * volume, base fee) — unlike the market gate, an absent hotness metric is a
+ * rejection, because hotness is the entire point. Token-leg safety reuses
+ * the market gate's leg policy verbatim (fail-open on absent metadata; the
+ * per-pool screen still gates ENTER).
+ */
+
+import type { DiscoveredPool } from "./services.js";
+import { isStableOrSol, marketLegPasses } from "./market-gate.js";
+
+const HOUR_MS = 3_600_000;
+
+export interface LaunchGateConfig {
+  readonly minTvlUsd: number;
+  readonly maxTvlUsd: number;
+  readonly maxAgeHours: number;
+  readonly minVolume1hUsd: number;
+  readonly minBaseFeePct: number;
+  readonly minBinStep: number;
+  readonly maxBinStep: number;
+  /** Max 24h-volume/TVL turnover; above this is wash-trading. */
+  readonly maxVolumeTurnover: number;
+  /** Minimum holders for a non-stable, non-SOL leg (rug/IL pre-filter). */
+  readonly minHolders: number;
+  readonly stablecoinMints: ReadonlySet<string>;
+  /** Current wall-clock ms (injected for determinism/testability). */
+  readonly now: number;
+}
+
+export interface LaunchPoolRank {
+  readonly pool: DiscoveredPool;
+  /** 1h fee/TVL ratio percent (fee_tvl_ratio_1h) — the hotness metric. */
+  readonly feeYield1hPct: number;
+  readonly volume1hUsd: number;
+  /** Rank score: feeYield1hPct (higher = hotter). */
+  readonly score: number;
+  /** Why the pool was admitted (first N flags). */
+  readonly notes: ReadonlyArray<string>;
+}
+
+export interface LaunchGateResult {
+  readonly ranked: ReadonlyArray<LaunchPoolRank>;
+  /** Pools that failed the gate, with the first rejection reason each. */
+  readonly rejected: ReadonlyArray<{ readonly address: string; readonly reason: string }>;
+}
+
+/** Gates and ranks one launch-radar snapshot. Pure; callers feed it the
+ *  adapter's `discoverHotPools` output. */
+export function gateAndRankLaunchPools(
+  pools: ReadonlyArray<DiscoveredPool>,
+  config: LaunchGateConfig,
+): LaunchGateResult {
+  const ranked: LaunchPoolRank[] = [];
+  const rejected: Array<{ readonly address: string; readonly reason: string }> = [];
+
+  for (const pool of pools) {
+    const reject = (reason: string): void => {
+      rejected.push({ address: pool.address, reason });
+    };
+
+    // Fail closed on missing data — hotness is the point.
+    if (pool.feeYield1hPct === undefined || !Number.isFinite(pool.feeYield1hPct)) {
+      reject("missing 1h fee yield");
+      continue;
+    }
+    if (pool.createdAtMs === undefined) {
+      reject("missing createdAt");
+      continue;
+    }
+    if (!Number.isFinite(pool.createdAtMs) || pool.createdAtMs > config.now) {
+      reject(`createdAt ${pool.createdAtMs} in the future`);
+      continue;
+    }
+    const ageHours = (config.now - pool.createdAtMs) / HOUR_MS;
+    if (ageHours > config.maxAgeHours) {
+      reject(`age ${ageHours.toFixed(1)}h > ${config.maxAgeHours}h`);
+      continue;
+    }
+    if (!Number.isFinite(pool.tvlUsd) || pool.tvlUsd < config.minTvlUsd) {
+      reject(`tvl ${pool.tvlUsd} < ${config.minTvlUsd}`);
+      continue;
+    }
+    if (pool.tvlUsd > config.maxTvlUsd) {
+      reject(`tvl ${pool.tvlUsd} > ${config.maxTvlUsd} (established, not a launch)`);
+      continue;
+    }
+    if (
+      pool.volume1hUsd === undefined ||
+      !Number.isFinite(pool.volume1hUsd) ||
+      pool.volume1hUsd < config.minVolume1hUsd
+    ) {
+      reject(`1h volume ${pool.volume1hUsd} < ${config.minVolume1hUsd}`);
+      continue;
+    }
+    if (
+      pool.baseFeePct === undefined ||
+      !Number.isFinite(pool.baseFeePct) ||
+      pool.baseFeePct < config.minBaseFeePct
+    ) {
+      reject(`base fee ${pool.baseFeePct} < ${config.minBaseFeePct}%`);
+      continue;
+    }
+    if (
+      !Number.isInteger(pool.binStep) ||
+      pool.binStep < config.minBinStep ||
+      pool.binStep > config.maxBinStep
+    ) {
+      reject(`binStep ${pool.binStep} outside [${config.minBinStep}, ${config.maxBinStep}]`);
+      continue;
+    }
+    // Wash-turnover guard: 24h volume/TVL must land in (0, max].
+    if (!Number.isFinite(pool.volume24hUsd) || pool.volume24hUsd <= 0) {
+      reject("no 24h volume (cannot compute turnover)");
+      continue;
+    }
+    const volumeTurnover = pool.volume24hUsd / pool.tvlUsd;
+    if (volumeTurnover > config.maxVolumeTurnover) {
+      reject(`volume turnover ${volumeTurnover.toFixed(1)} > ${config.maxVolumeTurnover} (wash)`);
+      continue;
+    }
+    // Token-leg safety, same policy as the market gate.
+    const legs = [
+      {
+        mint: pool.tokenX,
+        symbol: pool.tokenXSymbol,
+        verified: pool.tokenXVerified,
+        freezeDisabled: pool.tokenXFreezeDisabled,
+        holders: pool.tokenXHolders,
+      },
+      {
+        mint: pool.tokenY,
+        symbol: pool.tokenYSymbol,
+        verified: pool.tokenYVerified,
+        freezeDisabled: pool.tokenYFreezeDisabled,
+        holders: pool.tokenYHolders,
+      },
+    ];
+    let legRejected = false;
+    for (const leg of legs) {
+      if (
+        !marketLegPasses(
+          {
+            isStableOrSol: isStableOrSol(leg.mint, config.stablecoinMints),
+            verified: leg.verified,
+            freezeDisabled: leg.freezeDisabled,
+            holders: leg.holders,
+          },
+          config.minHolders,
+        )
+      ) {
+        reject(`leg ${leg.symbol ?? leg.mint} fails token safety`);
+        legRejected = true;
+        break;
+      }
+    }
+    if (legRejected) continue;
+
+    const notes: string[] = [
+      `age ${ageHours.toFixed(1)}h`,
+      `turnover ${volumeTurnover.toFixed(2)}`,
+    ];
+    ranked.push({
+      pool,
+      feeYield1hPct: pool.feeYield1hPct,
+      volume1hUsd: pool.volume1hUsd,
+      score: pool.feeYield1hPct,
+      notes,
+    });
+  }
+
+  ranked.sort((a, b) => b.score - a.score);
+  return { ranked, rejected };
+}

--- a/engine/launch-gate.ts
+++ b/engine/launch-gate.ts
@@ -15,6 +15,10 @@ import type { DiscoveredPool } from "./services.js";
 import { isStableOrSol, marketLegPasses } from "./market-gate.js";
 
 const HOUR_MS = 3_600_000;
+// The pool's createdAt comes from the Meteora API clock, config.now from the
+// engine host — allow a small skew so a pool created moments ago on the API
+// clock is not rejected as "in the future" when the host clock lags.
+const CLOCK_SKEW_MS = 60_000;
 
 export interface LaunchGateConfig {
   readonly minTvlUsd: number;
@@ -73,11 +77,11 @@ export function gateAndRankLaunchPools(
       reject("missing createdAt");
       continue;
     }
-    if (!Number.isFinite(pool.createdAtMs) || pool.createdAtMs > config.now) {
+    if (!Number.isFinite(pool.createdAtMs) || pool.createdAtMs > config.now + CLOCK_SKEW_MS) {
       reject(`createdAt ${pool.createdAtMs} in the future`);
       continue;
     }
-    const ageHours = (config.now - pool.createdAtMs) / HOUR_MS;
+    const ageHours = Math.max(0, config.now - pool.createdAtMs) / HOUR_MS;
     if (ageHours > config.maxAgeHours) {
       reject(`age ${ageHours.toFixed(1)}h > ${config.maxAgeHours}h`);
       continue;

--- a/engine/market-gate.ts
+++ b/engine/market-gate.ts
@@ -44,7 +44,7 @@ export interface MarketGateResult {
   readonly rejected: ReadonlyArray<{ readonly address: string; readonly reason: string }>;
 }
 
-function isStableOrSol(mint: string, stablecoinMints: ReadonlySet<string>): boolean {
+export function isStableOrSol(mint: string, stablecoinMints: ReadonlySet<string>): boolean {
   return mint === SOL_MINT || stablecoinMints.has(mint);
 }
 

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -37,6 +37,7 @@ import { EntryPrepLive } from "./entry-prep-service.js";
 import { shouldDiscoverPools } from "./pool-policy.js";
 import { advanceScreenedCandidates } from "./candidate-discovery.js";
 import { gateAndRankMarketPools, type MarketPoolRank } from "./market-gate.js";
+import { gateAndRankLaunchPools } from "./launch-gate.js";
 import { transitionCandidate } from "./candidate-policy.js";
 import { getPrismUserConfigDir } from "./paths.js";
 
@@ -3942,6 +3943,59 @@ export const program = Effect.gen(function* () {
       });
     });
 
+  // ─── Launch-mode radar refresh ─────────────────────────────────────────
+  // When LAUNCH_SCAN_ENABLED, re-runs the launch gate on
+  // LAUNCH_SCAN_REFRESH_INTERVAL_MS (clamped to >= 10s): fetch the hot-pool
+  // shortlist (sorted by 24h fee/TVL ratio desc), gate it by age / TVL band /
+  // 1h volume / base fee / bin step / token safety, and log the top-K radar
+  // (fee yield, 1h volume, age). Discovery + screening ONLY — v1 wires no
+  // execution lane. Every failure path fails open and the default
+  // (launchScanEnabled=false) path is behavior-identical.
+  let lastLaunchScanAt = 0;
+  const refreshLaunchScan = (now: number): Effect.Effect<void, never> =>
+    Effect.gen(function* () {
+      if (config.launchScanEnabled !== true) return;
+      if (adapter.discoverHotPools === undefined) {
+        logger.warn("Launch radar: adapter does not expose discoverHotPools — disabled");
+        return;
+      }
+      const intervalMs = Math.max(config.launchScanRefreshIntervalMs ?? 120_000, 10_000);
+      if (now - lastLaunchScanAt < intervalMs) return;
+      lastLaunchScanAt = now;
+      const discovered = yield* adapter.discoverHotPools(config.launchScanTopK ?? 30);
+      if (discovered.length === 0) {
+        logger.warn("Launch radar: hot-pool fetch returned nothing");
+        return;
+      }
+      const { ranked } = gateAndRankLaunchPools(discovered, {
+        minTvlUsd: config.launchScanMinTvlUsd ?? 5_000,
+        maxTvlUsd: config.launchScanMaxTvlUsd ?? 1_000_000,
+        maxAgeHours: config.launchScanMaxAgeHours ?? 6,
+        minVolume1hUsd: config.launchScanMinVolume1hUsd ?? 50_000,
+        minBaseFeePct: config.launchScanMinBaseFeePct ?? 1,
+        minBinStep: config.launchScanMinBinStep ?? 50,
+        maxBinStep: config.launchScanMaxBinStep ?? 200,
+        maxVolumeTurnover: 50,
+        minHolders: 1000,
+        stablecoinMints: config.stablecoinMints ?? new Set<string>(),
+        now,
+      });
+      logger.info("Launch radar", {
+        universe: discovered.length,
+        admitted: ranked.length,
+        rejected: discovered.length - ranked.length,
+        top: ranked.slice(0, config.launchScanTopK ?? 30).map((r) => ({
+          pool: `${r.pool.tokenXSymbol ?? "?"}/${r.pool.tokenYSymbol ?? "?"}`,
+          feeYield1hPct: r.feeYield1hPct,
+          volume1hUsd: r.volume1hUsd,
+          ageHours:
+            r.pool.createdAtMs === undefined
+              ? null
+              : Math.max(0, (now - r.pool.createdAtMs) / 3_600_000),
+        })),
+      });
+    });
+
   // ─── Rotation metrics (session-scoped) ─────────────────────────────────
   // Counters since process start for the high-frequency-rotation profile:
   // ENTER/EXIT executions and the average age of tracked positions. Logged
@@ -3972,6 +4026,7 @@ export const program = Effect.gen(function* () {
       yield* refreshAutonomousCandidates(scanCount);
       yield* refreshFallenAngelCandidates(scanCount);
       yield* refreshMarketUniverse(Date.now());
+      yield* refreshLaunchScan(Date.now());
       // The universe refresh may have rebuilt the market top-K — make the
       // fresh active set visible to the "no pools" check and the scan loop.
       rebuildPoolsToScan();

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -3987,6 +3987,7 @@ export const program = Effect.gen(function* () {
         admitted: ranked.length,
         rejected: discovered.length - ranked.length,
         top: ranked.slice(0, config.launchScanTopK ?? 30).map((r) => ({
+          address: r.pool.address,
           pool: `${r.pool.tokenXSymbol ?? "?"}/${r.pool.tokenYSymbol ?? "?"}`,
           feeYield1hPct: r.feeYield1hPct,
           volume1hUsd: r.volume1hUsd,

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -3962,7 +3962,9 @@ export const program = Effect.gen(function* () {
       const intervalMs = Math.max(config.launchScanRefreshIntervalMs ?? 120_000, 10_000);
       if (now - lastLaunchScanAt < intervalMs) return;
       lastLaunchScanAt = now;
-      const discovered = yield* adapter.discoverHotPools(config.launchScanTopK ?? 30);
+      const discovered = yield* adapter.discoverHotPools(
+        config.launchScanUniverseSize ?? 500,
+      );
       if (discovered.length === 0) {
         logger.warn("Launch radar: hot-pool fetch returned nothing");
         return;

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -154,7 +154,7 @@ export interface AdapterApi {
    * last ranked set. Optional so test mocks compile unchanged.
    */
   readonly discoverHotPools?: (
-    limit: number,
+    candidateLimit: number,
   ) => Effect.Effect<ReadonlyArray<DiscoveredPool>, never>;
   readonly getPositions: (
     poolAddress: string,

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -43,6 +43,12 @@ export interface DiscoveredPool {
   readonly fees24hUsd: number;
   readonly apr: number;
   readonly binStep: number;
+  /** 1h fee/volume/ratio from the Data API list payload. Optional so legacy
+   *  mappers/tests compile unchanged; the launch radar gate needs them. */
+  readonly volume1hUsd?: number;
+  readonly fees1hUsd?: number;
+  readonly feeYield1hPct?: number;
+  readonly baseFeePct?: number;
   readonly tokenX: string;
   readonly tokenY: string;
   readonly createdAtMs?: number;
@@ -139,6 +145,16 @@ export interface AdapterApi {
    */
   readonly discoverPoolsTopPages?: (
     pages: number,
+  ) => Effect.Effect<ReadonlyArray<DiscoveredPool>, never>;
+  /**
+   * Discover the hottest DLMM pools for the launch radar — the top of the
+   * fee-yield-ranked universe (1h fee/TVL ratio). Never fails: any
+   * page/network/parse error logs a warning and returns [] (fail-open,
+   * exactly like discoverPoolsTopPages) so the radar falls back to its
+   * last ranked set. Optional so test mocks compile unchanged.
+   */
+  readonly discoverHotPools?: (
+    limit: number,
   ) => Effect.Effect<ReadonlyArray<DiscoveredPool>, never>;
   readonly getPositions: (
     poolAddress: string,


### PR DESCRIPTION
Launch Mode v1 from the $10→1M compounding research: a hot-DLMM-pool **radar** that surfaces the highest fee-yield pools on a sub-minute cadence. **Discovery + screening only — no execution** (the launch risk lane, time-box/decay exits, single-sided entry are PR 2).

## What
- **`engine/launch-gate.ts`** (pure): fail-closed admission — age ≤ `maxAgeHours`, TVL band, min 1h volume, min base fee, bin-step band, wash-turnover cap, token-safety legs (reuses market-gate helpers); ranked by 1h fee yield
- **`discoverHotPools`** (optional AdapterApi member): `/pools?sort_by=fee_tvl_ratio_24h:desc`, fail-open ([] + warn), launchpad filtered; payload paths **curl-verified** (volume/fees/fee_tvl_ratio are nested `{30m..24h}` objects, `base_fee_pct` under `pool_config`, `created_at` ms)
- **10 `LAUNCH_SCAN_*` settings** (off by default; refresh min 10s; feasibility defaults: minTvl $5k, maxTvl $1M, maxAge 6h, minVolume1h $50k, minBaseFeePct 1%, binStep 50–200)
- **`refreshLaunchScan`** radar per cycle: interval-gated, logs top-K with feeYield1hPct/volume1hUsd/age. Default path behavior-identical.

## Why this matters
Live Meteora data: the >5%/day fee-yield universe is entirely young pump.fun launches below Prism's current TVL floors — today's leaderboard (174%/day, 59%/day, 36%/day pools) is invisible to the engine. This radar is the data path; the execution lane is next.

## Verification
12 launch-gate unit tests (admit/reject matrix + ranking), full suite 1596/1596, tsc 0, oxlint 0 diagnostics (Effect rules enforced: error channels typed `Error`).

Built with 3 parallel subagents: API ground-truth research + two implementation slices, contract-negotiated optional signature (precedent: `getSwapStatus?`).

## Summary by Sourcery

Introduce a configurable launch-mode radar that periodically discovers, gates, and ranks hot young DLMM pools for monitoring only, without affecting existing execution behavior.

New Features:
- Add launch-scan configuration options to control radar enablement, refresh cadence, pool filters, and logging depth.
- Extend the adapter API with a discoverHotPools endpoint and wire its output into a new pure launch gate that ranks pools by 1h fee yield.
- Integrate the launch radar refresh into the main engine scan loop to log top-ranked launch pools with key fee-yield and volume metrics.

Enhancements:
- Share stablecoin/SOL token classification logic from the market gate for reuse in the launch gate.
- Minor formatting and style cleanups in CLI and benchmark tests for clearer expectations and output.

Tests:
- Add unit tests for the launch gate covering admission, rejection reasons, and ranking order for various pool scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a launch-pool radar that discovers, filters, and ranks promising pools by one-hour fee yield.
  - Added configurable launch-scan settings, including refresh rate, TVL, age, volume, fee, and bin-step limits.
  - Launch scans now display ranked results with fee yield, trading volume, and pool age.
  - Added safeguards to exclude stale, unsafe, low-quality, or incomplete pool data.
  - Discovery failures now fail safely with warnings rather than interrupting scans.

- **Tests**
  - Added coverage for pool eligibility checks and fee-yield ranking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->