### PR TITLE
fix(engine): exit withdrawal measured from on-chain wallet delta (#205)

### DIFF
--- a/bench/adapter-exit-accounting.test.ts
+++ b/bench/adapter-exit-accounting.test.ts
@@ -53,7 +53,7 @@ describe("measureWithdrawalDelta", () => {
     expect(result).toEqual({ amountAtomic: "24377718", measured: false });
   });
 
-  it("falls back when the leg was not held before (new ATA, no measurable delta)", () => {
+  it("measures a new-ATA credit via the SPL delta (before = 0n)", () => {
     const before = held([]);
     const after = held([[USDC, 41_910_000n]]);
     const result = measureWithdrawalDelta({
@@ -137,12 +137,16 @@ describe("excludeSameMintRewards", () => {
     expect(result).toBe("0");
   });
 
-  it("falls back only for a genuinely negative result (reward exceeds the delta)", () => {
+  it("returns zero when the same-mint reward exceeds the measured delta (no double count)", () => {
+    // Measurement inconsistency: the reward snapshot (500k) exceeds the
+    // measured delta (400k). Returning the reward-inclusive delta would
+    // double-count the reward (sweptRewards books it separately) — the leg's
+    // provable value is 0.
     const result = excludeSameMintRewards(
       { amountAtomic: "400000", measured: true },
       "REWARD1",
       slots,
     );
-    expect(result).toBe("400000");
+    expect(result).toBe("0");
   });
 });

--- a/bench/adapter-exit-accounting.test.ts
+++ b/bench/adapter-exit-accounting.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { measureWithdrawalDelta } from "../engine/adapter-service.js";
+import { excludeSameMintRewards, measureWithdrawalDelta } from "../engine/adapter-service.js";
 import { SOL_MINT } from "../engine/constants.js";
 
 const USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
@@ -13,7 +13,7 @@ function held(
 describe("measureWithdrawalDelta", () => {
   it("uses the measured SPL delta when the close credited more than the SDK snapshot (issue #205)", () => {
     // The live case: position closed all-USDC, on-chain credited $41.91 USDC
-    // (24,377,718 -> 41,910,000 micro read as pre->post), SDK snapshot 24.38.
+    // (2,438,792 -> 44,352,396 micro), SDK snapshot 24.38.
     const before = held([[USDC, 2_438_792n]]);
     const after = held([[USDC, 44_352_396n]]);
     const result = measureWithdrawalDelta({
@@ -24,7 +24,7 @@ describe("measureWithdrawalDelta", () => {
       mint: USDC,
       snapshotAmount: "24377718",
     });
-    expect(result).toBe("41913604");
+    expect(result).toEqual({ amountAtomic: "41913604", measured: true });
   });
 
   it("falls back to the snapshot when the SPL delta is not positive", () => {
@@ -38,7 +38,7 @@ describe("measureWithdrawalDelta", () => {
       mint: USDC,
       snapshotAmount: "24377718",
     });
-    expect(result).toBe("24377718");
+    expect(result).toEqual({ amountAtomic: "24377718", measured: false });
   });
 
   it("falls back to the snapshot when the wallet reads failed", () => {
@@ -50,7 +50,7 @@ describe("measureWithdrawalDelta", () => {
       mint: USDC,
       snapshotAmount: "24377718",
     });
-    expect(result).toBe("24377718");
+    expect(result).toEqual({ amountAtomic: "24377718", measured: false });
   });
 
   it("falls back when the leg was not held before (new ATA, no measurable delta)", () => {
@@ -64,19 +64,19 @@ describe("measureWithdrawalDelta", () => {
       mint: USDC,
       snapshotAmount: "24377718",
     });
-    expect(result).toBe("41910000");
+    expect(result).toEqual({ amountAtomic: "41910000", measured: true });
   });
 
-  it("measures the native SOL leg from the balance delta", () => {
+  it("measures the native SOL leg from the balance delta even when SPL reads failed", () => {
     const result = measureWithdrawalDelta({
-      beforeHeld: held([]),
-      afterHeld: held([]),
+      beforeHeld: null,
+      afterHeld: null,
       beforeNativeSol: 1_000_000_000n,
       afterNativeSol: 1_500_000_000n,
       mint: SOL_MINT,
       snapshotAmount: "100000000",
     });
-    expect(result).toBe("500000000");
+    expect(result).toEqual({ amountAtomic: "500000000", measured: true });
   });
 
   it("falls back for a native SOL leg whose credit is eaten by tx fees (delta not positive)", () => {
@@ -88,6 +88,49 @@ describe("measureWithdrawalDelta", () => {
       mint: SOL_MINT,
       snapshotAmount: "100000000",
     });
-    expect(result).toBe("100000000");
+    expect(result).toEqual({ amountAtomic: "100000000", measured: false });
+  });
+});
+
+describe("excludeSameMintRewards", () => {
+  const slots = [
+    { mint: "REWARD1", amountAtomic: 500_000n },
+    { mint: "REWARD2", amountAtomic: 250_000n },
+  ];
+
+  it("subtracts a same-mint swept reward from a measured delta (no double count)", () => {
+    const result = excludeSameMintRewards(
+      { amountAtomic: "41913604", measured: true },
+      "REWARD1",
+      slots,
+    );
+    expect(result).toBe("41413604");
+  });
+
+  it("leaves a snapshot-based (unmeasured) amount unchanged — snapshots never include rewards", () => {
+    const result = excludeSameMintRewards(
+      { amountAtomic: "24377718", measured: false },
+      "REWARD1",
+      slots,
+    );
+    expect(result).toBe("24377718");
+  });
+
+  it("does not touch a measured delta when the reward mints differ from the leg", () => {
+    const result = excludeSameMintRewards(
+      { amountAtomic: "41913604", measured: true },
+      USDC,
+      slots,
+    );
+    expect(result).toBe("41913604");
+  });
+
+  it("never goes negative when the reward exceeds the delta", () => {
+    const result = excludeSameMintRewards(
+      { amountAtomic: "400000", measured: true },
+      "REWARD1",
+      slots,
+    );
+    expect(result).toBe("400000");
   });
 });

--- a/bench/adapter-exit-accounting.test.ts
+++ b/bench/adapter-exit-accounting.test.ts
@@ -27,9 +27,37 @@ describe("measureWithdrawalDelta", () => {
     expect(result).toEqual({ amountAtomic: "41913604", measured: true });
   });
 
-  it("falls back to the snapshot when the SPL delta is not positive", () => {
+  it("measures a zero SPL delta as zero when the leg was observed unchanged", () => {
     const before = held([[USDC, 44_352_396n]]);
     const after = held([[USDC, 44_352_396n]]);
+    const result = measureWithdrawalDelta({
+      beforeHeld: before,
+      afterHeld: after,
+      beforeNativeSol: 1n,
+      afterNativeSol: 1n,
+      mint: USDC,
+      snapshotAmount: "24377718",
+    });
+    expect(result).toEqual({ amountAtomic: "0", measured: true });
+  });
+
+  it("measures a zero delta for the empty leg of a single-sided exit (routine, not a fallback)", () => {
+    // The empty leg: not held before, not held after — a correctly observed
+    // zero withdrawal. measured: true keeps the audit warn quiet.
+    const result = measureWithdrawalDelta({
+      beforeHeld: held([]),
+      afterHeld: held([]),
+      beforeNativeSol: 1n,
+      afterNativeSol: 1n,
+      mint: USDC,
+      snapshotAmount: "0",
+    });
+    expect(result).toEqual({ amountAtomic: "0", measured: true });
+  });
+
+  it("falls back when a leg's balance moved DOWN during the close window", () => {
+    const before = held([[USDC, 44_352_396n]]);
+    const after = held([[USDC, 40_000_000n]]);
     const result = measureWithdrawalDelta({
       beforeHeld: before,
       afterHeld: after,

--- a/bench/adapter-exit-accounting.test.ts
+++ b/bench/adapter-exit-accounting.test.ts
@@ -125,7 +125,19 @@ describe("excludeSameMintRewards", () => {
     expect(result).toBe("41913604");
   });
 
-  it("never goes negative when the reward exceeds the delta", () => {
+  it("preserves an exactly-zero leg when the measured delta was entirely a same-mint reward", () => {
+    // An empty position leg whose measured delta consists only of the swept
+    // reward: subtracting the reward correctly yields 0 — the leg has no
+    // value of its own and the reward books separately.
+    const result = excludeSameMintRewards(
+      { amountAtomic: "500000", measured: true },
+      "REWARD1",
+      slots,
+    );
+    expect(result).toBe("0");
+  });
+
+  it("falls back only for a genuinely negative result (reward exceeds the delta)", () => {
     const result = excludeSameMintRewards(
       { amountAtomic: "400000", measured: true },
       "REWARD1",

--- a/bench/adapter-exit-accounting.test.ts
+++ b/bench/adapter-exit-accounting.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { measureWithdrawalDelta } from "../engine/adapter-service.js";
+import { SOL_MINT } from "../engine/constants.js";
+
+const USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+function held(
+  entries: ReadonlyArray<[string, bigint]>,
+): ReadonlyMap<string, { readonly amountAtomic: bigint; readonly decimals: number }> {
+  return new Map(entries.map(([mint, amountAtomic]) => [mint, { amountAtomic, decimals: 6 }]));
+}
+
+describe("measureWithdrawalDelta", () => {
+  it("uses the measured SPL delta when the close credited more than the SDK snapshot (issue #205)", () => {
+    // The live case: position closed all-USDC, on-chain credited $41.91 USDC
+    // (24,377,718 -> 41,910,000 micro read as pre->post), SDK snapshot 24.38.
+    const before = held([[USDC, 2_438_792n]]);
+    const after = held([[USDC, 44_352_396n]]);
+    const result = measureWithdrawalDelta({
+      beforeHeld: before,
+      afterHeld: after,
+      beforeNativeSol: 1n,
+      afterNativeSol: 1n,
+      mint: USDC,
+      snapshotAmount: "24377718",
+    });
+    expect(result).toBe("41913604");
+  });
+
+  it("falls back to the snapshot when the SPL delta is not positive", () => {
+    const before = held([[USDC, 44_352_396n]]);
+    const after = held([[USDC, 44_352_396n]]);
+    const result = measureWithdrawalDelta({
+      beforeHeld: before,
+      afterHeld: after,
+      beforeNativeSol: 1n,
+      afterNativeSol: 1n,
+      mint: USDC,
+      snapshotAmount: "24377718",
+    });
+    expect(result).toBe("24377718");
+  });
+
+  it("falls back to the snapshot when the wallet reads failed", () => {
+    const result = measureWithdrawalDelta({
+      beforeHeld: null,
+      afterHeld: null,
+      beforeNativeSol: null,
+      afterNativeSol: null,
+      mint: USDC,
+      snapshotAmount: "24377718",
+    });
+    expect(result).toBe("24377718");
+  });
+
+  it("falls back when the leg was not held before (new ATA, no measurable delta)", () => {
+    const before = held([]);
+    const after = held([[USDC, 41_910_000n]]);
+    const result = measureWithdrawalDelta({
+      beforeHeld: before,
+      afterHeld: after,
+      beforeNativeSol: 1n,
+      afterNativeSol: 1n,
+      mint: USDC,
+      snapshotAmount: "24377718",
+    });
+    expect(result).toBe("41910000");
+  });
+
+  it("measures the native SOL leg from the balance delta", () => {
+    const result = measureWithdrawalDelta({
+      beforeHeld: held([]),
+      afterHeld: held([]),
+      beforeNativeSol: 1_000_000_000n,
+      afterNativeSol: 1_500_000_000n,
+      mint: SOL_MINT,
+      snapshotAmount: "100000000",
+    });
+    expect(result).toBe("500000000");
+  });
+
+  it("falls back for a native SOL leg whose credit is eaten by tx fees (delta not positive)", () => {
+    const result = measureWithdrawalDelta({
+      beforeHeld: held([]),
+      afterHeld: held([]),
+      beforeNativeSol: 1_500_000_000n,
+      afterNativeSol: 1_480_000_000n,
+      mint: SOL_MINT,
+      snapshotAmount: "100000000",
+    });
+    expect(result).toBe("100000000");
+  });
+});

--- a/bench/program-autonomous-token.test.ts
+++ b/bench/program-autonomous-token.test.ts
@@ -771,6 +771,92 @@ describe("settlement job processing", () => {
     expect(outcome).toEqual({ snapshotId: 42, pnl: 10 });
   });
 
+  it("does not clobber a resolved exit realized PnL with a settlement-derived figure (issue #205)", async () => {
+    // Given a position whose EXIT already booked a resolved realized (+0.78)
+    // and a confirmed settlement that recovered only PART of the withdrawal.
+    // The settlement-derived recompute would be -16.78 — it must NOT overwrite.
+    const job = settlementJob({
+      status: "confirmed",
+      outputUsd: 24.35,
+      executionCostUsd: 0.028,
+      confirmedOutputAtomic: "1",
+    });
+    const position = {
+      cumulativeFeesClaimedUsd: 0.51,
+      cumulativeRewardsClaimedUsd: 0,
+      depositedUsd: 41.63,
+      realizedPnlUsd: 0.78,
+      entrySignalSnapshotId: null,
+    };
+    let finalizedPnl: number | null = null;
+    const db = {
+      saveSettlementJob: () => Effect.void,
+      getPosition: () => Effect.succeed(position),
+      finalizeSettlementGroup: (input: { readonly realizedPnlUsd: number | null }) =>
+        Effect.sync(() => {
+          finalizedPnl = input.realizedPnlUsd;
+        }),
+    } as unknown as DbApi;
+
+    // When
+    await Effect.runPromise(
+      processSettlementJobs({
+        adapter: {} as AdapterApi,
+        db,
+        jobs: [job],
+        mode: "live",
+        now: 10_000,
+        maxSwapSlippageBps: 50,
+      }),
+    );
+
+    // Then the exit's resolved realized survives; the settlement only fills
+    // the NULL (unresolved) case.
+    expect(finalizedPnl).toBe(0.78);
+  });
+
+  it("fills the settlement-derived realized when the exit left it unresolved (null)", async () => {
+    // Given an exit whose pricing was unresolved (realized NULL) — the
+    // settlement finalize must fill it from the recovered outputs.
+    const job = settlementJob({
+      status: "confirmed",
+      outputUsd: 41.91,
+      executionCostUsd: 0,
+      confirmedOutputAtomic: "1",
+    });
+    const position = {
+      cumulativeFeesClaimedUsd: 0.51,
+      cumulativeRewardsClaimedUsd: 0,
+      depositedUsd: 41.63,
+      realizedPnlUsd: null,
+      entrySignalSnapshotId: null,
+    };
+    let finalizedPnl: number | null = null;
+    const db = {
+      saveSettlementJob: () => Effect.void,
+      getPosition: () => Effect.succeed(position),
+      finalizeSettlementGroup: (input: { readonly realizedPnlUsd: number | null }) =>
+        Effect.sync(() => {
+          finalizedPnl = input.realizedPnlUsd;
+        }),
+    } as unknown as DbApi;
+
+    // When
+    await Effect.runPromise(
+      processSettlementJobs({
+        adapter: {} as AdapterApi,
+        db,
+        jobs: [job],
+        mode: "live",
+        now: 10_000,
+        maxSwapSlippageBps: 50,
+      }),
+    );
+
+    // Then the settlement-derived figure fills the gap: 41.91 + 0.51 - 41.63.
+    expect(finalizedPnl).toBeCloseTo(0.79, 2);
+  });
+
   it("reconciles confirmed swap output from transaction evidence when fields are missing", async () => {
     // Given
     const job = settlementJob({

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -165,6 +165,43 @@ export function atomicToUnits(amountAtomic: bigint, decimals: number): number {
   const frac = amountAtomic % base;
   return Number(whole) + Number(frac) / Number(base);
 }
+
+/**
+ * Issue #205: the SDK's position snapshot can understate the actual
+ * withdrawal (observed: a $41.91 all-USDC position closed with the snapshot
+ * reporting $24.38 — $17.53 vanished from the ledger and the exit settlement
+ * sold only the snapshot amount). The wallet's balance DELTA around the close
+ * batch is the on-chain truth. Prefer it per leg; fall back to the SDK
+ * snapshot when the delta is unmeasurable (reads failed) or non-positive (a
+ * SOL leg whose tx fees ate the credit).
+ */
+export function measureWithdrawalDelta(input: {
+  readonly beforeHeld: ReadonlyMap<
+    string,
+    { readonly amountAtomic: bigint; readonly decimals?: number }
+  > | null;
+  readonly afterHeld: ReadonlyMap<
+    string,
+    { readonly amountAtomic: bigint; readonly decimals?: number }
+  > | null;
+  readonly beforeNativeSol: bigint | null;
+  readonly afterNativeSol: bigint | null;
+  readonly mint: string;
+  readonly snapshotAmount: string;
+}): string {
+  if (input.beforeHeld === null || input.afterHeld === null) return input.snapshotAmount;
+  if (input.mint === SOL_MINT) {
+    if (input.beforeNativeSol === null || input.afterNativeSol === null) {
+      return input.snapshotAmount;
+    }
+    const delta = input.afterNativeSol - input.beforeNativeSol;
+    return delta > 0n ? delta.toString() : input.snapshotAmount;
+  }
+  const before = input.beforeHeld.get(input.mint)?.amountAtomic ?? 0n;
+  const after = input.afterHeld.get(input.mint)?.amountAtomic ?? 0n;
+  const delta = after - before;
+  return delta > 0n ? delta.toString() : input.snapshotAmount;
+}
 const logger = createLogger("adapter-service");
 
 // Mints we have already warned about for being unpriceable during wallet
@@ -2522,16 +2559,23 @@ export const AdapterLive = Layer.effect(
           // accrued swap fees AND LM rewards on-chain, so withdrawn =
           // principal + pending fees. The *ExcludeTransferFee variants equal
           // gross for plain SPL and are correct (net-of-fee) for token-2022.
-          const withdrawnXAtomic = positionData.totalXAmountExcludeTransferFee
-            .add(positionData.feeXExcludeTransferFee)
-            .toString();
-          const withdrawnYAtomic = positionData.totalYAmountExcludeTransferFee
-            .add(positionData.feeYExcludeTransferFee)
-            .toString();
-          const pendingFeeXAtomic = positionData.feeXExcludeTransferFee.toString();
-          const pendingFeeYAtomic = positionData.feeYExcludeTransferFee.toString();
-          const rewardOneAtomic = positionData.rewardOneExcludeTransferFee;
-          const rewardTwoAtomic = positionData.rewardTwoExcludeTransferFee;
+          //
+          // Issue #205: the SDK snapshot can understate the actual withdrawal
+          // (observed: position worth $41.91 closed as all-USDC, snapshot
+          // reported 24.38 — 17.53 USDC vanished from the ledger and the
+          // settlement sold only the snapshot amount). The wallet's balance
+          // DELTA around the close batch is the on-chain truth: measure it
+          // per leg and prefer it, falling back to the SDK snapshot when the
+          // delta is unavailable (read failure) or not positive (a SOL leg
+          // whose fees ate the credit).
+          const beforeHeld = yield* readWalletSnapshot().pipe(
+            Effect.catch(() => Effect.succeed(null)),
+          );
+          const beforeNativeSol = yield* readNativeSolBalance().pipe(
+            Effect.catch(() => Effect.succeed(null)),
+          );
+          const tokenXMint = dlmm.lbPair.tokenXMint.toBase58();
+          const tokenYMint = dlmm.lbPair.tokenYMint.toBase58();
 
           const txs = yield* Effect.tryPromise(() =>
             dlmm.removeLiquidity({
@@ -2560,13 +2604,49 @@ export const AdapterLive = Layer.effect(
           }
           yield* invalidateBalanceCaches;
 
+          const snapshotWithdrawnXAtomic = positionData.totalXAmountExcludeTransferFee
+            .add(positionData.feeXExcludeTransferFee)
+            .toString();
+          const snapshotWithdrawnYAtomic = positionData.totalYAmountExcludeTransferFee
+            .add(positionData.feeYExcludeTransferFee)
+            .toString();
+
+          // Prefer the measured wallet delta (post-close minus pre-close) per
+          // leg. The delta includes swept fees/rewards (shouldClaimAndClose),
+          // which is exactly what the settlement must sell. Falls back to the
+          // SDK snapshot when the delta is unmeasurable or non-positive.
+          const afterHeld = yield* readWalletSnapshot().pipe(
+            Effect.catch(() => Effect.succeed(null)),
+          );
+          const afterNativeSol = yield* readNativeSolBalance().pipe(
+            Effect.catch(() => Effect.succeed(null)),
+          );
+          const withdrawnXAtomic = measureWithdrawalDelta({
+            beforeHeld: beforeHeld?.held ?? null,
+            afterHeld: afterHeld?.held ?? null,
+            beforeNativeSol,
+            afterNativeSol,
+            mint: tokenXMint,
+            snapshotAmount: snapshotWithdrawnXAtomic,
+          });
+          const withdrawnYAtomic = measureWithdrawalDelta({
+            beforeHeld: beforeHeld?.held ?? null,
+            afterHeld: afterHeld?.held ?? null,
+            beforeNativeSol,
+            afterNativeSol,
+            mint: tokenYMint,
+            snapshotAmount: snapshotWithdrawnYAtomic,
+          });
+          const pendingFeeXAtomic = positionData.feeXExcludeTransferFee.toString();
+          const pendingFeeYAtomic = positionData.feeYExcludeTransferFee.toString();
+          const rewardOneAtomic = positionData.rewardOneExcludeTransferFee;
+          const rewardTwoAtomic = positionData.rewardTwoExcludeTransferFee;
+
           // USD pricing is best-effort and runs ONLY after the close txs land —
           // it must never abort or delay removing bleeding liquidity. Any
           // failure resolves the USD legs to null (never 0, never the mark) so
           // the caller books a NULL realized PnL; atomics are always returned.
           const accounting = yield* Effect.gen(function* () {
-            const tokenXMint = dlmm.lbPair.tokenXMint.toBase58();
-            const tokenYMint = dlmm.lbPair.tokenYMint.toBase58();
             const decimalsX = dlmm.tokenX.mint.decimals;
             const decimalsY = dlmm.tokenY.mint.decimals;
 

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -172,11 +172,14 @@ export function atomicToUnits(amountAtomic: bigint, decimals: number): number {
  * reporting $24.38 — $17.53 vanished from the ledger and the exit settlement
  * sold only the snapshot amount). The wallet's balance DELTA around the close
  * batch is the on-chain truth. Prefer it per leg; fall back to the SDK
- * snapshot when the delta is unmeasurable (reads failed) or non-positive (a
- * SOL leg whose tx fees ate the credit). `measured: true` marks a delta-based
- * result — a measured amount may include swept LM rewards (shouldClaimAndClose)
- * that the exit books separately, so the caller can exclude same-mint rewards;
- * the snapshot amount never includes them.
+ * snapshot when the delta is genuinely unmeasurable (reads timed out /
+ * failed) or negative (a SOL leg whose tx fees ate the credit, or a leg whose
+ * balance moved DOWN during the window). An observed ZERO delta is a measured
+ * zero — the empty leg of a single-sided position is routine, not a fallback.
+ * `measured: true` marks a delta-based result — a measured amount may include
+ * swept LM rewards (shouldClaimAndClose) that the exit books separately, so
+ * the caller can exclude same-mint rewards; the snapshot amount never
+ * includes them.
  */
 export function measureWithdrawalDelta(input: {
   readonly beforeHeld: ReadonlyMap<
@@ -201,13 +204,15 @@ export function measureWithdrawalDelta(input: {
   if (input.mint === SOL_MINT) {
     if (input.beforeNativeSol === null || input.afterNativeSol === null) return fallback();
     const delta = input.afterNativeSol - input.beforeNativeSol;
-    return delta > 0n ? { amountAtomic: delta.toString(), measured: true } : fallback();
+    if (delta < 0n) return fallback();
+    return { amountAtomic: delta.toString(), measured: true };
   }
   if (input.beforeHeld === null || input.afterHeld === null) return fallback();
   const before = input.beforeHeld.get(input.mint)?.amountAtomic ?? 0n;
   const after = input.afterHeld.get(input.mint)?.amountAtomic ?? 0n;
   const delta = after - before;
-  return delta > 0n ? { amountAtomic: delta.toString(), measured: true } : fallback();
+  if (delta < 0n) return fallback();
+  return { amountAtomic: delta.toString(), measured: true };
 }
 
 /**

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -2716,6 +2716,15 @@ export const AdapterLive = Layer.effect(
           });
           const withdrawnXAtomic = excludeSameMintRewards(measuredX, tokenXMint, rewardSlots);
           const withdrawnYAtomic = excludeSameMintRewards(measuredY, tokenYMint, rewardSlots);
+          if (!measuredX.measured || !measuredY.measured) {
+            // The measured flag distinguishes on-chain-delta withdrawals from
+            // the known-understating SDK snapshot in the audit trail — a
+            // silent fallback would defeat the point of #205. Exits are rare,
+            // so an unbounded warn per exit is fine.
+            logger.warn(
+              `[exit] withdrawal delta unmeasured for ${positionPubkey.toBase58()} — booking SDK snapshot amounts (X: ${measuredX.measured ? "measured" : "snapshot"}, Y: ${measuredY.measured ? "measured" : "snapshot"})`,
+            );
+          }
           const pendingFeeXAtomic = positionData.feeXExcludeTransferFee.toString();
           const pendingFeeYAtomic = positionData.feeYExcludeTransferFee.toString();
 

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -227,7 +227,11 @@ export function excludeSameMintRewards(
   for (const slot of rewardSlots) {
     if (slot.mint === mint) result -= slot.amountAtomic;
   }
-  return result > 0n ? result.toString() : measured.amountAtomic;
+  // Preserve an exactly-zero leg (an empty position leg whose measured delta
+  // was entirely a same-mint swept reward — the reward books separately, so
+  // the leg itself has no value). Fall back only for a genuinely invalid
+  // NEGATIVE result (measurement inconsistency: reward exceeds the delta).
+  return result >= 0n ? result.toString() : measured.amountAtomic;
 }
 const logger = createLogger("adapter-service");
 

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -173,7 +173,10 @@ export function atomicToUnits(amountAtomic: bigint, decimals: number): number {
  * sold only the snapshot amount). The wallet's balance DELTA around the close
  * batch is the on-chain truth. Prefer it per leg; fall back to the SDK
  * snapshot when the delta is unmeasurable (reads failed) or non-positive (a
- * SOL leg whose tx fees ate the credit).
+ * SOL leg whose tx fees ate the credit). `measured: true` marks a delta-based
+ * result — a measured amount may include swept LM rewards (shouldClaimAndClose)
+ * that the exit books separately, so the caller can exclude same-mint rewards;
+ * the snapshot amount never includes them.
  */
 export function measureWithdrawalDelta(input: {
   readonly beforeHeld: ReadonlyMap<
@@ -188,19 +191,43 @@ export function measureWithdrawalDelta(input: {
   readonly afterNativeSol: bigint | null;
   readonly mint: string;
   readonly snapshotAmount: string;
-}): string {
-  if (input.beforeHeld === null || input.afterHeld === null) return input.snapshotAmount;
+}): { readonly amountAtomic: string; readonly measured: boolean } {
+  const fallback = (): { readonly amountAtomic: string; readonly measured: false } => ({
+    amountAtomic: input.snapshotAmount,
+    measured: false,
+  });
+  // Native SOL is measured from the balance delta alone — an SPL holdings
+  // read failing must not block a measurable SOL leg.
   if (input.mint === SOL_MINT) {
-    if (input.beforeNativeSol === null || input.afterNativeSol === null) {
-      return input.snapshotAmount;
-    }
+    if (input.beforeNativeSol === null || input.afterNativeSol === null) return fallback();
     const delta = input.afterNativeSol - input.beforeNativeSol;
-    return delta > 0n ? delta.toString() : input.snapshotAmount;
+    return delta > 0n ? { amountAtomic: delta.toString(), measured: true } : fallback();
   }
+  if (input.beforeHeld === null || input.afterHeld === null) return fallback();
   const before = input.beforeHeld.get(input.mint)?.amountAtomic ?? 0n;
   const after = input.afterHeld.get(input.mint)?.amountAtomic ?? 0n;
   const delta = after - before;
-  return delta > 0n ? delta.toString() : input.snapshotAmount;
+  return delta > 0n ? { amountAtomic: delta.toString(), measured: true } : fallback();
+}
+
+/**
+ * Exclude a same-mint swept LM reward from a MEASURED withdrawal delta: the
+ * whole-wallet delta includes the reward (shouldClaimAndClose sweeps it into
+ * the same ATA), and the exit books it separately via sweptRewards — without
+ * this subtraction it would be double-counted. Snapshot-based (unmeasured)
+ * amounts never include rewards and are returned unchanged.
+ */
+export function excludeSameMintRewards(
+  measured: { readonly amountAtomic: string; readonly measured: boolean },
+  mint: string,
+  rewardSlots: ReadonlyArray<{ readonly mint: string | null; readonly amountAtomic: bigint }>,
+): string {
+  if (!measured.measured) return measured.amountAtomic;
+  let result = BigInt(measured.amountAtomic);
+  for (const slot of rewardSlots) {
+    if (slot.mint === mint) result -= slot.amountAtomic;
+  }
+  return result > 0n ? result.toString() : measured.amountAtomic;
 }
 const logger = createLogger("adapter-service");
 
@@ -1177,6 +1204,51 @@ export const AdapterLive = Layer.effect(
     }
 
     /**
+     * Raw per-mint SPL holdings across Token Program + Token-2022, WITHOUT
+     * USD pricing. Two unfiltered reads capture all ATAs (pool residues,
+     * reward mints, wSOL); amounts accumulate per mint. Used by
+     * readWalletSnapshot (which adds pricing) and by the exit path's
+     * before/after withdrawal-delta measurement (issue #205 — the delta only
+     * needs amounts, and pricing must not delay broadcasting an exit).
+     */
+    function readWalletHoldingsRaw(): Effect.Effect<
+      ReadonlyMap<string, { readonly amountAtomic: bigint; readonly decimals: number }>,
+      Error
+    > {
+      return Effect.gen(function* () {
+        const held = new Map<string, { amountAtomic: bigint; decimals: number }>();
+        if (!wallet) return held;
+        for (const programId of [TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID]) {
+          const accounts = yield* rpcCall((conn) =>
+            conn.getParsedTokenAccountsByOwner(wallet.publicKey, { programId }),
+          );
+          for (const account of accounts.value) {
+            const data = account.account.data;
+            if (!isObject(data)) continue;
+            const parsed = data["parsed"];
+            if (!isObject(parsed)) continue;
+            const info = parsed["info"];
+            if (!isObject(info)) continue;
+            const mint = info["mint"];
+            if (typeof mint !== "string") continue;
+            const tokenAmount = info["tokenAmount"];
+            if (!isObject(tokenAmount)) continue;
+            const amountRaw = tokenAmount["amount"];
+            const decimals = tokenAmount["decimals"];
+            if (typeof amountRaw !== "string" || typeof decimals !== "number") continue;
+            if (!/^\d+$/.test(amountRaw)) continue;
+            const amountAtomic = BigInt(amountRaw);
+            if (amountAtomic <= 0n) continue; // skip empty / rent-only ATAs
+            const existing = held.get(mint);
+            if (existing) existing.amountAtomic += amountAtomic;
+            else held.set(mint, { amountAtomic, decimals });
+          }
+        }
+        return held;
+      });
+    }
+
+    /**
      * One chain reconciliation of the wallet: the aggregate USD balance AND
      * the per-mint SPL holdings it is computed from. Both are served from the
      * SAME cached snapshot (same TTL, same invalidation after every mutating
@@ -1207,37 +1279,8 @@ export const AdapterLive = Layer.effect(
         const lamports = Number(yield* readNativeSolBalance());
 
         // Reconcile EVERY SPL token account the wallet holds, across both the
-        // legacy Token Program and Token-2022. Two unfiltered reads (no mint
-        // filter) capture all ATAs — pool-token residues, single-sided-entry
-        // leftovers, reward mints and wSOL ATAs — which the old SOL+USDC-only
-        // read left invisible. Amounts accumulate per mint.
-        const held = new Map<string, { amountAtomic: bigint; decimals: number }>();
-        for (const programId of [TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID]) {
-          const accounts = yield* rpcCall((conn) =>
-            conn.getParsedTokenAccountsByOwner(wallet.publicKey, { programId }),
-          );
-          for (const account of accounts.value) {
-            const data = account.account.data;
-            if (!isObject(data)) continue;
-            const parsed = data["parsed"];
-            if (!isObject(parsed)) continue;
-            const info = parsed["info"];
-            if (!isObject(info)) continue;
-            const mint = info["mint"];
-            if (typeof mint !== "string") continue;
-            const tokenAmount = info["tokenAmount"];
-            if (!isObject(tokenAmount)) continue;
-            const amountRaw = tokenAmount["amount"];
-            const decimals = tokenAmount["decimals"];
-            if (typeof amountRaw !== "string" || typeof decimals !== "number") continue;
-            if (!/^\d+$/.test(amountRaw)) continue;
-            const amountAtomic = BigInt(amountRaw);
-            if (amountAtomic <= 0n) continue; // skip empty / rent-only ATAs
-            const existing = held.get(mint);
-            if (existing) existing.amountAtomic += amountAtomic;
-            else held.set(mint, { amountAtomic, decimals });
-          }
-        }
+        // legacy Token Program and Token-2022 (see readWalletHoldingsRaw).
+        const held = yield* readWalletHoldingsRaw();
 
         // Price every discovered mint plus native SOL in ONE batched call.
         // useFallback: false — an unresolvable price becomes 0 below (never a
@@ -2561,21 +2604,32 @@ export const AdapterLive = Layer.effect(
           // gross for plain SPL and are correct (net-of-fee) for token-2022.
           //
           // Issue #205: the SDK snapshot can understate the actual withdrawal
-          // (observed: position worth $41.91 closed as all-USDC, snapshot
-          // reported 24.38 — 17.53 USDC vanished from the ledger and the
-          // settlement sold only the snapshot amount). The wallet's balance
-          // DELTA around the close batch is the on-chain truth: measure it
-          // per leg and prefer it, falling back to the SDK snapshot when the
-          // delta is unavailable (read failure) or not positive (a SOL leg
-          // whose fees ate the credit).
-          const beforeHeld = yield* readWalletSnapshot().pipe(
-            Effect.catch(() => Effect.succeed(null)),
-          );
-          const beforeNativeSol = yield* readNativeSolBalance().pipe(
-            Effect.catch(() => Effect.succeed(null)),
-          );
           const tokenXMint = dlmm.lbPair.tokenXMint.toBase58();
           const tokenYMint = dlmm.lbPair.tokenYMint.toBase58();
+          const rewardOneAtomic = positionData.rewardOneExcludeTransferFee;
+          const rewardTwoAtomic = positionData.rewardTwoExcludeTransferFee;
+          // Reward slots (mint + pending atomic), resolved once and shared by
+          // the same-mint reward exclusion on the measured withdrawal delta
+          // and the sweptRewards ledger below.
+          const rewardInfos = dlmm.lbPair.rewardInfos;
+          const mintOf = (mint: PublicKey | undefined): string | null => {
+            const base58 = mint?.toBase58();
+            return base58 != null && base58 !== DEFAULT_PUBLIC_KEY ? base58 : null;
+          };
+          const rewardSlots = [
+            { mint: mintOf(rewardInfos[0]?.mint), amountAtomic: rewardOneAtomic },
+            { mint: mintOf(rewardInfos[1]?.mint), amountAtomic: rewardTwoAtomic },
+          ].filter((s) => s.amountAtomic > 0n);
+
+          // Pre-close wallet holdings WITHOUT pricing (a price lookup must not
+          // delay broadcasting an exit) and a FORCED native-SOL read (bypasses
+          // the 30s cache so the measured delta covers only the close window).
+          const beforeHeld = yield* readWalletHoldingsRaw().pipe(
+            Effect.catch(() => Effect.succeed(null)),
+          );
+          const beforeNativeSol = yield* readNativeSolBalance({ force: true }).pipe(
+            Effect.catch(() => Effect.succeed(null)),
+          );
 
           const txs = yield* Effect.tryPromise(() =>
             dlmm.removeLiquidity({
@@ -2613,34 +2667,35 @@ export const AdapterLive = Layer.effect(
 
           // Prefer the measured wallet delta (post-close minus pre-close) per
           // leg. The delta includes swept fees/rewards (shouldClaimAndClose),
-          // which is exactly what the settlement must sell. Falls back to the
-          // SDK snapshot when the delta is unmeasurable or non-positive.
-          const afterHeld = yield* readWalletSnapshot().pipe(
+          // which is exactly what the settlement must sell — same-mint rewards
+          // are excluded because the exit books them separately. Falls back to
+          // the SDK snapshot when the delta is unmeasurable or non-positive.
+          const afterHeld = yield* readWalletHoldingsRaw().pipe(
             Effect.catch(() => Effect.succeed(null)),
           );
           const afterNativeSol = yield* readNativeSolBalance().pipe(
             Effect.catch(() => Effect.succeed(null)),
           );
-          const withdrawnXAtomic = measureWithdrawalDelta({
-            beforeHeld: beforeHeld?.held ?? null,
-            afterHeld: afterHeld?.held ?? null,
+          const measuredX = measureWithdrawalDelta({
+            beforeHeld,
+            afterHeld,
             beforeNativeSol,
             afterNativeSol,
             mint: tokenXMint,
             snapshotAmount: snapshotWithdrawnXAtomic,
           });
-          const withdrawnYAtomic = measureWithdrawalDelta({
-            beforeHeld: beforeHeld?.held ?? null,
-            afterHeld: afterHeld?.held ?? null,
+          const measuredY = measureWithdrawalDelta({
+            beforeHeld,
+            afterHeld,
             beforeNativeSol,
             afterNativeSol,
             mint: tokenYMint,
             snapshotAmount: snapshotWithdrawnYAtomic,
           });
+          const withdrawnXAtomic = excludeSameMintRewards(measuredX, tokenXMint, rewardSlots);
+          const withdrawnYAtomic = excludeSameMintRewards(measuredY, tokenYMint, rewardSlots);
           const pendingFeeXAtomic = positionData.feeXExcludeTransferFee.toString();
           const pendingFeeYAtomic = positionData.feeYExcludeTransferFee.toString();
-          const rewardOneAtomic = positionData.rewardOneExcludeTransferFee;
-          const rewardTwoAtomic = positionData.rewardTwoExcludeTransferFee;
 
           // USD pricing is best-effort and runs ONLY after the close txs land —
           // it must never abort or delay removing bleeding liquidity. Any
@@ -2649,22 +2704,6 @@ export const AdapterLive = Layer.effect(
           const accounting = yield* Effect.gen(function* () {
             const decimalsX = dlmm.tokenX.mint.decimals;
             const decimalsY = dlmm.tokenY.mint.decimals;
-
-            const rewardInfos = dlmm.lbPair.rewardInfos;
-            const mintOf = (mint: PublicKey | undefined): string | null => {
-              const base58 = mint?.toBase58();
-              return base58 != null && base58 !== DEFAULT_PUBLIC_KEY ? base58 : null;
-            };
-            const rewardSlots = [
-              {
-                mint: mintOf(rewardInfos[0]?.mint),
-                amountAtomic: Number(rewardOneAtomic.toString()),
-              },
-              {
-                mint: mintOf(rewardInfos[1]?.mint),
-                amountAtomic: Number(rewardTwoAtomic.toString()),
-              },
-            ].filter((s) => Number.isFinite(s.amountAtomic) && s.amountAtomic > 0);
 
             const priceMints = [
               tokenXMint,
@@ -2715,7 +2754,7 @@ export const AdapterLive = Layer.effect(
               }
               sweptRewards.push({
                 mint: slot.mint ?? "unknown",
-                amountAtomic: slot.amountAtomic,
+                amountAtomic: Number(slot.amountAtomic.toString()),
                 amountUsd,
               });
             }

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -229,9 +229,10 @@ export function excludeSameMintRewards(
   }
   // Preserve an exactly-zero leg (an empty position leg whose measured delta
   // was entirely a same-mint swept reward — the reward books separately, so
-  // the leg itself has no value). Fall back only for a genuinely invalid
-  // NEGATIVE result (measurement inconsistency: reward exceeds the delta).
-  return result >= 0n ? result.toString() : measured.amountAtomic;
+  // the leg itself has no value). A NEGATIVE result (reward exceeds the
+  // delta: measurement inconsistency) likewise resolves to 0 — returning the
+  // reward-inclusive delta would re-introduce the same-mint double count.
+  return result >= 0n ? result.toString() : "0";
 }
 const logger = createLogger("adapter-service");
 

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -26,7 +26,7 @@ import DLMM, {
   type StrategyParameters,
 } from "@meteora-ag/dlmm";
 import { BN } from "@coral-xyz/anchor";
-import { Effect, Layer } from "effect";
+import { Duration, Effect, Layer } from "effect";
 import {
   AdapterService,
   type AdapterApi,
@@ -2629,12 +2629,24 @@ export const AdapterLive = Layer.effect(
           // Pre-close wallet holdings WITHOUT pricing (a price lookup must not
           // delay broadcasting an exit) and a FORCED native-SOL read (bypasses
           // the 30s cache so the measured delta covers only the close window).
-          const beforeHeld = yield* readWalletHoldingsRaw().pipe(
-            Effect.catch(() => Effect.succeed(null)),
-          );
-          const beforeNativeSol = yield* readNativeSolBalance({ force: true }).pipe(
-            Effect.catch(() => Effect.succeed(null)),
-          );
+          // Both are best-effort with a short deadline: a degraded primary RPC
+          // must not postpone a risk-driven EXIT through the full retry chain
+          // (2 × 15s attempts per rpcCall, repeatable on the fallback).
+          const preClose = yield* Effect.all(
+            {
+              held: readWalletHoldingsRaw().pipe(Effect.catch(() => Effect.succeed(null))),
+              nativeSol: readNativeSolBalance({ force: true }).pipe(
+                Effect.catch(() => Effect.succeed(null)),
+              ),
+            },
+            { concurrency: "unbounded" },
+          )
+            .pipe(
+              Effect.timeout(Duration.millis(2000)),
+              Effect.catch(() => Effect.succeed({ held: null, nativeSol: null })),
+            );
+          const beforeHeld = preClose.held;
+          const beforeNativeSol = preClose.nativeSol;
 
           const txs = yield* Effect.tryPromise(() =>
             dlmm.removeLiquidity({
@@ -2675,25 +2687,30 @@ export const AdapterLive = Layer.effect(
           // which is exactly what the settlement must sell — same-mint rewards
           // are excluded because the exit books them separately. Falls back to
           // the SDK snapshot when the delta is unmeasurable or non-positive.
-          const afterHeld = yield* readWalletHoldingsRaw().pipe(
-            Effect.catch(() => Effect.succeed(null)),
-          );
-          const afterNativeSol = yield* readNativeSolBalance().pipe(
-            Effect.catch(() => Effect.succeed(null)),
-          );
+          const afterSnapshot = yield* Effect.all(
+            {
+              held: readWalletHoldingsRaw().pipe(Effect.catch(() => Effect.succeed(null))),
+              nativeSol: readNativeSolBalance().pipe(Effect.catch(() => Effect.succeed(null))),
+            },
+            { concurrency: "unbounded" },
+          )
+            .pipe(
+              Effect.timeout(Duration.millis(2000)),
+              Effect.catch(() => Effect.succeed({ held: null, nativeSol: null })),
+            );
           const measuredX = measureWithdrawalDelta({
             beforeHeld,
-            afterHeld,
+            afterHeld: afterSnapshot.held,
             beforeNativeSol,
-            afterNativeSol,
+            afterNativeSol: afterSnapshot.nativeSol,
             mint: tokenXMint,
             snapshotAmount: snapshotWithdrawnXAtomic,
           });
           const measuredY = measureWithdrawalDelta({
             beforeHeld,
-            afterHeld,
+            afterHeld: afterSnapshot.held,
             beforeNativeSol,
-            afterNativeSol,
+            afterNativeSol: afterSnapshot.nativeSol,
             mint: tokenYMint,
             snapshotAmount: snapshotWithdrawnYAtomic,
           });

--- a/engine/autonomous-runtime.ts
+++ b/engine/autonomous-runtime.ts
@@ -702,10 +702,16 @@ export function processSettlementJobs(
         settlementCostUsd: executionCostUsd,
         executionCostUsd: 0,
       });
+      // Issue #205: the exit's withdrawal-based realized PnL is authoritative
+      // once resolved — never clobber it with a settlement-output-derived
+      // figure. The settlement can be PARTIAL (observed: $24.38 sold of a
+      // $41.91 withdrawal recomputed a correct +$0.78 exit into -$16.78).
+      // Only fill the NULL case (exit pricing was unresolved).
+      const effectiveRealizedPnlUsd = position.realizedPnlUsd ?? realizedPnlUsd;
       yield* input.db
         .finalizeSettlementGroup({
           positionId,
-          realizedPnlUsd,
+          realizedPnlUsd: effectiveRealizedPnlUsd,
           jobIds: jobs.map((job) => job.id),
           finalizedAt: input.now,
           signalSnapshotId: position.entrySignalSnapshotId,


### PR DESCRIPTION
Fixes the exit-accounting bug found via the jup.ag cross-check: the exit's SDK position snapshot understated the real withdrawal, and the settlement finalize clobbered the correct realized PnL.

## Root cause (live-verified)
- On-chain close credited the wallet **+41.91 USDC** (2.44 → 44.35) — the position was all-USDC
- The SDK snapshot reported withdrawn = **24.38 USDC** — $17.53 missing from the ledger
- Exit settlement sold only the snapshot amount (24.38), leaving ~$17 in the wallet
- `finalizeSettlementGroup` recomputed realized from the **partial** settlement outputs → **-16.78**, overwriting the correct +0.78

## Fix
1. **`exitPosition`**: each leg's withdrawal is now measured as the wallet balance **delta around the close batch** (the on-chain truth; includes swept fees/rewards). Falls back to the SDK snapshot when the delta is unmeasurable or non-positive (native-SOL leg whose tx fees ate the credit). New pure `measureWithdrawalDelta` helper.
2. **`finalizeSettlementGroup`**: only fills realized PnL when the exit left it **NULL** (unresolved pricing). A resolved exit realized is authoritative and never overwritten.

Tests: 6 delta-helper cases (including the exact 41.91-vs-24.38 live case) + 2 finalize cases. 1648/1648 suite, tsc 0, oxlint 0.

## Summary by Sourcery

Correct exit-accounting to use on-chain wallet balance deltas for withdrawals and prevent settlement processing from overwriting resolved realized PnL.

Bug Fixes:
- Measure per-leg exit withdrawals from wallet balance changes around the close batch, falling back to SDK snapshot only when deltas are unavailable or non-positive.
- Ensure settlement finalization only fills realized PnL when the exit left it unresolved (null), preserving any already-resolved exit PnL.

Tests:
- Add unit tests covering withdrawal delta measurement for SPL and native SOL legs, including the live 41.91-vs-24.38 under-withdrawal case and fallback scenarios.
- Add tests validating that settlement-derived realized PnL does not clobber resolved exit PnL and correctly fills when the exit left it null.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved withdrawal accounting by measuring actual token and SOL balance changes after position closures.
  * Added fallback handling when wallet balances cannot be read or measured deltas are unavailable.
  * Included swept fees and rewards more accurately in settlement calculations.
  * Preserved previously finalized realized PnL instead of overwriting it with conflicting settlement data.
  * Populated missing realized PnL from recovered settlement proceeds and costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->