### PR TITLE
feat(engine): launch-mode execution lane — time-boxed launch positions

### DIFF
--- a/bench/launch-position.test.ts
+++ b/bench/launch-position.test.ts
@@ -1,0 +1,211 @@
+/** Launch-position policy unit tests (Slice A): every exit trigger at its
+ * boundary, non-fires below thresholds, unknown-value null handling, and
+ * entry-sizing caps. */
+import { describe, it, expect } from "vitest";
+import {
+  launchPositionExit,
+  launchEntrySizeUsd,
+  type LaunchPositionExitInput,
+} from "../engine/launch-position.js";
+
+const NOW = 1_800_000_000_000;
+const HOUR_MS = 3.6e6;
+
+/** Healthy base state: 1h old, fees well above the 10% floor, no drawdown,
+ * healthy fee/IL ratio — nothing should fire. */
+function baseInput(overrides: Partial<LaunchPositionExitInput> = {}): LaunchPositionExitInput {
+  return {
+    createdAtMs: NOW - HOUR_MS,
+    now: NOW,
+    timeboxHours: 6,
+    volumeDecayExitPct: 0.1,
+    drawdownPct: 0.25,
+    currentFees1hUsd: 20,
+    peakFees1hUsd: 100,
+    currentValueUsd: 100,
+    peakValueUsd: 100,
+    feeIlRatio: 2,
+    ...overrides,
+  };
+}
+
+describe("launchPositionExit — timebox", () => {
+  it("fires at exactly timeboxHours", () => {
+    const r = launchPositionExit(
+      baseInput({ createdAtMs: NOW - 6 * HOUR_MS, currentFees1hUsd: 50 }),
+    );
+    expect(r).toEqual({ exit: true, reason: "timebox" });
+  });
+
+  it("fires past the timebox", () => {
+    const r = launchPositionExit(
+      baseInput({ createdAtMs: NOW - 7 * HOUR_MS, currentFees1hUsd: 50 }),
+    );
+    expect(r).toEqual({ exit: true, reason: "timebox" });
+  });
+
+  it("does not fire just below the timebox", () => {
+    const r = launchPositionExit(baseInput({ createdAtMs: NOW - 6 * HOUR_MS + 1 }));
+    expect(r.exit).toBe(false);
+  });
+
+  it("does not fire timebox for a young position (decay may still fire)", () => {
+    // Age-based exit requires the timebox to elapse; a young position whose
+    // fees collapsed still exits via volume-decay, not timebox.
+    const r = launchPositionExit(baseInput({ currentFees1hUsd: 0 }));
+    expect(r).toEqual({ exit: true, reason: "volume-decay" });
+  });
+});
+
+describe("launchPositionExit — volume decay", () => {
+  it("fires when current 1h fees fall below 10% of peak", () => {
+    const r = launchPositionExit(baseInput({ currentFees1hUsd: 9.99 }));
+    expect(r).toEqual({ exit: true, reason: "volume-decay" });
+  });
+
+  it("does not fire at exactly 10% of peak (strict <)", () => {
+    const r = launchPositionExit(baseInput({ currentFees1hUsd: 10 }));
+    expect(r.exit).toBe(false);
+  });
+
+  it("does not fire above the 10% floor", () => {
+    const r = launchPositionExit(baseInput({ currentFees1hUsd: 50 }));
+    expect(r.exit).toBe(false);
+  });
+
+  it("does not fire when peak fees are unknown", () => {
+    const r = launchPositionExit(baseInput({ currentFees1hUsd: 1, peakFees1hUsd: null }));
+    expect(r.exit).toBe(false);
+  });
+
+  it("does not fire when current fees are unknown", () => {
+    const r = launchPositionExit(baseInput({ currentFees1hUsd: null }));
+    expect(r.exit).toBe(false);
+  });
+
+  it("does not fire when peak fees are zero", () => {
+    const r = launchPositionExit(baseInput({ currentFees1hUsd: 0, peakFees1hUsd: 0 }));
+    expect(r.exit).toBe(false);
+  });
+});
+
+describe("launchPositionExit — drawdown", () => {
+  it("fires at exactly 25% drawdown", () => {
+    const r = launchPositionExit(baseInput({ currentValueUsd: 75 }));
+    expect(r).toEqual({ exit: true, reason: "drawdown" });
+  });
+
+  it("fires deeper than 25% drawdown", () => {
+    const r = launchPositionExit(baseInput({ currentValueUsd: 50 }));
+    expect(r).toEqual({ exit: true, reason: "drawdown" });
+  });
+
+  it("does not fire just above the 25% line", () => {
+    const r = launchPositionExit(baseInput({ currentValueUsd: 75.01 }));
+    expect(r.exit).toBe(false);
+  });
+
+  it("does not fire when peak value is unknown", () => {
+    const r = launchPositionExit(baseInput({ currentValueUsd: 10, peakValueUsd: null }));
+    expect(r.exit).toBe(false);
+  });
+});
+
+describe("launchPositionExit — fee/IL floor", () => {
+  it("fires below the 0.5 floor", () => {
+    const r = launchPositionExit(baseInput({ feeIlRatio: 0.4999 }));
+    expect(r).toEqual({ exit: true, reason: "fee-il" });
+  });
+
+  it("does not fire at exactly 0.5 (floor is exclusive)", () => {
+    const r = launchPositionExit(baseInput({ feeIlRatio: 0.5 }));
+    expect(r.exit).toBe(false);
+  });
+
+  it("does not fire above the floor", () => {
+    const r = launchPositionExit(baseInput({ feeIlRatio: 1.2 }));
+    expect(r.exit).toBe(false);
+  });
+
+  it("does not fire when the ratio is unknown", () => {
+    const r = launchPositionExit(baseInput({ feeIlRatio: null }));
+    expect(r.exit).toBe(false);
+  });
+});
+
+describe("launchPositionExit — rule priority & healthy hold", () => {
+  it("timebox wins when several rules fire at once", () => {
+    const r = launchPositionExit(
+      baseInput({
+        createdAtMs: NOW - 10 * HOUR_MS, // timebox
+        currentFees1hUsd: 1, // decay
+        currentValueUsd: 10, // drawdown
+        feeIlRatio: 0.1, // fee-il
+      }),
+    );
+    expect(r).toEqual({ exit: true, reason: "timebox" });
+  });
+
+  it("decay wins over drawdown/fee-il when timebox has not elapsed", () => {
+    const r = launchPositionExit(
+      baseInput({
+        currentFees1hUsd: 5, // decay
+        currentValueUsd: 10, // drawdown
+        feeIlRatio: 0.1, // fee-il
+      }),
+    );
+    expect(r).toEqual({ exit: true, reason: "volume-decay" });
+  });
+
+  it("drawdown wins over fee-il when both are below their lines", () => {
+    const r = launchPositionExit(baseInput({ currentValueUsd: 60, feeIlRatio: 0.1 }));
+    expect(r).toEqual({ exit: true, reason: "drawdown" });
+  });
+
+  it("holds when everything is healthy and nulls are absent", () => {
+    const r = launchPositionExit(baseInput());
+    expect(r).toEqual({ exit: false, reason: null });
+  });
+
+  it("holds with all optional signals unknown (timebox backstops later)", () => {
+    const r = launchPositionExit(
+      baseInput({
+        currentFees1hUsd: null,
+        peakFees1hUsd: null,
+        peakValueUsd: null,
+        feeIlRatio: null,
+      }),
+    );
+    expect(r).toEqual({ exit: false, reason: null });
+  });
+});
+
+describe("launchEntrySizeUsd", () => {
+  it("caps at maxSizeUsd when it is the smallest term", () => {
+    expect(launchEntrySizeUsd({ walletUsd: 1_000, poolTvlUsd: 100_000, maxSizeUsd: 100 })).toBe(
+      100,
+    );
+  });
+
+  it("caps at 0.005 x pool TVL when that is the smallest term", () => {
+    expect(
+      launchEntrySizeUsd({ walletUsd: 1_000_000, poolTvlUsd: 10_000, maxSizeUsd: 1_000 }),
+    ).toBe(50);
+  });
+
+  it("caps at 0.5 x wallet when that is the smallest term", () => {
+    expect(launchEntrySizeUsd({ walletUsd: 100, poolTvlUsd: 10_000_000, maxSizeUsd: 1_000 })).toBe(
+      50,
+    );
+  });
+
+  it("floors at 0 for a negative wallet", () => {
+    expect(launchEntrySizeUsd({ walletUsd: -100, poolTvlUsd: 10_000_000, maxSizeUsd: 1_000 })).toBe(
+      0,
+    );
+  });
+
+  it("floors at 0 for a negative TVL", () => {
+    expect(launchEntrySizeUsd({ walletUsd: 1_000, poolTvlUsd: -1, maxSizeUsd: 100 })).toBe(0);
+  });
+});

