### PR TITLE
chore(release): bump version to 0.2.1, backfill changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 All notable changes to Prism are documented here.
 
-## [Unreleased]
+## [0.2.1] — 2026-08-09
+
+### Added
+
+- **Launch Mode v2 — execution lane**: launch-gated pools now flow into a separate time-boxed execution lane. `launchPositionExit` (pure policy: 6h time-box, 1h-fee volume decay vs in-process peak, drawdown from peak seeded at deposit, fee/IL < 0.5) and `launchEntrySizeUsd` (min size cap, 0.5% TVL, 50% wallet); launch ENTERs run the FULL existing gate chain with a separate `LAUNCH_MAX_OPEN_POSITIONS` counter; per-position lifecycle exits via the normal EXIT path; measured Data-API fees only (gecko/heuristic never fire volume-decay). Position mode survives applied agent proposals; exits stay armed if the lane is disabled mid-position; executable set bounded to top-K (#202)
 
 ### Fixed
 
-- Exit settlement amounts are reconciled with the live wallet balance at execution time: the sell amount is clamped to `min(job amount, wallet balance)` before quoting (a concurrent entry consuming the exit proceeds previously made the swap simulation fail forever — 130 attempts in the field), a fully-consumed balance terminalizes with a clear error instead of looping, and the orphan sweep now revives a terminal job's wallet-held excess even when the mint is position-backed (position liquidity lives in the position account, not the wallet). Entry preparation reserves pending settlement claims from the spendable balance, so a new entry can no longer consume funds an exit settlement is about to sell (#201)
+- Exit settlement amounts are reconciled with the live wallet balance at execution time: the sell amount is clamped to `min(job amount, wallet balance)` before quoting (a concurrent entry consuming the exit proceeds previously made the swap simulation fail forever — 130 attempts in the field), a fully-consumed balance terminalizes with a clear error instead of looping, and the orphan sweep now revives a terminal job's wallet-held excess even when the mint is position-backed (position liquidity lives in the position account, not the wallet). Entry preparation reserves pending settlement claims from the spendable balance, so a new entry can no longer consume funds an exit settlement is about to sell (#203)
+
+### Changed
+
+- Bumped version to 0.2.1.
 
 ## [0.2.0] — 2026-08-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-liquidity-agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Autonomous liquidity agent for Solana pools (currently Meteora DLMM)",
   "keywords": [
     "ai-agent",


### PR DESCRIPTION
- **Added**: Launch Mode v2 execution lane — time-boxed launch positions (pure `launchPositionExit` policy, separate `LAUNCH_MAX_OPEN_POSITIONS` counter, lifecycle exits through the normal path, measured-fees-only decay) (#202)
- **Fixed**: exit settlement amounts reconciled with the live wallet balance (kills the 130-attempt swap-simulation loop), pending-settlement reservation in entry prep, orphan sweep revives wallet-held excess even for position-backed mints (#203)

After merge: tag v0.2.1.

## Summary by Sourcery

Prepare 0.2.1 release by documenting changes and updating version metadata.

New Features:
- Document Launch Mode v2 execution lane for launch-gated pools in the changelog.

Bug Fixes:
- Document live wallet balance reconciliation and settlement handling fixes in the changelog.

Enhancements:
- Note the new bounded executable set and related Launch Mode v2 behavior in the changelog.

Build:
- Bump package version to 0.2.1 for the new release.