### PR TITLE
fix(autonomous): reconcile settlement amounts with the live wallet balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Prism are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- Exit settlement amounts are reconciled with the live wallet balance at execution time: the sell amount is clamped to `min(job amount, wallet balance)` before quoting (a concurrent entry consuming the exit proceeds previously made the swap simulation fail forever — 130 attempts in the field), a fully-consumed balance terminalizes with a clear error instead of looping, and the orphan sweep now revives a terminal job's wallet-held excess even when the mint is position-backed (position liquidity lives in the position account, not the wallet). Entry preparation reserves pending settlement claims from the spendable balance, so a new entry can no longer consume funds an exit settlement is about to sell (#201)
+
 ## [0.2.0] — 2026-08-09
 
 ### Added

--- a/bench/entry-prep.test.ts
+++ b/bench/entry-prep.test.ts
@@ -976,6 +976,83 @@ describe("EntryPrepService", () => {
     ).rejects.toThrow(/INSUFFICIENT_USDC_BALANCE/);
   });
 
+  it("reserves pending USDC claims when funding a token/token pool entry (issue #201)", async () => {
+    // Neither pool leg is USDC — the funding swaps buy the missing leg with
+    // wallet USDC. A pending USDC settlement claim must still be reserved,
+    // or the entry would consume the exit settlement's funds (the P1 gap:
+    // leg-only claims missed this path).
+    const TOKEN_Z = "FakeToken2222222222222222222222222222222222";
+    const tokenBalances: Record<string, bigint> = { [TOKEN_Y]: 600_000_000n };
+    const swapSpy = vi.fn((mint: string) => {
+      // Simulate the swap landing so the post-swap balance reconciliation
+      // passes in the no-claim scenario.
+      tokenBalances[mint] = 10_000_000_000n;
+      return Effect.succeed("mock-swap-tx");
+    });
+    const poolAdapter = {
+      getPoolState: () =>
+        Effect.succeed({
+          address: POOL_ADDRESS,
+          tokenX: TOKEN_Y,
+          tokenY: TOKEN_Z,
+          tokenXSymbol: "FAKE1",
+          tokenYSymbol: "FAKE2",
+          tvlUsd: 100_000,
+          volume24hUsd: 30_000,
+          fees24hUsd: 300,
+          apr: 60,
+          activeBinId: 5000,
+          binStep: 10,
+          currentPrice: 1,
+          timestamp: Date.now(),
+        }),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
+      getTokenBalance: (mint: string) =>
+        Effect.succeed(mint === USDC_MINT ? 800_000_000n : (tokenBalances[mint] ?? 0n)),
+      getTokenPrices: () => Effect.succeed({ [TOKEN_Y]: 1, [TOKEN_Z]: 1, [USDC_MINT]: 1 }),
+      getTokenDecimals: () => Effect.succeed(6),
+      swapUSDCForToken: swapSpy,
+    };
+
+    // Without a claim the missing FAKE2 leg is bought with wallet USDC.
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const prep = yield* EntryPrepService;
+        return yield* prep.prepareEntryTokens(POOL_ADDRESS, 1_000);
+      }).pipe(Effect.provide(buildLayer(poolAdapter, true))),
+    );
+    expect(swapSpy).toHaveBeenCalledWith(TOKEN_Z, expect.any(BigInt), expect.anything());
+
+    // With a pending USDC claim the entry cannot spend the exit's funds.
+    // Fresh adapter: the no-claim scenario's swap mutated the token balances.
+    const claimAdapter = {
+      ...poolAdapter,
+      getTokenBalance: (mint: string) =>
+        Effect.succeed(mint === USDC_MINT ? 800_000_000n : mint === TOKEN_Y ? 600_000_000n : 0n),
+    };
+    await expect(
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const prep = yield* EntryPrepService;
+          return yield* prep.prepareEntryTokens(POOL_ADDRESS, 1_000);
+        }).pipe(
+          Effect.provide(
+            buildLayer(claimAdapter, true, "off", {
+              listSettlementJobs: () =>
+                Effect.succeed([
+                  {
+                    tokenMint: USDC_MINT,
+                    amountAtomic: "400000000",
+                    status: "retryable",
+                  } as unknown as SettlementJobRecord,
+                ]),
+            }),
+          ),
+        ),
+      ),
+    ).rejects.toThrow(/INSUFFICIENT_USDC_BALANCE/);
+  });
+
   it("computes USDC input without precision loss for large amounts", () => {
     // 1 unit of a 9-decimal token at $1 with a 1% buffer -> 1.01 USDC atomic.
     expect(computeUsdcInputAtomic(1_000_000_000n, 9, 1)).toBe(1_010_000n);

--- a/bench/entry-prep.test.ts
+++ b/bench/entry-prep.test.ts
@@ -11,10 +11,11 @@ import {
   computeRequiredAtomic,
   computeUsdcInputAtomic,
 } from "../engine/entry-prep-service.js";
-import { AdapterService, type AdapterApi } from "../engine/services.js";
+import { AdapterService, DbService, type AdapterApi, type DbApi } from "../engine/services.js";
 import { ConfigService } from "../engine/config-service.js";
 import { defaultAppConfig } from "./helpers.js";
 import { SOL_MINT, USDC_MINT, SOL_ENTRY_TRANSACTION_BUFFER_LAMPORTS } from "../engine/constants.js";
+import type { SettlementJobRecord } from "../engine/types.js";
 import { SwapQuoteError } from "../engine/errors.js";
 
 const TOKEN_X = SOL_MINT;
@@ -106,6 +107,7 @@ function buildLayer(
   adapterMock: Partial<AdapterApi> = {},
   autoSwapEntry = false,
   autonomousTokenMode: "off" | "shadow" | "canary" | "live" = "off",
+  dbOverrides: Partial<DbApi> = {},
 ) {
   const adapter = makeAdapter(adapterMock);
   const adapterLayer = Layer.succeed(AdapterService, adapter);
@@ -113,7 +115,11 @@ function buildLayer(
     ConfigService,
     defaultAppConfig({ autoSwapEntry, autonomousTokenMode }),
   );
-  return Layer.provide(EntryPrepLive, Layer.merge(adapterLayer, configLayer));
+  const dbLayer = Layer.succeed(DbService, {
+    listSettlementJobs: () => Effect.succeed([]),
+    ...dbOverrides,
+  } as unknown as DbApi);
+  return Layer.provide(EntryPrepLive, Layer.merge(Layer.merge(adapterLayer, configLayer), dbLayer));
 }
 
 function makeQuote(request: SwapRequest): SwapQuote {
@@ -902,6 +908,72 @@ describe("EntryPrepService", () => {
     ).rejects.toThrow(/INSUFFICIENT_USDC_BALANCE/);
 
     expect(swapSpy).not.toHaveBeenCalled();
+  });
+
+  it("reserves pending settlement claims from the spendable balance (issue #201)", async () => {
+    // Given a USDC pool leg and a wallet whose USDC is partially claimed by a
+    // pending settlement job (an exit settlement about to sell it): the entry
+    // must not spend the claimed funds — the field bug was an entry consuming
+    // the exit settlement's USDC and stranding the exit ($41.91 expected,
+    // $24.35 in wallet).
+    const baseAdapter = {
+      getPoolState: () =>
+        Effect.succeed({
+          address: POOL_ADDRESS,
+          tokenX: TOKEN_Y,
+          tokenY: USDC_MINT,
+          tokenXSymbol: "FAKE",
+          tokenYSymbol: "USDC",
+          tvlUsd: 100_000,
+          volume24hUsd: 30_000,
+          fees24hUsd: 300,
+          apr: 60,
+          activeBinId: 5000,
+          binStep: 10,
+          currentPrice: 1,
+          timestamp: Date.now(),
+        }),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
+      getTokenBalance: (mint: string) =>
+        Effect.succeed(mint === USDC_MINT ? 600_000_000n : mint === TOKEN_Y ? 600_000_000n : 0n),
+      getTokenPrices: () => Effect.succeed({ [TOKEN_Y]: 1, [USDC_MINT]: 1 }),
+      getTokenDecimals: () => Effect.succeed(6),
+    };
+
+    // Without a pending claim the $1,000 entry (half in each leg) is fully
+    // fundable from the $600 USDC + $600 token balances.
+    const noClaim = await Effect.runPromise(
+      Effect.gen(function* () {
+        const prep = yield* EntryPrepService;
+        return yield* prep.prepareEntryTokens(POOL_ADDRESS, 1_000);
+      }).pipe(Effect.provide(buildLayer(baseAdapter, true))),
+    );
+    expect(noClaim).toBeUndefined();
+
+    // With a pending USDC claim of $200, the spendable USDC drops below the
+    // $500 leg requirement → INSUFFICIENT_USDC_BALANCE instead of silently
+    // spending the exit settlement's funds.
+    await expect(
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const prep = yield* EntryPrepService;
+          return yield* prep.prepareEntryTokens(POOL_ADDRESS, 1_000);
+        }).pipe(
+          Effect.provide(
+            buildLayer(baseAdapter, true, "off", {
+              listSettlementJobs: () =>
+                Effect.succeed([
+                  {
+                    tokenMint: USDC_MINT,
+                    amountAtomic: "200000000",
+                    status: "retryable",
+                  } as unknown as SettlementJobRecord,
+                ]),
+            }),
+          ),
+        ),
+      ),
+    ).rejects.toThrow(/INSUFFICIENT_USDC_BALANCE/);
   });
 
   it("computes USDC input without precision loss for large amounts", () => {

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -552,6 +552,11 @@ describe("settlement job processing", () => {
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 1, [job.tokenMint]: 1 }),
       getTokenDecimals: () => Effect.succeed(6),
+      // Issue #201: the processor clamps the sell amount to the live
+      // wallet balance — these mocks hand back a generous balance so
+      // the clamp is a no-op for the tested scenarios.
+      getTokenBalance: () => Effect.succeed(1_000_000_000_000_000_000n),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
     } as unknown as AdapterApi;
 
     // When
@@ -593,6 +598,11 @@ describe("settlement job processing", () => {
       getSwapStatus: () => Effect.succeed({ state: "not_found", error: null }),
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 1, [job.tokenMint]: 1 }),
       getTokenDecimals: () => Effect.succeed(6),
+      // Issue #201: the processor clamps the sell amount to the live
+      // wallet balance — these mocks hand back a generous balance so
+      // the clamp is a no-op for the tested scenarios.
+      getTokenBalance: () => Effect.succeed(1_000_000_000_000_000_000n),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
       quoteSwap: () =>
         Effect.sync(() => {
           quoteCalls++;
@@ -666,10 +676,14 @@ describe("settlement job processing", () => {
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 1, [job.tokenMint]: 1 }),
       getTokenDecimals: () => Effect.succeed(6),
+      // Issue #201: the processor clamps the sell amount to the live
+      // wallet balance — these mocks hand back a generous balance so
+      // the clamp is a no-op for the tested scenarios.
+      getTokenBalance: () => Effect.succeed(1_000_000_000_000_000_000n),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
       quoteSwap: () => Effect.succeed(quote),
       prepareSwap: () => Effect.succeed(prepared),
       simulateSwap: () => Effect.succeed(simulation),
-      getNativeSolBalance: () => Effect.succeed(100n),
       submitSwap: (
         _prepared: PreparedSwap,
         onBroadcast: ((signature: string) => Effect.Effect<void, Error>) | undefined,
@@ -699,6 +713,7 @@ describe("settlement job processing", () => {
     const savedJobs: SettlementJobRecord[] = [];
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 1 }),
+      getNativeSolBalance: () => Effect.succeed(10_000_000_000_000_000_000n),
     } as unknown as AdapterApi;
 
     // When
@@ -1049,6 +1064,11 @@ describe("issue #166 settlement recovery", () => {
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "token-1": 1 }),
       getTokenDecimals: () => Effect.succeed(6),
+      // Issue #201: the processor clamps the sell amount to the live
+      // wallet balance — these mocks hand back a generous balance so
+      // the clamp is a no-op for the tested scenarios.
+      getTokenBalance: () => Effect.succeed(1_000_000_000_000_000_000n),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
       quoteSwap: () => Effect.fail(new Error("Jupiter quote failed: 429")),
       prepareSwap: () => Effect.fail(new Error("unused")),
       simulateSwap: () => Effect.fail(new Error("unused")),
@@ -1075,6 +1095,11 @@ describe("issue #166 settlement recovery", () => {
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "token-1": 1 }),
       getTokenDecimals: () => Effect.succeed(6),
+      // Issue #201: the processor clamps the sell amount to the live
+      // wallet balance — these mocks hand back a generous balance so
+      // the clamp is a no-op for the tested scenarios.
+      getTokenBalance: () => Effect.succeed(1_000_000_000_000_000_000n),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
       quoteSwap: () => Effect.fail(new Error("insufficient funds for swap")),
       prepareSwap: () => Effect.fail(new Error("unused")),
       simulateSwap: () => Effect.fail(new Error("unused")),
@@ -1093,6 +1118,100 @@ describe("issue #166 settlement recovery", () => {
     });
   });
 
+  it("clamps the sell amount to the live wallet balance before quoting (issue #201)", async () => {
+    // Given a settlement expecting 41.91 USDC (the exit proceeds) while the
+    // wallet now holds 24.35 — a concurrent entry consumed the rest. The
+    // stale amount made the swap simulation fail with insufficient balance
+    // 130 times in the field. The clamp must quote only what exists.
+    const job = settlementJob({
+      tokenMint: "usdc-mint",
+      amountAtomic: "41913604",
+      status: "retryable",
+      nextRetryAt: 9_000,
+    });
+    let quotedAmount: bigint | null = null;
+    const adapter = {
+      getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "usdc-mint": 1 }),
+      getTokenDecimals: () => Effect.succeed(6),
+      getTokenBalance: (mint: string) => Effect.succeed(mint === "usdc-mint" ? 24_350_000n : 0n),
+      quoteSwap: (request: { amountAtomic: bigint }) => {
+        quotedAmount = request.amountAtomic;
+        return Effect.fail(new Error("Jupiter quote failed: 429"));
+      },
+      prepareSwap: () => Effect.fail(new Error("unused")),
+      simulateSwap: () => Effect.fail(new Error("unused")),
+      submitSwap: () => Effect.fail(new Error("unused")),
+    } as unknown as AdapterApi;
+    const db = {
+      saveSettlementJob: () => Effect.void,
+      getPosition: () => Effect.succeed(null),
+    } as unknown as DbApi;
+
+    // When
+    const [processed] = await Effect.runPromise(
+      processSettlementJobs({
+        adapter,
+        db,
+        jobs: [job],
+        mode: "live",
+        now: 10_000,
+        maxSwapSlippageBps: 50,
+        settlementDustUsd: 0.1,
+      }),
+    );
+
+    // Then the quote was requested for the WALLET balance, not the stale
+    // job amount — a simulation of 41.91 USDC can never succeed now.
+    expect(quotedAmount).toBe(24_350_000n);
+    expect(processed).toMatchObject({ status: "retryable", error: "Jupiter quote failed: 429" });
+  });
+
+  it("terminalizes a settlement whose wallet balance was fully consumed (issue #201)", async () => {
+    // Given a settlement for a mint the wallet no longer holds any balance
+    // of — the funds were consumed by concurrent activity; there are no
+    // proceeds to sell, so the job must stop retrying with a clear error
+    // instead of looping forever.
+    const job = settlementJob({
+      tokenMint: "usdc-mint",
+      amountAtomic: "41913604",
+      status: "retryable",
+      nextRetryAt: 9_000,
+    });
+    const adapter = {
+      getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "usdc-mint": 1 }),
+      getTokenDecimals: () => Effect.succeed(6),
+      getTokenBalance: () => Effect.succeed(0n),
+      quoteSwap: () => Effect.fail(new Error("unused — quote must never run")),
+      prepareSwap: () => Effect.fail(new Error("unused")),
+      simulateSwap: () => Effect.fail(new Error("unused")),
+      submitSwap: () => Effect.fail(new Error("unused")),
+    } as unknown as AdapterApi;
+    const db = {
+      saveSettlementJob: () => Effect.void,
+      getPosition: () => Effect.succeed(null),
+    } as unknown as DbApi;
+
+    // When
+    const [processed] = await Effect.runPromise(
+      processSettlementJobs({
+        adapter,
+        db,
+        jobs: [job],
+        mode: "live",
+        now: 10_000,
+        maxSwapSlippageBps: 50,
+        settlementDustUsd: 0.1,
+      }),
+    );
+
+    // Then the job is terminal with the exhaustion error and no quote ran.
+    expect(processed).toMatchObject({
+      status: "terminal",
+      nextRetryAt: null,
+      error: expect.stringContaining("wallet holds no balance"),
+    });
+  });
+
   it("keeps retrying a non-transient failure before expiry", async () => {
     // Given
     const job = settlementJob({ expiresAt: 100_000 });
@@ -1100,6 +1219,11 @@ describe("issue #166 settlement recovery", () => {
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "token-1": 1 }),
       getTokenDecimals: () => Effect.succeed(6),
+      // Issue #201: the processor clamps the sell amount to the live
+      // wallet balance — these mocks hand back a generous balance so
+      // the clamp is a no-op for the tested scenarios.
+      getTokenBalance: () => Effect.succeed(1_000_000_000_000_000_000n),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
       quoteSwap: () => Effect.fail(new Error("insufficient funds for swap")),
       prepareSwap: () => Effect.fail(new Error("unused")),
       simulateSwap: () => Effect.fail(new Error("unused")),
@@ -1123,6 +1247,11 @@ describe("issue #166 settlement recovery", () => {
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "no-price-1": 0 }),
       getTokenDecimals: () => Effect.succeed(6),
+      // Issue #201: the processor clamps the sell amount to the live
+      // wallet balance — these mocks hand back a generous balance so
+      // the clamp is a no-op for the tested scenarios.
+      getTokenBalance: () => Effect.succeed(1_000_000_000_000_000_000n),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
       quoteSwap: () => Effect.fail(new Error("unused — quote must never run")),
       prepareSwap: () => Effect.fail(new Error("unused")),
       simulateSwap: () => Effect.fail(new Error("unused")),
@@ -1168,6 +1297,11 @@ describe("issue #166 settlement recovery", () => {
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "no-price-1": 0 }),
       getTokenDecimals: () => Effect.succeed(6),
+      // Issue #201: the processor clamps the sell amount to the live
+      // wallet balance — these mocks hand back a generous balance so
+      // the clamp is a no-op for the tested scenarios.
+      getTokenBalance: () => Effect.succeed(1_000_000_000_000_000_000n),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
       quoteSwap: () => Effect.fail(new Error("Jupiter quote failed: 400")),
       prepareSwap: () => Effect.fail(new Error("unused")),
       simulateSwap: () => Effect.fail(new Error("unused")),
@@ -1205,6 +1339,11 @@ describe("issue #166 settlement recovery", () => {
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "token-1": 1 }),
       getTokenDecimals: () => Effect.succeed(6),
+      // Issue #201: the processor clamps the sell amount to the live
+      // wallet balance — these mocks hand back a generous balance so
+      // the clamp is a no-op for the tested scenarios.
+      getTokenBalance: () => Effect.succeed(1_000_000_000_000_000_000n),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
       quoteSwap: () => Effect.fail(new Error("unused — quote must never run")),
       prepareSwap: () => Effect.fail(new Error("unused")),
       simulateSwap: () => Effect.fail(new Error("unused")),
@@ -1315,6 +1454,11 @@ describe("issue #166 settlement recovery", () => {
     const adapter = {
       getTokenPrices: () => Effect.succeed({ [SOL_MINT]: 100, "no-price-1": 0 }),
       getTokenDecimals: () => Effect.succeed(6),
+      // Issue #201: the processor clamps the sell amount to the live
+      // wallet balance — these mocks hand back a generous balance so
+      // the clamp is a no-op for the tested scenarios.
+      getTokenBalance: () => Effect.succeed(1_000_000_000_000_000_000n),
+      getNativeSolBalance: () => Effect.succeed(1_000_000_000n),
       quoteSwap: () => Effect.fail(new Error("Jupiter quote failed: 429")),
       prepareSwap: () => Effect.fail(new Error("unused")),
       simulateSwap: () => Effect.fail(new Error("unused")),
@@ -1419,6 +1563,69 @@ describe("issue #166 settlement recovery", () => {
       expiresAt: 3_610_000,
       error: null,
       positionId: expect.stringMatching(/^orphan:/),
+    });
+  });
+
+  it("revives a terminal job despite position backing — wallet-held excess wins (issue #201)", async () => {
+    // Given a wallet holding USDC, an open HYPE/USDC position (so USDC is
+    // position-backed), and a TERMINAL job with unspent balance for USDC
+    // (the exit settlement that died after 130 attempts). Position liquidity
+    // lives in the position account, NOT the wallet — the wallet-held USDC
+    // is excess the terminal job proves was never sold, so the sweep must
+    // revive it with the LIVE wallet amount instead of skipping the mint.
+    const holdings = new Map<string, { amountAtomic: bigint; decimals: number }>([
+      ["usdc-mint", { amountAtomic: 24_350_000n, decimals: 6 }], // $24.35
+    ]);
+    const terminalJob = settlementJob({
+      id: "terminal-usdc",
+      positionId: "position-exit",
+      tokenMint: "usdc-mint",
+      amountAtomic: "41913604", // stale 41.91
+      status: "terminal",
+      attempts: 130,
+      nextRetryAt: null,
+      txSignature: null,
+      confirmedOutputAtomic: null,
+      expiresAt: 1_000,
+      error: "Swap simulation failed",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const adapter = {
+      hasWallet: () => true,
+      getWalletHoldings: () => Effect.succeed(holdings),
+      getPoolState: () => Effect.succeed({ tokenX: "hype-mint", tokenY: "usdc-mint" }),
+      getTokenPrices: () => Effect.succeed({ "usdc-mint": 1 }),
+    } as unknown as AdapterApi;
+    const db = {
+      listSettlementJobs: () => Effect.succeed([terminalJob]),
+      getAllPositions: () => Effect.succeed([{ positionId: "live-pos", poolAddress: "pool-1" }]),
+    } as unknown as DbApi;
+
+    // When
+    const jobs = await Effect.runPromise(
+      sweepOrphanSettlements({
+        adapter,
+        db,
+        walletAddress: "wallet-1",
+        agentInstanceId: "primary",
+        settlementMaxPendingMs: 3_600_000,
+        settlementDustUsd: 0.1,
+        now: 10_000,
+      }),
+    );
+
+    // Then the terminal job is revived in place with the LIVE wallet amount
+    // (24.35), not the stale 41.91 — the processor clamp then sells exactly
+    // what exists.
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toMatchObject({
+      id: "terminal-usdc",
+      tokenMint: "usdc-mint",
+      status: "pending",
+      amountAtomic: "24350000",
+      attempts: 131,
+      error: null,
     });
   });
 

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -493,15 +493,54 @@ export function processSettlementJobs(
             new Error("Prepared settlement requires operator reconciliation"),
           );
         }
-        const amountAtomic = BigInt(job.amountAtomic);
+        let amountAtomic = BigInt(job.amountAtomic);
         const prices = yield* input.adapter.getTokenPrices([job.tokenMint, SOL_MINT]);
         const solPriceUsd = prices[SOL_MINT] ?? 0;
         if (!(solPriceUsd > 0)) return yield* Effect.fail(new Error("SOL price unavailable"));
+        // Issue #201: reconcile the sell amount with the LIVE wallet balance.
+        // The job amount is fixed at creation, but a concurrent entry can
+        // consume part of the wallet (field evidence: an exit settlement
+        // expecting 41.91 USDC while the wallet held 24.35 — quoting the
+        // stale amount made the swap simulation fail with insufficient
+        // balance 130 times, then terminal). Clamp to what the wallet
+        // actually holds; a failed balance read fails open (keeps the job
+        // amount — the simulation still catches genuine insufficiency).
+        // When the wallet holds nothing of the mint, the funds were consumed
+        // elsewhere — terminalize with a clear error instead of looping.
+        const readWalletBalance = (): Effect.Effect<bigint | null, never> => {
+          const reader =
+            job.tokenMint === SOL_MINT
+              ? input.adapter.getNativeSolBalance
+              : input.adapter.getTokenBalance;
+          // Guard for partial adapters (mirrors the sweep's optional-method
+          // checks): a missing balance reader fails open — keep the job
+          // amount; the simulation still catches genuine insufficiency.
+          return typeof reader === "function"
+            ? reader
+                .call(input.adapter, job.tokenMint)
+                .pipe(Effect.catch(() => Effect.succeed(null)))
+            : Effect.succeed(null);
+        };
+        const walletBalance = yield* readWalletBalance();
+        if (walletBalance !== null && walletBalance < amountAtomic) {
+          amountAtomic = walletBalance;
+        }
+        if (amountAtomic <= 0n) {
+          return {
+            ...job,
+            status: "terminal" as const,
+            attempts: job.attempts + 1,
+            nextRetryAt: null,
+            error:
+              "Settlement amount exhausted — wallet holds no balance of the mint (concurrent activity consumed it)",
+            updatedAt: input.now,
+          };
+        }
         if (job.tokenMint === SOL_MINT) {
           return {
             ...job,
             status: "confirmed" as const,
-            confirmedOutputAtomic: job.amountAtomic,
+            confirmedOutputAtomic: amountAtomic.toString(),
             outputUsd: atomicUsd(amountAtomic, 9, solPriceUsd),
             executionCostUsd: 0,
             attempts: job.attempts + 1,
@@ -721,7 +760,15 @@ export function sweepOrphanSettlements(
     const existingJobs = yield* input.db
       .listSettlementJobs(input.walletAddress, input.agentInstanceId)
       .pipe(Effect.catch(() => Effect.succeed([])));
-    const backedMints = new Set<string>(
+    // Two distinct backing sources (issue #201): ACTIVE settlement jobs own
+    // their mint outright (an in-flight job is handling it — never double
+    // sell). POSITION legs do NOT reserve wallet-held balances of the same
+    // mint — position liquidity lives in the position account, not the
+    // wallet — so they only suppress the sweep when no stranded-terminal
+    // evidence exists for the mint (a terminal job with unspent balance is
+    // proof the wallet-held excess was never sold; it wins over position
+    // backing so the sweep revives it with the live wallet amount).
+    const activeJobMints = new Set<string>(
       existingJobs
         .filter((job) => job.status !== "terminal" && job.status !== "confirmed")
         .map((job) => job.tokenMint),
@@ -732,6 +779,7 @@ export function sweepOrphanSettlements(
     // live wallet's stranded tokens. The engine's model is one wallet per DB
     // (portfolio/equity math already assumes it), so remaining rows belong to
     // the current wallet.
+    const positionBackedMints = new Set<string>();
     const openPositions = yield* input.db
       .getAllPositions()
       .pipe(Effect.catch(() => Effect.succeed([])));
@@ -744,8 +792,8 @@ export function sweepOrphanSettlements(
         .getPoolState(poolAddress)
         .pipe(Effect.catch(() => Effect.succeed(null)));
       if (state) {
-        backedMints.add(state.tokenX);
-        backedMints.add(state.tokenY);
+        positionBackedMints.add(state.tokenX);
+        positionBackedMints.add(state.tokenY);
       }
     }
     const prices = yield* input.adapter.getTokenPrices(candidates.map(([mint]) => mint)).pipe(
@@ -785,7 +833,11 @@ export function sweepOrphanSettlements(
     const jobs: SettlementJobRecord[] = [];
     for (const [mint, holding] of holdings) {
       if (mint === SOL_MINT || holding.amountAtomic <= 0n) continue;
-      if (backedMints.has(mint)) continue;
+      if (activeJobMints.has(mint)) continue;
+      // A position-backed mint is still swept when a stranded-terminal job
+      // exists for it (issue #201): the terminal job's unspent balance is
+      // wallet-held excess the sweep must recover.
+      if (positionBackedMints.has(mint) && !terminalByMint.has(mint)) continue;
       const priceUsd = prices[mint] ?? 0;
       if (
         input.settlementDustUsd > 0 &&

--- a/engine/entry-prep-service.ts
+++ b/engine/entry-prep-service.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer } from "effect";
 import {
   AdapterService,
+  DbService,
   EntryPrepService,
   type EntryPreparationOutcome,
   type EntryPreparationReceipt,
@@ -153,6 +154,7 @@ export const EntryPrepLive = Layer.effect(
   Effect.gen(function* () {
     const adapter = yield* AdapterService;
     const config = yield* ConfigService;
+    const db = yield* DbService;
 
     const api: EntryPrepApi = {
       prepareEntryTokens: (poolAddress, positionSizeUsd) =>
@@ -302,23 +304,56 @@ export const EntryPrepLive = Layer.effect(
 
           const nativeSolLamports = yield* readNativeSolBalance();
 
+          // Issue #201: a pending settlement job claims wallet funds that
+          // this entry must not spend — a concurrent entry consuming the
+          // exit settlement's USDC was the root cause of the field stranding
+          // ($41.91 expected, $24.35 in wallet). Reserve the sum of
+          // non-final job amounts per mint by subtracting it from the
+          // spendable balance (floor 0). A claim read failure fails open.
+          const pendingClaims = new Map<string, bigint>();
+          const executionWallet = adapter.getWalletAddress();
+          if (executionWallet !== null) {
+            const activeJobs = yield* db
+              .listSettlementJobs(executionWallet, config.agentInstanceId)
+              .pipe(Effect.catch(() => Effect.succeed([])));
+            for (const job of activeJobs) {
+              if (job.status === "confirmed" || job.status === "terminal") continue;
+              let claim: bigint;
+              try {
+                claim = BigInt(job.amountAtomic);
+              } catch {
+                continue;
+              }
+              if (claim <= 0n) continue;
+              pendingClaims.set(job.tokenMint, (pendingClaims.get(job.tokenMint) ?? 0n) + claim);
+            }
+          }
+          const claimedX = pendingClaims.get(pool.tokenX) ?? 0n;
+          const claimedY = pendingClaims.get(pool.tokenY) ?? 0n;
+
           const balanceX =
             pool.tokenX === SOL_MINT ? nativeSolLamports : yield* readTokenBalance(pool.tokenX);
           const balanceY =
             pool.tokenY === SOL_MINT ? nativeSolLamports : yield* readTokenBalance(pool.tokenY);
 
-          const availableX =
-            pool.tokenX === SOL_MINT
-              ? balanceX > GAS_RESERVE_LAMPORTS
-                ? balanceX - GAS_RESERVE_LAMPORTS
-                : 0n
-              : balanceX;
-          const availableY =
-            pool.tokenY === SOL_MINT
-              ? balanceY > GAS_RESERVE_LAMPORTS
-                ? balanceY - GAS_RESERVE_LAMPORTS
-                : 0n
-              : balanceY;
+          const availableX = (() => {
+            const free =
+              pool.tokenX === SOL_MINT
+                ? balanceX > GAS_RESERVE_LAMPORTS
+                  ? balanceX - GAS_RESERVE_LAMPORTS
+                  : 0n
+                : balanceX;
+            return free > claimedX ? free - claimedX : 0n;
+          })();
+          const availableY = (() => {
+            const free =
+              pool.tokenY === SOL_MINT
+                ? balanceY > GAS_RESERVE_LAMPORTS
+                  ? balanceY - GAS_RESERVE_LAMPORTS
+                  : 0n
+                : balanceY;
+            return free > claimedY ? free - claimedY : 0n;
+          })();
 
           // Single-sided precedence (Wave 7): when exactly one leg cannot fund
           // its half and the other leg alone covers a full-size single-sided

--- a/engine/entry-prep-service.ts
+++ b/engine/entry-prep-service.ts
@@ -673,6 +673,12 @@ export const EntryPrepLive = Layer.effect(
           }
 
           const usdcBalance = yield* readTokenBalance(USDC_MINT);
+          // Issue #201: even when neither pool leg is USDC, the funding swaps
+          // spend wallet USDC — subtract pending USDC settlement claims so a
+          // token/token entry cannot consume USDC an exit settlement is about
+          // to sell.
+          const usdcClaimed = pendingClaims.get(USDC_MINT) ?? 0n;
+          const spendableUsdc = usdcBalance > usdcClaimed ? usdcBalance - usdcClaimed : 0n;
           const totalUsdcInputAtomic = deficits.reduce(
             (sum, deficit) =>
               sum + computeUsdcInputAtomic(deficit.amount, deficit.decimals, deficit.price),
@@ -688,12 +694,12 @@ export const EntryPrepLive = Layer.effect(
             : 0n;
           const totalUsdcRequired = totalUsdcInputAtomic + requiredUsdcPoolLeg + gasTopUpAtomic;
 
-          if (usdcBalance < totalUsdcRequired) {
+          if (spendableUsdc < totalUsdcRequired) {
             const gasNote = needsGasTopUp ? " + gas top-up" : "";
             return yield* Effect.fail(
               makePrepError(
                 "INSUFFICIENT_USDC_BALANCE",
-                `Wallet USDC balance ${formatAtomic(usdcBalance, USDC_DECIMALS)} is less than required ${formatAtomic(totalUsdcRequired, USDC_DECIMALS)} for auto-swap entry (swaps + USDC pool leg${gasNote})`,
+                `Wallet USDC balance ${formatAtomic(spendableUsdc, USDC_DECIMALS)} (after ${formatAtomic(usdcClaimed, USDC_DECIMALS)} pending settlement claims) is less than required ${formatAtomic(totalUsdcRequired, USDC_DECIMALS)} for auto-swap entry (swaps + USDC pool leg${gasNote})`,
                 poolAddress,
               ),
             );

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -912,7 +912,7 @@ export function buildLayer(cfg?: AppConfig): Layer.Layer<AllServices, never, nev
   const revenueConfigDeps = Layer.merge(dbLayer, configLayer);
   const revenueConfig = Layer.provide(RevenueConfigServiceLive, revenueConfigDeps);
 
-  const entryPrepDeps = Layer.merge(adapter, configLayer);
+  const entryPrepDeps = Layer.merge(Layer.merge(adapter, configLayer), dbLayer);
   const entryPrep = Layer.provide(EntryPrepLive, entryPrepDeps);
 
   const merged = Layer.merge(adapter, StrategyLive);


### PR DESCRIPTION
Fixes #201

## Problem

An exit settlement's sell amount is fixed at creation and never reconciled with the live wallet balance. A concurrent entry consumed part of the wallet USDC the pending settlement still expected (41.91 USDC expected, 24.35 in wallet): every swap attempt failed simulation ("Swap simulation failed" — insufficient balance) 130 times, the job went terminal, and the orphan sweep could not recover it — `backedMints` includes open-position legs, and the two HYPE/USDC positions made ALL wallet USDC "position-backed" even though position liquidity lives in the position account. Result: $24.35 (25% of live equity) permanently stranded.

## Fix

1. **Settlement amount clamp** (`processSettlementJobs`): the sell amount is clamped to `min(job amount, live wallet balance)` before quoting. A partial balance persists through the retryable job (next attempt quotes what exists); a fully-consumed balance terminalizes with a clear error instead of looping; a failed balance read fails open; partial adapters fail open instead of defecting.
2. **Amount-aware sweep backing** (`sweepOrphanSettlements`): position backing no longer exempts a mint that has a stranded-terminal job — the terminal job's unspent balance proves the wallet-held excess was never sold, so the sweep revives it with the LIVE wallet amount. Active-job backing still suppresses (an in-flight job owns the mint).
3. **Entry prep reserves pending settlement claims** (`entry-prep-service`): the spendable balance subtracts non-final settlement job amounts per mint, so a new entry can no longer consume funds an exit settlement is about to sell. `EntryPrepLive` now takes `DbService` (wired through `buildLayer` and test layers).

## Verification

- New regression tests: processor clamps the quote amount to the wallet balance; zero-balance terminalizes without quoting; the sweep revives a terminal job despite position backing with the live wallet amount; entry prep rejects with `INSUFFICIENT_USDC_BALANCE` when a pending claim makes the USDC leg unaffordable.
- `bun run lint` clean; `bun run test` 123 files / 1610 tests pass.

## Summary by Sourcery

Reconcile autonomous exit settlements with the live wallet balance to prevent stranded funds and infinite retry loops.

Bug Fixes:
- Clamp settlement sell amounts to the current wallet balance when processing jobs, terminalizing settlements whose balances have been fully consumed instead of repeatedly failing swaps.
- Adjust orphan settlement sweeping so wallet-held excess for a mint is revived even when that mint is position-backed, while still avoiding double-selling mints with active jobs.
- Reserve pending non-final settlement job amounts from entry preparation spendable balances so new entries cannot consume funds that existing settlements expect to sell.

Enhancements:
- Wire database access into the entry preparation service and runtime to support settlement-aware balance calculations.
- Extend autonomous runtime and sweep logic with wallet and position awareness to better model live holdings at execution time.

Documentation:
- Document the settlement reconciliation behaviour and its safeguards in the unreleased CHANGELOG entry.

Tests:
- Add regression tests covering clamped quote amounts, terminalization on zero wallet balance, orphan sweep revival of terminal jobs with wallet-held excess, and entry preparation failures when pending settlement claims exhaust USDC balance.
- Update existing autonomous token and entry-prep tests to mock wallet balances and DB services required for the new reconciliation logic.