--- a/bench/launch-position.test.ts
+++ b/bench/launch-position.test.ts
@@ -109,6 +109,11 @@ describe("launchPositionExit — drawdown", () => {
     const r = launchPositionExit(baseInput({ currentValueUsd: 10, peakValueUsd: null }));
     expect(r.exit).toBe(false);
   });
+
+  it("is disabled when drawdownPct is 0 (0 = off convention)", () => {
+    const r = launchPositionExit(baseInput({ currentValueUsd: 10, drawdownPct: 0 }));
+    expect(r.exit).toBe(false);
+  });
 });
 
 describe("launchPositionExit — fee/IL floor", () => {

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -209,6 +209,28 @@ export interface AppConfig {
   readonly launchScanMinBinStep?: number;
   /** Skip pools with bin step above this. Default 200. */
   readonly launchScanMaxBinStep?: number;
+
+  // ─── Launch Mode v2: execution lane ──────────────────────────────────────
+  // Launch-gated pools flow through a separate time-boxed lane with
+  // launch-specific exits. OFF by default — only effective when
+  // launchScanEnabled is also on.
+  /** Master switch for launch EXECUTION (radar-only v1 stays OFF here).
+   *  Default false; only effective when launchScanEnabled is true. */
+  readonly launchExecutionEnabled?: boolean;
+  /** Max simultaneous launch positions portfolio-wide (separate counter
+   *  from MAX_OPEN_POSITIONS). Default 3 (1..30). */
+  readonly launchMaxOpenPositions?: number;
+  /** Hard USD cap per launch entry (the sizing formula's cap term).
+   *  Default $100 (min 10). */
+  readonly launchPositionMaxSizeUsd?: number;
+  /** Launch position time-box: exit when held this many hours regardless of
+   *  P&L. Default 6 (1..72). */
+  readonly launchTimeboxHours?: number;
+  /** Volume-decay exit: exit when current 1h fees fall below this fraction
+   *  of the position's observed peak. Default 0.1 (10%). */
+  readonly launchVolumeDecayExitPct?: number;
+  /** Hard drawdown stop from the position's peak value. Default 0.25. */
+  readonly launchExitDrawdownPct?: number;
   readonly deployerBlacklistPath: string;
   readonly tokenBlacklistPath: string;
   readonly sqliteDbPath: string;
@@ -1336,12 +1358,7 @@ const loadConfig = Effect.gen(function* () {
     120_000,
   );
   const launchScanTopK = yield* validatedNumber("LAUNCH_SCAN_TOP_K", 1, 30, 200);
-  const launchScanUniverseSize = yield* validatedNumber(
-    "LAUNCH_SCAN_UNIVERSE_SIZE",
-    1,
-    500,
-    1000,
-  );
+  const launchScanUniverseSize = yield* validatedNumber("LAUNCH_SCAN_UNIVERSE_SIZE", 1, 500, 1000);
   const launchScanMinTvlUsd = yield* validatedNumber("LAUNCH_SCAN_MIN_TVL_USD", 0, 5_000);
   const launchScanMaxTvlUsd = yield* validatedNumber("LAUNCH_SCAN_MAX_TVL_USD", 0, 1_000_000);
   const launchScanMaxAgeHours = yield* validatedNumber("LAUNCH_SCAN_MAX_AGE_HOURS", 1, 6, 72);
@@ -1353,6 +1370,24 @@ const loadConfig = Effect.gen(function* () {
   const launchScanMinBaseFeePct = yield* validatedNumber("LAUNCH_SCAN_MIN_BASE_FEE_PCT", 0, 1);
   const launchScanMinBinStep = yield* validatedNumber("LAUNCH_SCAN_MIN_BIN_STEP", 0, 50);
   const launchScanMaxBinStep = yield* validatedNumber("LAUNCH_SCAN_MAX_BIN_STEP", 1, 200);
+
+  // ─── Launch Mode v2: execution lane ───────────────────────────────────────
+  // Launch EXECUTION is opt-in on top of the launch radar; both switches must
+  // be on for the lane to exist (Slice B wiring).
+  const launchExecutionEnabled = yield* Config.boolean("LAUNCH_EXECUTION_ENABLED").pipe(
+    Effect.orElseSucceed(() => false),
+  );
+  const launchMaxOpenPositions = yield* validatedNumber("LAUNCH_MAX_OPEN_POSITIONS", 1, 3, 30);
+  const launchPositionMaxSizeUsd = yield* validatedNumber("LAUNCH_POSITION_MAX_SIZE_USD", 10, 100);
+  const launchTimeboxHours = yield* validatedNumber("LAUNCH_TIMEBOX_HOURS", 1, 6, 72);
+  const launchVolumeDecayExitPct = yield* validatedNumber(
+    "LAUNCH_VOLUME_DECAY_EXIT_PCT",
+    0,
+    0.1,
+    1,
+  );
+  const launchExitDrawdownPct = yield* validatedNumber("LAUNCH_EXIT_DRAWDOWN_PCT", 0, 0.25, 1);
+
   const deployerBlacklistPath = yield* Config.string("DEPLOYER_BLACKLIST_PATH").pipe(
     Effect.orElseSucceed(() => "./engine/data/deployer-blacklist.json"),
   );
@@ -1525,6 +1560,12 @@ const loadConfig = Effect.gen(function* () {
     launchScanMinBaseFeePct,
     launchScanMinBinStep,
     launchScanMaxBinStep,
+    launchExecutionEnabled,
+    launchMaxOpenPositions,
+    launchPositionMaxSizeUsd,
+    launchTimeboxHours,
+    launchVolumeDecayExitPct,
+    launchExitDrawdownPct,
     deployerBlacklistPath,
     tokenBlacklistPath,
     sqliteDbPath,

--- a/engine/launch-position.ts
+++ b/engine/launch-position.ts
@@ -67,6 +67,7 @@ export function launchPositionExit(input: LaunchPositionExitInput): LaunchPositi
   }
 
   if (
+    input.drawdownPct > 0 &&
     input.peakValueUsd !== null &&
     input.currentValueUsd <= input.peakValueUsd * (1 - input.drawdownPct)
   ) {

--- a/engine/launch-position.ts
+++ b/engine/launch-position.ts
@@ -1,0 +1,95 @@
+/**
+ * Launch Mode v2 — pure launch-lane policy (Slice A).
+ *
+ * Launch-gated pools run on a separate time-boxed execution lane with
+ * launch-specific exits. This module is deliberately pure: every input is
+ * passed in, nothing is imported, no state is kept — it is unit-testable in
+ * isolation (see bench/launch-position.test.ts).
+ */
+
+export interface LaunchPositionExitInput {
+  /** Position open timestamp (ms epoch). */
+  createdAtMs: number;
+  /** Current time (ms epoch). */
+  now: number;
+  /** Time-box: exit once the position reaches this age. Hours. */
+  timeboxHours: number;
+  /** Exit when current 1h fees fall below this fraction of the observed peak. */
+  volumeDecayExitPct: number;
+  /** Hard stop: exit when value drops to <= (1 - this) of peak value. */
+  drawdownPct: number;
+  /** Current 1h fees in USD (measured datapi only upstream); null if unknown. */
+  currentFees1hUsd: number | null;
+  /** Observed peak 1h fees in USD; null if never measured. */
+  peakFees1hUsd: number | null;
+  /** Current position value in USD. */
+  currentValueUsd: number;
+  /** Peak position value in USD (position.highestValueUsd); null if unknown. */
+  peakValueUsd: number | null;
+  /** Fee/IL ratio from metrics; null if unknown. */
+  feeIlRatio: number | null;
+}
+
+export type LaunchExitReason = "timebox" | "volume-decay" | "drawdown" | "fee-il";
+
+export interface LaunchPositionExitResult {
+  exit: boolean;
+  reason: LaunchExitReason | null;
+}
+
+const HOUR_MS = 3.6e6;
+
+/**
+ * Evaluate the four independent launch exit rules; the first hit wins.
+ *
+ * - timebox:      ageHours >= timeboxHours
+ * - volume-decay: peak and current fees known, peak > 0, and
+ *                 current < peak * volumeDecayExitPct
+ * - drawdown:     peak value known and current <= peak * (1 - drawdownPct)
+ * - fee-il:       ratio known and < 0.5 (the conservative lane's floor)
+ *
+ * Unknown values (null peak/fees) never fire their rule — the timebox stays
+ * the backstop for data-starved positions.
+ */
+export function launchPositionExit(input: LaunchPositionExitInput): LaunchPositionExitResult {
+  const ageHours = (input.now - input.createdAtMs) / HOUR_MS;
+  if (ageHours >= input.timeboxHours) {
+    return { exit: true, reason: "timebox" };
+  }
+
+  if (
+    input.peakFees1hUsd !== null &&
+    input.currentFees1hUsd !== null &&
+    input.peakFees1hUsd > 0 &&
+    input.currentFees1hUsd < input.peakFees1hUsd * input.volumeDecayExitPct
+  ) {
+    return { exit: true, reason: "volume-decay" };
+  }
+
+  if (
+    input.peakValueUsd !== null &&
+    input.currentValueUsd <= input.peakValueUsd * (1 - input.drawdownPct)
+  ) {
+    return { exit: true, reason: "drawdown" };
+  }
+
+  if (input.feeIlRatio !== null && input.feeIlRatio < 0.5) {
+    return { exit: true, reason: "fee-il" };
+  }
+
+  return { exit: false, reason: null };
+}
+
+export interface LaunchEntrySizeInput {
+  walletUsd: number;
+  poolTvlUsd: number;
+  maxSizeUsd: number;
+}
+
+/**
+ * Launch entry sizing: min(maxSizeUsd, 0.005 x pool TVL, 0.5 x wallet),
+ * floored at 0 so degenerate/negative inputs never size a position.
+ */
+export function launchEntrySizeUsd(input: LaunchEntrySizeInput): number {
+  return Math.max(0, Math.min(input.maxSizeUsd, 0.005 * input.poolTvlUsd, 0.5 * input.walletUsd));
+}

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -4057,11 +4057,15 @@ export const program = Effect.gen(function* () {
         now,
       });
       // v2 execution lane: the admitted radar set becomes the executable
-      // launch pool set. Only when BOTH flags are on — the v1 radar-only
-      // path leaves launchScanPools empty and behavior-identical.
+      // launch pool set, bounded to the top-K by fee yield so the per-cycle
+      // RPC/decision cost stays proportional to LAUNCH_SCAN_TOP_K, not the
+      // full admitted universe. Only when BOTH flags are on — the v1
+      // radar-only path leaves launchScanPools empty and behavior-identical.
       if (config.launchExecutionEnabled === true) {
         launchScanPools.clear();
-        for (const r of ranked) launchScanPools.add(r.pool.address);
+        for (const r of ranked.slice(0, config.launchScanTopK ?? 30)) {
+          launchScanPools.add(r.pool.address);
+        }
       }
       logger.info("Launch radar", {
         universe: discovered.length,
@@ -5354,8 +5358,10 @@ export const program = Effect.gen(function* () {
         // deterministic exit with the same precedence as the FA lifecycle.
         let launchLifecycle: { reasoning: string } | null = null;
         if (
-          config.launchScanEnabled === true &&
-          config.launchExecutionEnabled === true &&
+          // Launch exits run whenever a stored position is a launch position —
+          // INDEPENDENT of the entry flags: an operator disabling the lane
+          // must not silently remove the time-box/decay/drawdown protection
+          // from positions that are already open.
           pos.positionMode === "launch"
         ) {
           const now = Date.now();
@@ -5391,7 +5397,10 @@ export const program = Effect.gen(function* () {
             currentFees1hUsd,
             peakFees1hUsd,
             currentValueUsd: pos.currentValueUsd,
-            peakValueUsd: pos.highestValueUsd,
+            // Seed the drawdown peak from the deposit: highestValueUsd stays
+            // null until the position appreciates, so an initial 25% loss
+            // would otherwise never trip the drawdown gate.
+            peakValueUsd: pos.highestValueUsd ?? pos.depositedUsd,
             // Fee-purity: a modeled ratio (gecko/heuristic, feeIlRatioKnown
             // false) must never fire the launch fee-il exit — null skips the
             // rule, mirroring the normal chain's feeIlRatioKnown guard.
@@ -7039,6 +7048,12 @@ export const program = Effect.gen(function* () {
                   const originalAction = decision.action;
                   const deterministicReasoning = decision.reasoning;
                   decision = validation.adjustedDecision;
+                  // Preserve the launch lane marker: an advisor that echoes or
+                  // resizes a launch ENTER must not silently drop positionMode
+                  // — the launch timebox/decay/drawdown exits key off it.
+                  if (preApplyDecision.positionMode !== undefined && decision.action === "ENTER") {
+                    decision = { ...decision, positionMode: preApplyDecision.positionMode };
+                  }
                   if (
                     originalAction === "EXIT" &&
                     decision.action === "EXIT" &&

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -3596,6 +3596,12 @@ export const program = Effect.gen(function* () {
           recentPnlUsd,
           poolAddress: candidate.poolAddress,
           activeBinId: candidate.pool.activeBinId,
+          // Launch ENTERs are governed by their own launchMaxOpenPositions
+          // counter — the normal global cap must not block them nor consume
+          // normal slots (risk gate 2 uses this override).
+          ...(decision.action === "ENTER" && decision.positionMode === "launch"
+            ? { maxOpenPositions: Number.POSITIVE_INFINITY }
+            : {}),
         };
         // Issue #148: the wallet safety pause is informational in shadow mode
         // (no-send by design) — it must never block a decision there.
@@ -5361,6 +5367,13 @@ export const program = Effect.gen(function* () {
             pool.tvlUsd > 0
               ? (datapiStats.feeTvlRatio1h / 100) * pool.tvlUsd
               : null;
+          if (currentFees1hUsd === null) {
+            logger.debug("Launch position: 1h fees unmeasured — volume-decay gate skipped", {
+              pool: pos.poolAddress,
+              position: pos.positionId,
+              statsSource: pool.statsSource,
+            });
+          }
           const prevPeak = launchPeakFees1h.get(pos.positionId);
           if (
             currentFees1hUsd !== null &&
@@ -5385,7 +5398,10 @@ export const program = Effect.gen(function* () {
             feeIlRatio: metrics.feeIlRatioKnown ? metrics.feeIlRatio : null,
           });
           if (launchExitEval.exit) {
-            launchPeakFees1h.delete(pos.positionId);
+            // The peak is NOT deleted here: the exit decision may still be
+            // blocked downstream (approval gate, risk gate, execution) — the
+            // peak stays until the position actually closes (see the
+            // launchPeakFees1h prune in the close path).
             const launchReason = launchExitEval.reason ?? "exit";
             let detail = "";
             if (launchReason === "timebox") {
@@ -6341,30 +6357,15 @@ export const program = Effect.gen(function* () {
                 (p) => p.positionMode === "launch",
               ).length;
               const launchMaxOpenPositions = config.launchMaxOpenPositions ?? 3;
-              if (
+              const isLaunchPool =
                 config.launchScanEnabled === true &&
                 config.launchExecutionEnabled === true &&
-                launchScanPools.has(poolAddress) &&
-                openLaunchPositions < launchMaxOpenPositions
-              ) {
-                const launchSizeUsd = launchEntrySizeUsd({
-                  walletUsd: walletBalanceUsd,
-                  poolTvlUsd: pool.tvlUsd,
-                  maxSizeUsd: config.launchPositionMaxSizeUsd ?? 100,
-                });
-                const launchAllocation = evaluatePerPoolAllocation({
-                  proposedDepositUsd: launchSizeUsd,
-                  portfolioValueUsd,
-                  openPositions,
-                  maxPerPoolAllocationPct: config.maxPerPoolAllocationPct,
-                  maxOpenPositions: Number.POSITIVE_INFINITY,
-                  poolAddress,
-                  maxPositionsPerPool: config.maxPositionsPerPool,
-                });
-                if (!launchAllocation.approved) {
-                  console.info(
-                    `[launch-alloc-gate] Skipping launch ENTER ${poolAddress} — ${launchAllocation.reason}`,
-                  );
+                launchScanPools.has(poolAddress);
+              if (isLaunchPool) {
+                if (openLaunchPositions >= launchMaxOpenPositions) {
+                  // Launch cap full: reject the ENTER for this pool — it must
+                  // NOT fall through to the normal lane, which would size it
+                  // with the uncapped normal entry sizing.
                   yield* audit
                     .recordDecision({
                       timestamp: Date.now(),
@@ -6372,33 +6373,11 @@ export const program = Effect.gen(function* () {
                       poolAddress,
                       action: "ENTER",
                       confidence: 0,
-                      reasoning: `[launch-alloc-gate] ${launchAllocation.reason}`,
+                      reasoning: `[launch-cap] ${openLaunchPositions} launch positions >= ${launchMaxOpenPositions}`,
                       metrics,
                       riskResult: {
                         approved: false,
-                        reason: `[launch-alloc-gate] ${launchAllocation.reason}`,
-                      },
-                      executed: false,
-                      paperTrading: config.paperTrading,
-                    })
-                    .pipe(Effect.catch(() => Effect.void));
-                  enterGateRejected = true;
-                } else if (launchSizeUsd <= 0) {
-                  // Degenerate sizing (zero TVL or wallet) — no entry. Consume
-                  // the slot so the normal lane below cannot substitute its own
-                  // (uncapped) sizing for a launch-gated pool.
-                  yield* audit
-                    .recordDecision({
-                      timestamp: Date.now(),
-                      cycleId,
-                      poolAddress,
-                      action: "ENTER",
-                      confidence: 0,
-                      reasoning: "[launch-size] Launch entry size rounds to zero",
-                      metrics,
-                      riskResult: {
-                        approved: false,
-                        reason: "[launch-size] Launch entry size rounds to zero",
+                        reason: `[launch-cap] ${openLaunchPositions} >= ${launchMaxOpenPositions}`,
                       },
                       executed: false,
                       paperTrading: config.paperTrading,
@@ -6406,29 +6385,47 @@ export const program = Effect.gen(function* () {
                     .pipe(Effect.catch(() => Effect.void));
                   enterGateRejected = true;
                 } else {
-                  // [token-risk] launch ENTER gate — the same advisory overlay
-                  // as the normal lane: blocks when either leg carries a hard
-                  // risk signal; unknown/disabled/failed signals never block.
-                  if (config.jupiterTokenRiskEnabled !== false) {
-                    const launchRisk = yield* Effect.promise(() =>
-                      consultTokenRisks([pool.tokenX, pool.tokenY], config),
-                    );
-                    const launchLegRiskReason = (mint: string, symbol: string): string | null => {
-                      const signal = launchRisk.get(mint);
-                      if (signal === undefined) return null;
-                      if (signal.isSus) {
-                        return `${symbol} (${mint}): Jupiter audit flags suspicious (isSus)`;
-                      }
-                      if (signal.organicScoreLabel === "low") {
-                        return `${symbol} (${mint}): Jupiter organic score is low`;
-                      }
-                      return null;
-                    };
-                    const launchRiskReasons = [
-                      launchLegRiskReason(pool.tokenX, pool.tokenXSymbol),
-                      launchLegRiskReason(pool.tokenY, pool.tokenYSymbol),
-                    ].filter((reason): reason is string => reason !== null);
-                    if (launchRiskReasons.length > 0) {
+                  const launchSizeUsd = launchEntrySizeUsd({
+                    walletUsd: walletBalanceUsd,
+                    poolTvlUsd: pool.tvlUsd,
+                    maxSizeUsd: config.launchPositionMaxSizeUsd ?? 100,
+                  });
+                  if (launchSizeUsd <= 0) {
+                    // Degenerate sizing (zero TVL or wallet) — no entry.
+                    // Consume the slot so the normal lane cannot substitute
+                    // its own sizing for a launch-gated pool.
+                    yield* audit
+                      .recordDecision({
+                        timestamp: Date.now(),
+                        cycleId,
+                        poolAddress,
+                        action: "ENTER",
+                        confidence: 0,
+                        reasoning: "[launch-size] Launch entry size rounds to zero",
+                        metrics,
+                        riskResult: {
+                          approved: false,
+                          reason: "[launch-size] Launch entry size rounds to zero",
+                        },
+                        executed: false,
+                        paperTrading: config.paperTrading,
+                      })
+                      .pipe(Effect.catch(() => Effect.void));
+                    enterGateRejected = true;
+                  } else {
+                    const launchAllocation = evaluatePerPoolAllocation({
+                      proposedDepositUsd: launchSizeUsd,
+                      portfolioValueUsd,
+                      openPositions,
+                      maxPerPoolAllocationPct: config.maxPerPoolAllocationPct,
+                      maxOpenPositions: Number.POSITIVE_INFINITY,
+                      poolAddress,
+                      maxPositionsPerPool: config.maxPositionsPerPool,
+                    });
+                    if (!launchAllocation.approved) {
+                      console.info(
+                        `[launch-alloc-gate] Skipping launch ENTER ${poolAddress} — ${launchAllocation.reason}`,
+                      );
                       yield* audit
                         .recordDecision({
                           timestamp: Date.now(),
@@ -6436,31 +6433,78 @@ export const program = Effect.gen(function* () {
                           poolAddress,
                           action: "ENTER",
                           confidence: 0,
-                          reasoning: `[token-risk] ${launchRiskReasons.join("; ")} — launch ENTER blocked`,
+                          reasoning: `[launch-alloc-gate] ${launchAllocation.reason}`,
                           metrics,
                           riskResult: {
                             approved: false,
-                            reason: `[token-risk] ${launchRiskReasons.join("; ")}`,
+                            reason: `[launch-alloc-gate] ${launchAllocation.reason}`,
                           },
                           executed: false,
                           paperTrading: config.paperTrading,
                         })
                         .pipe(Effect.catch(() => Effect.void));
                       enterGateRejected = true;
+                    } else if (!enterGateRejected) {
+                      // [token-risk] launch ENTER gate — the same advisory overlay
+                      // as the normal lane: blocks when either leg carries a hard
+                      // risk signal; unknown/disabled/failed signals never block.
+                      if (config.jupiterTokenRiskEnabled !== false) {
+                        const launchRisk = yield* Effect.promise(() =>
+                          consultTokenRisks([pool.tokenX, pool.tokenY], config),
+                        );
+                        const launchLegRiskReason = (
+                          mint: string,
+                          symbol: string,
+                        ): string | null => {
+                          const signal = launchRisk.get(mint);
+                          if (signal === undefined) return null;
+                          if (signal.isSus) {
+                            return `${symbol} (${mint}): Jupiter audit flags suspicious (isSus)`;
+                          }
+                          if (signal.organicScoreLabel === "low") {
+                            return `${symbol} (${mint}): Jupiter organic score is low`;
+                          }
+                          return null;
+                        };
+                        const launchRiskReasons = [
+                          launchLegRiskReason(pool.tokenX, pool.tokenXSymbol),
+                          launchLegRiskReason(pool.tokenY, pool.tokenYSymbol),
+                        ].filter((reason): reason is string => reason !== null);
+                        if (launchRiskReasons.length > 0) {
+                          yield* audit
+                            .recordDecision({
+                              timestamp: Date.now(),
+                              cycleId,
+                              poolAddress,
+                              action: "ENTER",
+                              confidence: 0,
+                              reasoning: `[token-risk] ${launchRiskReasons.join("; ")} — launch ENTER blocked`,
+                              metrics,
+                              riskResult: {
+                                approved: false,
+                                reason: `[token-risk] ${launchRiskReasons.join("; ")}`,
+                              },
+                              executed: false,
+                              paperTrading: config.paperTrading,
+                            })
+                            .pipe(Effect.catch(() => Effect.void));
+                          enterGateRejected = true;
+                        }
+                      }
+                      if (!enterGateRejected) {
+                        rawDecisions.push({
+                          action: "ENTER",
+                          poolAddress,
+                          confidence: Math.min(0.5 + feeIlRatio * 0.05, 0.85),
+                          reasoning: `Launch: launch-gated hot pool — time-boxed entry, $${launchAllocation.adjustedDepositUsd.toFixed(0)}`,
+                          positionSizeUsd: launchAllocation.adjustedDepositUsd,
+                          positionMode: "launch",
+                        });
+                        // Consume the ENTER slot: the launch branch pushed the
+                        // decision, so the normal ENTER below must not duplicate.
+                        enterGateRejected = true;
+                      }
                     }
-                  }
-                  if (!enterGateRejected) {
-                    rawDecisions.push({
-                      action: "ENTER",
-                      poolAddress,
-                      confidence: Math.min(0.5 + feeIlRatio * 0.05, 0.85),
-                      reasoning: `Launch: launch-gated hot pool — time-boxed entry, $${launchAllocation.adjustedDepositUsd.toFixed(0)}`,
-                      positionSizeUsd: launchAllocation.adjustedDepositUsd,
-                      positionMode: "launch",
-                    });
-                    // Consume the ENTER slot: the launch branch pushed the
-                    // decision, so the normal ENTER below must not duplicate.
-                    enterGateRejected = true;
                   }
                 }
               }

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -3596,11 +3596,12 @@ export const program = Effect.gen(function* () {
           recentPnlUsd,
           poolAddress: candidate.poolAddress,
           activeBinId: candidate.pool.activeBinId,
-          // Launch ENTERs are governed by their own launchMaxOpenPositions
-          // counter — the normal global cap must not block them nor consume
-          // normal slots (risk gate 2 uses this override).
+          // Issue #201 review (P1): launch entries stay subject to the
+          // portfolio-wide MAX_OPEN_POSITIONS — the launch lane adds its own
+          // launchMaxOpenPositions sub-cap on top; it must not let the total
+          // exceed the configured global cap.
           ...(decision.action === "ENTER" && decision.positionMode === "launch"
-            ? { maxOpenPositions: Number.POSITIVE_INFINITY }
+            ? { maxOpenPositions: config.maxOpenPositions }
             : {}),
         };
         // Issue #148: the wallet safety pause is informational in shadow mode
@@ -4041,6 +4042,14 @@ export const program = Effect.gen(function* () {
       const discovered = yield* adapter.discoverHotPools(config.launchScanUniverseSize ?? 500);
       if (discovered.length === 0) {
         logger.warn("Launch radar: hot-pool fetch returned nothing");
+        // Fail closed for new launch entries (issue #201 review P2): the
+        // executable snapshot could not be refreshed — a stale set must not
+        // keep pools executable past their launch age or after they lose the
+        // launch gate's base-fee/volume/token-safety qualifications (those
+        // predicates are not rechecked by the per-pool decision chain).
+        if (config.launchExecutionEnabled === true) {
+          launchScanPools.clear();
+        }
         return;
       }
       const { ranked } = gateAndRankLaunchPools(discovered, {
@@ -6358,10 +6367,11 @@ export const program = Effect.gen(function* () {
               // screen, [fee-il-gate] floor, measured candidate conditions +
               // weighted score) enters with launch-specific sizing and the
               // time-boxed launch lane. launchMaxOpenPositions is a SEPARATE
-              // counter from MAX_OPEN_POSITIONS: launch entries never consume
-              // normal slots, so the allocation gate's total-open check is
-              // unbounded here — the per-pool count and per-pool exposure caps
-              // (the risk tail) still run verbatim.
+              // counter from MAX_OPEN_POSITIONS, but launch entries stay
+              // subject to the portfolio-wide cap (issue #201 review P1) —
+              // the total of normal + launch positions must never exceed
+              // MAX_OPEN_POSITIONS; the per-pool count and per-pool exposure
+              // caps (the risk tail) still run verbatim.
               const openLaunchPositions = Array.from(trackedPositions.values()).filter(
                 (p) => p.positionMode === "launch",
               ).length;
@@ -6427,7 +6437,7 @@ export const program = Effect.gen(function* () {
                       portfolioValueUsd,
                       openPositions,
                       maxPerPoolAllocationPct: config.maxPerPoolAllocationPct,
-                      maxOpenPositions: Number.POSITIVE_INFINITY,
+                      maxOpenPositions: config.maxOpenPositions,
                       poolAddress,
                       maxPositionsPerPool: config.maxPositionsPerPool,
                     });

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -111,6 +111,7 @@ import { identifyAssetMint } from "./fallen-angel-service.js";
 import { buildTpLadder, evaluateTpLadder, parseTpLadder, serializeTpLadder } from "./tp-ladder.js";
 import { getGeckoPoolOhlcv, type GeckoOhlcvSignals } from "./gecko-ohlcv-service.js";
 import { getRugCheckReport, type RugCheckReport } from "./rugcheck-service.js";
+import { launchEntrySizeUsd, launchPositionExit } from "./launch-position.js";
 import type {
   AgentDecision,
   AgentProposal,
@@ -2676,6 +2677,19 @@ export const program = Effect.gen(function* () {
   let lastMarketRefreshAt = 0;
   const marketScanPools = new Set<string>();
 
+  // ─── Launch-mode execution state (Launch Mode v2) ────────────────────────
+  // The launch radar's admitted pool set, populated by refreshLaunchScan ONLY
+  // when both launchScanEnabled AND launchExecutionEnabled are on (the default
+  // path never fills it, so the scan loop and ENTER gates below stay
+  // behavior-identical). Launch pools ride the FULL existing gate chain —
+  // blacklist/freeze/token-risk, metrics, pre-filter, risk tail — plus the
+  // launch-specific ENTER criteria.
+  const launchScanPools = new Set<string>();
+  // In-memory per-position peak 1h fees (USD) for the volume-decay exit.
+  // Session-local by design: a restart resets it and the time-box exit
+  // backstops the gap (contract: no persistence for the peak tracker).
+  const launchPeakFees1h = new Map<string, number>();
+
   // Rebuild the active scan set: the approved (watchlist) snapshot, the
   // market-scan top-K (ranked by the freshest gate), eligible autonomous
   // candidates and fallen-angel candidates. Called after every reconcile AND
@@ -2690,6 +2704,11 @@ export const program = Effect.gen(function* () {
       if (!poolsToScan.includes(poolAddress)) poolsToScan.push(poolAddress);
     }
     for (const poolAddress of fallenAngelCandidatePools) {
+      if (!poolsToScan.includes(poolAddress)) poolsToScan.push(poolAddress);
+    }
+    // Launch pools (Launch Mode v2): empty unless BOTH launchScanEnabled and
+    // launchExecutionEnabled are on, so the default path is unchanged.
+    for (const poolAddress of launchScanPools) {
       if (!poolsToScan.includes(poolAddress)) poolsToScan.push(poolAddress);
     }
   };
@@ -4013,9 +4032,7 @@ export const program = Effect.gen(function* () {
       const intervalMs = Math.max(config.launchScanRefreshIntervalMs ?? 120_000, 10_000);
       if (now - lastLaunchScanAt < intervalMs) return;
       lastLaunchScanAt = now;
-      const discovered = yield* adapter.discoverHotPools(
-        config.launchScanUniverseSize ?? 500,
-      );
+      const discovered = yield* adapter.discoverHotPools(config.launchScanUniverseSize ?? 500);
       if (discovered.length === 0) {
         logger.warn("Launch radar: hot-pool fetch returned nothing");
         return;
@@ -4033,6 +4050,13 @@ export const program = Effect.gen(function* () {
         stablecoinMints: config.stablecoinMints ?? new Set<string>(),
         now,
       });
+      // v2 execution lane: the admitted radar set becomes the executable
+      // launch pool set. Only when BOTH flags are on — the v1 radar-only
+      // path leaves launchScanPools empty and behavior-identical.
+      if (config.launchExecutionEnabled === true) {
+        launchScanPools.clear();
+        for (const r of ranked) launchScanPools.add(r.pool.address);
+      }
       logger.info("Launch radar", {
         universe: discovered.length,
         admitted: ranked.length,
@@ -5231,6 +5255,19 @@ export const program = Effect.gen(function* () {
         });
       }
 
+      // Launch peak-fee pruning (Launch Mode v2): drop entries whose position
+      // closed or left the launch lane (EXIT execution deletes the row from
+      // trackedPositions in the decision tail). In-memory only — the time-box
+      // exit backstops a restart.
+      if (config.launchScanEnabled === true && config.launchExecutionEnabled === true) {
+        for (const pid of launchPeakFees1h.keys()) {
+          const tracked = trackedPositions.get(pid);
+          if (tracked === undefined || tracked.positionMode !== "launch") {
+            launchPeakFees1h.delete(pid);
+          }
+        }
+      }
+
       for (const pos of poolPositions) {
         let decision: AgentDecision | null = null;
 
@@ -5300,6 +5337,70 @@ export const program = Effect.gen(function* () {
           }
         }
 
+        // ── Launch lifecycle (Launch Mode v2) ─────────────────────────────
+        // A launch position exits via launchPositionExit: time-box, 1h-fee
+        // volume-decay, peak-value drawdown, fee/IL floor (pure policy in
+        // launch-position.ts). Current 1h fees are MEASURED datapi only —
+        // feeTvlRatio1h is the identical Data-API 1h fee/TVL ratio the launch
+        // gate's feeYield1hPct mirrors, and the statsSource === "datapi"
+        // guard enforces the fee-purity rule (gecko/heuristic → null, and a
+        // null current fee never fires volume-decay). Position-targeted
+        // deterministic exit with the same precedence as the FA lifecycle.
+        let launchLifecycle: { reasoning: string } | null = null;
+        if (
+          config.launchScanEnabled === true &&
+          config.launchExecutionEnabled === true &&
+          pos.positionMode === "launch"
+        ) {
+          const now = Date.now();
+          const currentFees1hUsd =
+            pool.statsSource === "datapi" &&
+            datapiStats !== null &&
+            datapiStats.feeTvlRatio1h !== null &&
+            Number.isFinite(datapiStats.feeTvlRatio1h) &&
+            pool.tvlUsd > 0
+              ? (datapiStats.feeTvlRatio1h / 100) * pool.tvlUsd
+              : null;
+          const prevPeak = launchPeakFees1h.get(pos.positionId);
+          if (
+            currentFees1hUsd !== null &&
+            (prevPeak === undefined || currentFees1hUsd > prevPeak)
+          ) {
+            launchPeakFees1h.set(pos.positionId, currentFees1hUsd);
+          }
+          const peakFees1hUsd = launchPeakFees1h.get(pos.positionId) ?? null;
+          const launchExitEval = launchPositionExit({
+            createdAtMs: pos.timestamp,
+            now,
+            timeboxHours: config.launchTimeboxHours ?? 6,
+            volumeDecayExitPct: config.launchVolumeDecayExitPct ?? 0.1,
+            drawdownPct: config.launchExitDrawdownPct ?? 0.25,
+            currentFees1hUsd,
+            peakFees1hUsd,
+            currentValueUsd: pos.currentValueUsd,
+            peakValueUsd: pos.highestValueUsd,
+            // Fee-purity: a modeled ratio (gecko/heuristic, feeIlRatioKnown
+            // false) must never fire the launch fee-il exit — null skips the
+            // rule, mirroring the normal chain's feeIlRatioKnown guard.
+            feeIlRatio: metrics.feeIlRatioKnown ? metrics.feeIlRatio : null,
+          });
+          if (launchExitEval.exit) {
+            launchPeakFees1h.delete(pos.positionId);
+            const launchReason = launchExitEval.reason ?? "exit";
+            let detail = "";
+            if (launchReason === "timebox") {
+              detail = `age ${((now - pos.timestamp) / 3.6e6).toFixed(1)}h >= ${config.launchTimeboxHours ?? 6}h`;
+            } else if (launchReason === "volume-decay") {
+              detail = `1h fees $${(currentFees1hUsd ?? 0).toFixed(2)} < ${(config.launchVolumeDecayExitPct ?? 0.1) * 100}% of peak $${(peakFees1hUsd ?? 0).toFixed(2)}`;
+            } else if (launchReason === "drawdown") {
+              detail = `value $${pos.currentValueUsd.toFixed(2)} <= ${(1 - (config.launchExitDrawdownPct ?? 0.25)) * 100}% of peak $${(pos.highestValueUsd ?? 0).toFixed(2)}`;
+            } else if (launchReason === "fee-il") {
+              detail = `fee/IL ${metrics.feeIlRatio.toFixed(2)} < 0.5`;
+            }
+            launchLifecycle = { reasoning: `[launch-${launchReason}] ${detail}` };
+          }
+        }
+
         if (faLifecycle) {
           decision = {
             action: "EXIT",
@@ -5307,6 +5408,14 @@ export const program = Effect.gen(function* () {
             positionId: pos.positionId,
             confidence: 1,
             reasoning: faLifecycle.reasoning,
+          };
+        } else if (launchLifecycle) {
+          decision = {
+            action: "EXIT",
+            poolAddress,
+            positionId: pos.positionId,
+            confidence: 1,
+            reasoning: launchLifecycle.reasoning,
           };
         } else if (w15Signals.depeg || w15Signals.liquidityDrain) {
           decision = {
@@ -5929,7 +6038,10 @@ export const program = Effect.gen(function* () {
         } else if (
           !approvedPoolAddresses.includes(poolAddress) &&
           !autonomousCandidatePools.has(poolAddress) &&
-          !marketScanPools.has(poolAddress)
+          !marketScanPools.has(poolAddress) &&
+          // Launch Mode v2: launch-gated pools are managed pools once the
+          // execution lane is enabled (empty set on the default path).
+          !launchScanPools.has(poolAddress)
         ) {
           logger.info("Skipping ENTER for unmanaged pool", { pool: poolAddress });
           enterGateRejected = true;
@@ -6216,6 +6328,143 @@ export const program = Effect.gen(function* () {
                 .pipe(Effect.catch(() => Effect.void));
               enterGateRejected = true;
             } else {
+              // ── Launch ENTER (Launch Mode v2) ─────────────────────────────
+              // A launch-gated pool that cleared the FULL chain above (safety
+              // screen, [fee-il-gate] floor, measured candidate conditions +
+              // weighted score) enters with launch-specific sizing and the
+              // time-boxed launch lane. launchMaxOpenPositions is a SEPARATE
+              // counter from MAX_OPEN_POSITIONS: launch entries never consume
+              // normal slots, so the allocation gate's total-open check is
+              // unbounded here — the per-pool count and per-pool exposure caps
+              // (the risk tail) still run verbatim.
+              const openLaunchPositions = Array.from(trackedPositions.values()).filter(
+                (p) => p.positionMode === "launch",
+              ).length;
+              const launchMaxOpenPositions = config.launchMaxOpenPositions ?? 3;
+              if (
+                config.launchScanEnabled === true &&
+                config.launchExecutionEnabled === true &&
+                launchScanPools.has(poolAddress) &&
+                openLaunchPositions < launchMaxOpenPositions
+              ) {
+                const launchSizeUsd = launchEntrySizeUsd({
+                  walletUsd: walletBalanceUsd,
+                  poolTvlUsd: pool.tvlUsd,
+                  maxSizeUsd: config.launchPositionMaxSizeUsd ?? 100,
+                });
+                const launchAllocation = evaluatePerPoolAllocation({
+                  proposedDepositUsd: launchSizeUsd,
+                  portfolioValueUsd,
+                  openPositions,
+                  maxPerPoolAllocationPct: config.maxPerPoolAllocationPct,
+                  maxOpenPositions: Number.POSITIVE_INFINITY,
+                  poolAddress,
+                  maxPositionsPerPool: config.maxPositionsPerPool,
+                });
+                if (!launchAllocation.approved) {
+                  console.info(
+                    `[launch-alloc-gate] Skipping launch ENTER ${poolAddress} — ${launchAllocation.reason}`,
+                  );
+                  yield* audit
+                    .recordDecision({
+                      timestamp: Date.now(),
+                      cycleId,
+                      poolAddress,
+                      action: "ENTER",
+                      confidence: 0,
+                      reasoning: `[launch-alloc-gate] ${launchAllocation.reason}`,
+                      metrics,
+                      riskResult: {
+                        approved: false,
+                        reason: `[launch-alloc-gate] ${launchAllocation.reason}`,
+                      },
+                      executed: false,
+                      paperTrading: config.paperTrading,
+                    })
+                    .pipe(Effect.catch(() => Effect.void));
+                  enterGateRejected = true;
+                } else if (launchSizeUsd <= 0) {
+                  // Degenerate sizing (zero TVL or wallet) — no entry. Consume
+                  // the slot so the normal lane below cannot substitute its own
+                  // (uncapped) sizing for a launch-gated pool.
+                  yield* audit
+                    .recordDecision({
+                      timestamp: Date.now(),
+                      cycleId,
+                      poolAddress,
+                      action: "ENTER",
+                      confidence: 0,
+                      reasoning: "[launch-size] Launch entry size rounds to zero",
+                      metrics,
+                      riskResult: {
+                        approved: false,
+                        reason: "[launch-size] Launch entry size rounds to zero",
+                      },
+                      executed: false,
+                      paperTrading: config.paperTrading,
+                    })
+                    .pipe(Effect.catch(() => Effect.void));
+                  enterGateRejected = true;
+                } else {
+                  // [token-risk] launch ENTER gate — the same advisory overlay
+                  // as the normal lane: blocks when either leg carries a hard
+                  // risk signal; unknown/disabled/failed signals never block.
+                  if (config.jupiterTokenRiskEnabled !== false) {
+                    const launchRisk = yield* Effect.promise(() =>
+                      consultTokenRisks([pool.tokenX, pool.tokenY], config),
+                    );
+                    const launchLegRiskReason = (mint: string, symbol: string): string | null => {
+                      const signal = launchRisk.get(mint);
+                      if (signal === undefined) return null;
+                      if (signal.isSus) {
+                        return `${symbol} (${mint}): Jupiter audit flags suspicious (isSus)`;
+                      }
+                      if (signal.organicScoreLabel === "low") {
+                        return `${symbol} (${mint}): Jupiter organic score is low`;
+                      }
+                      return null;
+                    };
+                    const launchRiskReasons = [
+                      launchLegRiskReason(pool.tokenX, pool.tokenXSymbol),
+                      launchLegRiskReason(pool.tokenY, pool.tokenYSymbol),
+                    ].filter((reason): reason is string => reason !== null);
+                    if (launchRiskReasons.length > 0) {
+                      yield* audit
+                        .recordDecision({
+                          timestamp: Date.now(),
+                          cycleId,
+                          poolAddress,
+                          action: "ENTER",
+                          confidence: 0,
+                          reasoning: `[token-risk] ${launchRiskReasons.join("; ")} — launch ENTER blocked`,
+                          metrics,
+                          riskResult: {
+                            approved: false,
+                            reason: `[token-risk] ${launchRiskReasons.join("; ")}`,
+                          },
+                          executed: false,
+                          paperTrading: config.paperTrading,
+                        })
+                        .pipe(Effect.catch(() => Effect.void));
+                      enterGateRejected = true;
+                    }
+                  }
+                  if (!enterGateRejected) {
+                    rawDecisions.push({
+                      action: "ENTER",
+                      poolAddress,
+                      confidence: Math.min(0.5 + feeIlRatio * 0.05, 0.85),
+                      reasoning: `Launch: launch-gated hot pool — time-boxed entry, $${launchAllocation.adjustedDepositUsd.toFixed(0)}`,
+                      positionSizeUsd: launchAllocation.adjustedDepositUsd,
+                      positionMode: "launch",
+                    });
+                    // Consume the ENTER slot: the launch branch pushed the
+                    // decision, so the normal ENTER below must not duplicate.
+                    enterGateRejected = true;
+                  }
+                }
+              }
+
               const proposedSizeUsd = computeEntrySizeUsd({
                 walletBalanceUsd,
                 tvlUsd: pool.tvlUsd,

--- a/engine/risk-service.ts
+++ b/engine/risk-service.ts
@@ -336,7 +336,7 @@ export function evaluateAgentProposal(
         portfolioValueUsd: ctx.portfolioValueUsd,
         openPositions: ctx.openPositions,
         maxPerPoolAllocationPct: config.maxPerPoolAllocationPct,
-        maxOpenPositions: config.maxOpenPositions,
+        maxOpenPositions: ctx.maxOpenPositions ?? config.maxOpenPositions,
         poolAddress: proposal.poolAddress,
         maxPositionsPerPool: config.maxPositionsPerPool,
       });

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -659,6 +659,13 @@ export interface RiskContext {
    * positions.
    */
   readonly positionId?: string | undefined;
+  /**
+   * Per-call override for the global MAX_OPEN_POSITIONS cap. The launch lane
+   * (Launch Mode v2) passes Infinity — its own launchMaxOpenPositions counter
+   * governs, and launch entries must not consume normal slots or be blocked
+   * by the normal cap. Normal decisions omit it (config default applies).
+   */
+  readonly maxOpenPositions?: number | undefined;
 }
 
 export interface RiskResult {

--- a/engine/types.ts
+++ b/engine/types.ts
@@ -317,10 +317,10 @@ export interface AgentDecision {
    * pool holds multiple positions.
    */
   positionId?: string | undefined;
-  /** Fallen-angel ENTER lifecycle (Wave 19): "fallen-angel" position mode.
-   *  Carried on the decision so execution stamps the row; undefined for
-   *  standard positions. */
-  positionMode?: "fallen-angel" | undefined;
+  /** Position lifecycle mode carried on the decision so execution stamps the
+   *  row. "fallen-angel" (Wave 19) and "launch" (Launch Mode v2) enter with
+   *  lane-specific exits; undefined for standard positions. */
+  positionMode?: "fallen-angel" | "launch" | undefined;
   /** Serialized TP-ladder JSON (see engine/tp-ladder.ts) for FA positions. */
   tpLadderJson?: string | undefined;
   /** Invalidation stop price for FA positions. */


### PR DESCRIPTION
Launch Mode v2 — the execution lane. The radar (v1, #199) now drives time-boxed launch positions.

- **`engine/launch-position.ts`** (pure): `launchPositionExit` — time-box (default 6h), 1h-fee volume decay vs in-process peak (default exit at <10% of peak), drawdown from `highestValueUsd` (default 25%), fee/IL < 0.5; `launchEntrySizeUsd` — min(max size $100, 0.5% TVL, 50% wallet)
- **Position mode** `"launch"` (alongside the fallen-angel precedent); **6 `LAUNCH_EXECUTION_*` settings**, off by default and only effective with `LAUNCH_SCAN_ENABLED`
- **program.ts**: launch pools flow through the FULL existing gate chain (blacklist/freeze/token-risk, metrics, fee/IL, allocation, risk tail) plus launch sizing and a separate `launchMaxOpenPositions` counter; per-position launch lifecycle exits through the normal EXIT path; 1h-fee peak tracked in-process, **measured Data-API fees only** (gecko/heuristic never fires volume-decay — fee-purity rule)

Paper-first, off by default, default path behavior-identical. 28 new unit tests; full suite 1634/1634; tsc 0; oxlint 0 (Effect rules enforced).

Built with 2 parallel implementation slices (pure policy + program wiring) under a shared contract.

## Summary by Sourcery

Add Launch Mode v2 execution lane with time-boxed, radar-driven launch positions, configurable sizing and exits, and integrate it into the existing program flow without affecting the default path when disabled.

New Features:
- Introduce a dedicated launch position mode with a time-boxed execution lane driven by launch radar pools.
- Add configurable launch execution settings for position caps, per-entry size limits, time-box duration, volume-decay threshold, and drawdown stop.

Enhancements:
- Wire launch-mode positions through the existing gate chain with separate allocation and exit reasoning while keeping default behavior unchanged when execution is disabled.
- Extend position decision typing to support multiple lifecycle modes, including launch, for lane-specific exits.

Tests:
- Add unit tests covering launch position exit rules, priority ordering, null-signal handling, and launch entry sizing caps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Launch Mode v2 for tracking and managing launch-pool positions.
  * Added configurable launch execution, position limits, sizing, timeboxing, and exit thresholds.
  * Added automatic launch-position exits for time limits, volume decay, drawdowns, and fee-to-impermanent-loss deterioration.
  * Added safeguards that cap entry sizes based on configured limits, pool value, and wallet balance.

* **Tests**
  * Added comprehensive coverage for launch entry sizing and exit conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->