### PR TITLE
feat(launch): multi-timeframe window probes + rejection histogram (#206)

### DIFF
--- a/bench/launch-gate.test.ts
+++ b/bench/launch-gate.test.ts
@@ -183,16 +183,15 @@ describe("gateAndRankLaunchPools", () => {
 });
 
 describe("summarizeLaunchRejections", () => {
-  it("counts reasons and returns the top-N, highest count first", () => {
+  it("groups by stable category — value-embedded reasons do not fragment the histogram", () => {
     const summary = summarizeLaunchRejections([
-      { reason: "age 5.0h > 6h" },
-      { reason: "age 5.0h > 6h" },
-      { reason: "tvl 200000 > 1000000 (established, not a launch)" },
-      { reason: "age 5.0h > 6h" },
+      { category: "age" },
+      { category: "age" },
+      { category: "tvl" },
+      { category: "age" },
     ]);
-    expect(summary[0]!.reason).toContain("age");
-    expect(summary[0]!.count).toBe(3);
-    expect(summary[1]!.reason).toContain("tvl");
+    expect(summary[0]).toEqual({ category: "age", count: 3 });
+    expect(summary[1]).toEqual({ category: "tvl", count: 1 });
     expect(summary).toHaveLength(2);
   });
 
@@ -201,7 +200,7 @@ describe("summarizeLaunchRejections", () => {
   });
 
   it("clamps topN to at least one", () => {
-    const summary = summarizeLaunchRejections([{ reason: "a" }, { reason: "b" }], 0);
+    const summary = summarizeLaunchRejections([{ category: "age" }, { category: "tvl" }], 0);
     expect(summary).toHaveLength(1);
   });
 });

--- a/bench/launch-gate.test.ts
+++ b/bench/launch-gate.test.ts
@@ -183,15 +183,18 @@ describe("gateAndRankLaunchPools", () => {
 });
 
 describe("summarizeLaunchRejections", () => {
-  it("groups by stable category — value-embedded reasons do not fragment the histogram", () => {
+  it("groups by stable category and keeps one example reason per bucket", () => {
     const summary = summarizeLaunchRejections([
-      { category: "age" },
-      { category: "age" },
-      { category: "tvl" },
-      { category: "age" },
+      { category: "age", reason: "age 5.9h > 6h" },
+      { category: "age", reason: "age 40h > 6h" },
+      { category: "tvl", reason: "tvl 200000 > 1000000 (established, not a launch)" },
+      { category: "age", reason: "age 7.2h > 6h" },
     ]);
-    expect(summary[0]).toEqual({ category: "age", count: 3 });
-    expect(summary[1]).toEqual({ category: "tvl", count: 1 });
+    expect(summary[0]!.category).toBe("age");
+    expect(summary[0]!.count).toBe(3);
+    expect(summary[0]!.example).toBe("age 5.9h > 6h");
+    expect(summary[1]!.category).toBe("tvl");
+    expect(summary[1]!.count).toBe(1);
     expect(summary).toHaveLength(2);
   });
 
@@ -200,7 +203,10 @@ describe("summarizeLaunchRejections", () => {
   });
 
   it("clamps topN to at least one", () => {
-    const summary = summarizeLaunchRejections([{ category: "age" }, { category: "tvl" }], 0);
+    const summary = summarizeLaunchRejections(
+      [{ category: "age", reason: "a" }, { category: "tvl", reason: "b" }],
+      0,
+    );
     expect(summary).toHaveLength(1);
   });
 });

--- a/bench/launch-gate.test.ts
+++ b/bench/launch-gate.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect } from "vitest";
 import {
   gateAndRankLaunchPools,
+  summarizeLaunchRejections,
   type LaunchGateConfig,
   type LaunchGateResult,
   type LaunchPoolRank,
@@ -178,5 +179,29 @@ describe("gateAndRankLaunchPools", () => {
     const rankedAddresses = result.ranked.map((r: LaunchPoolRank) => r.pool.address);
     expect(rankedAddresses).toEqual(["hot", "mid", "low"]);
     expect(result.rejected).toHaveLength(0);
+  });
+});
+
+describe("summarizeLaunchRejections", () => {
+  it("counts reasons and returns the top-N, highest count first", () => {
+    const summary = summarizeLaunchRejections([
+      { reason: "age 5.0h > 6h" },
+      { reason: "age 5.0h > 6h" },
+      { reason: "tvl 200000 > 1000000 (established, not a launch)" },
+      { reason: "age 5.0h > 6h" },
+    ]);
+    expect(summary[0]!.reason).toContain("age");
+    expect(summary[0]!.count).toBe(3);
+    expect(summary[1]!.reason).toContain("tvl");
+    expect(summary).toHaveLength(2);
+  });
+
+  it("returns empty for an empty rejection list", () => {
+    expect(summarizeLaunchRejections([])).toEqual([]);
+  });
+
+  it("clamps topN to at least one", () => {
+    const summary = summarizeLaunchRejections([{ reason: "a" }, { reason: "b" }], 0);
+    expect(summary).toHaveLength(1);
   });
 });

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -389,6 +389,21 @@ function isValidPoolShape(v: unknown): v is MeteoraPool {
 }
 
 /**
+ * Extract the finite numeric values of a Data API rolling-window object
+ * (e.g. `fee_tvl_ratio` / `volume` with 30m/1h/2h/4h/12h/24h labels). Empty
+ * when the object is missing or carries no finite windows.
+ */
+function readWindowMap(raw: unknown): Map<string, number> {
+  if (!isObject(raw)) return new Map();
+  const out = new Map<string, number>();
+  for (const window of ["30m", "1h", "2h", "4h", "12h", "24h"] as const) {
+    const value = raw[window];
+    if (typeof value === "number" && Number.isFinite(value)) out.set(window, value);
+  }
+  return out;
+}
+
+/**
  * Shared row→DiscoveredPool mapper used by both discovery paths (rotating
  * single-page discovery and the market-scan universe refresh). Attaches the
  * Data API's token-safety metadata (verified / freeze-disabled / holders /
@@ -397,6 +412,12 @@ function isValidPoolShape(v: unknown): v is MeteoraPool {
  */
 function toDiscoveredPool(p: MeteoraPool): DiscoveredPool {
   const { token_x: tokenX, token_y: tokenY } = p;
+  // Rolling-window curves (30m/1h/2h/4h/12h/24h) for the radar's
+  // multi-timeframe probes: the list payload carries fee-yield AND volume
+  // windows per pool, so wash patterns (a burst confined to one window) and
+  // hotness cross-checks surface with no extra API call.
+  const feeYieldWindows = readWindowMap(p.fee_tvl_ratio);
+  const volumeWindows = readWindowMap(p.volume);
   return {
     address: p.address,
     tvlUsd: p.tvl,
@@ -423,6 +444,12 @@ function toDiscoveredPool(p: MeteoraPool): DiscoveredPool {
     ...(typeof p.fee_tvl_ratio?.["1h"] === "number" && Number.isFinite(p.fee_tvl_ratio["1h"])
       ? { feeYield1hPct: p.fee_tvl_ratio["1h"] }
       : {}),
+    // Rolling-window curves for the radar's multi-timeframe probes: the same
+    // payload carries 30m/1h/2h/4h/12h/24h fee-yield and volume windows, so
+    // the radar can surface wash patterns (a burst confined to one window)
+    // and cross-check hotness without any extra API call.
+    ...(feeYieldWindows.size > 0 ? { feeYieldWindows: Object.fromEntries(feeYieldWindows) } : {}),
+    ...(volumeWindows.size > 0 ? { volumeWindows: Object.fromEntries(volumeWindows) } : {}),
     ...(typeof p.pool_config?.base_fee_pct === "number" &&
     Number.isFinite(p.pool_config.base_fee_pct)
       ? { baseFeePct: p.pool_config.base_fee_pct }
@@ -2645,11 +2672,10 @@ export const AdapterLive = Layer.effect(
               ),
             },
             { concurrency: "unbounded" },
-          )
-            .pipe(
-              Effect.timeout(Duration.millis(2000)),
-              Effect.catch(() => Effect.succeed({ held: null, nativeSol: null })),
-            );
+          ).pipe(
+            Effect.timeout(Duration.millis(2000)),
+            Effect.catch(() => Effect.succeed({ held: null, nativeSol: null })),
+          );
           const beforeHeld = preClose.held;
           const beforeNativeSol = preClose.nativeSol;
 
@@ -2698,11 +2724,10 @@ export const AdapterLive = Layer.effect(
               nativeSol: readNativeSolBalance().pipe(Effect.catch(() => Effect.succeed(null))),
             },
             { concurrency: "unbounded" },
-          )
-            .pipe(
-              Effect.timeout(Duration.millis(2000)),
-              Effect.catch(() => Effect.succeed({ held: null, nativeSol: null })),
-            );
+          ).pipe(
+            Effect.timeout(Duration.millis(2000)),
+            Effect.catch(() => Effect.succeed({ held: null, nativeSol: null })),
+          );
           const measuredX = measureWithdrawalDelta({
             beforeHeld,
             afterHeld: afterSnapshot.held,

--- a/engine/launch-gate.ts
+++ b/engine/launch-gate.ts
@@ -50,27 +50,46 @@ export interface LaunchPoolRank {
 
 export interface LaunchGateResult {
   readonly ranked: ReadonlyArray<LaunchPoolRank>;
-  /** Pools that failed the gate, with the first rejection reason each. */
-  readonly rejected: ReadonlyArray<{ readonly address: string; readonly reason: string }>;
+  /** Pools that failed the gate: the first rejection reason each, bucketed
+   *  by a STABLE category (reason strings embed per-pool values like ages
+   *  and TVLs, so histograms must group by category, not full string). */
+  readonly rejected: ReadonlyArray<{
+    readonly address: string;
+    readonly reason: string;
+    readonly category: LaunchRejectCategory;
+  }>;
 }
 
+/** Stable rejection categories — the histogram keys. */
+export type LaunchRejectCategory =
+  | "missing-data"
+  | "created-at"
+  | "age"
+  | "tvl"
+  | "volume-1h"
+  | "base-fee"
+  | "bin-step"
+  | "turnover"
+  | "token-safety";
+
 /**
- * Top-N rejection reasons with counts — the radar's observable answer to
- * "why did the universe admit nothing". A pure one-liner over the gate
- * result, extracted for testability.
+ * Top-N rejection categories with counts — the radar's observable answer to
+ * "why did the universe admit nothing". Groups by the stable category, not
+ * the value-embedded reason string (which would fragment one cause into a
+ * thousand buckets). Pure, extracted for testability.
  */
 export function summarizeLaunchRejections(
-  rejected: ReadonlyArray<{ readonly reason: string }>,
+  rejected: ReadonlyArray<{ readonly category: LaunchRejectCategory }>,
   topN = 6,
-): ReadonlyArray<{ readonly reason: string; readonly count: number }> {
-  const counts = new Map<string, number>();
+): ReadonlyArray<{ readonly category: LaunchRejectCategory; readonly count: number }> {
+  const counts = new Map<LaunchRejectCategory, number>();
   for (const r of rejected) {
-    counts.set(r.reason, (counts.get(r.reason) ?? 0) + 1);
+    counts.set(r.category, (counts.get(r.category) ?? 0) + 1);
   }
   return [...counts.entries()]
     .sort((a, b) => b[1] - a[1])
     .slice(0, Math.max(topN, 1))
-    .map(([reason, count]) => ({ reason, count }));
+    .map(([category, count]) => ({ category, count }));
 }
 
 /** Gates and ranks one launch-radar snapshot. Pure; callers feed it the
@@ -80,37 +99,41 @@ export function gateAndRankLaunchPools(
   config: LaunchGateConfig,
 ): LaunchGateResult {
   const ranked: LaunchPoolRank[] = [];
-  const rejected: Array<{ readonly address: string; readonly reason: string }> = [];
+  const rejected: Array<{
+    readonly address: string;
+    readonly reason: string;
+    readonly category: LaunchRejectCategory;
+  }> = [];
 
   for (const pool of pools) {
-    const reject = (reason: string): void => {
-      rejected.push({ address: pool.address, reason });
+    const reject = (reason: string, category: LaunchRejectCategory): void => {
+      rejected.push({ address: pool.address, reason, category });
     };
 
     // Fail closed on missing data — hotness is the point.
     if (pool.feeYield1hPct === undefined || !Number.isFinite(pool.feeYield1hPct)) {
-      reject("missing 1h fee yield");
+      reject("missing 1h fee yield", "missing-data");
       continue;
     }
     if (pool.createdAtMs === undefined) {
-      reject("missing createdAt");
+      reject("missing createdAt", "missing-data");
       continue;
     }
     if (!Number.isFinite(pool.createdAtMs) || pool.createdAtMs > config.now + CLOCK_SKEW_MS) {
-      reject(`createdAt ${pool.createdAtMs} in the future`);
+      reject(`createdAt ${pool.createdAtMs} in the future`, "created-at");
       continue;
     }
     const ageHours = Math.max(0, config.now - pool.createdAtMs) / HOUR_MS;
     if (ageHours > config.maxAgeHours) {
-      reject(`age ${ageHours.toFixed(1)}h > ${config.maxAgeHours}h`);
+      reject(`age ${ageHours.toFixed(1)}h > ${config.maxAgeHours}h`, "age");
       continue;
     }
     if (!Number.isFinite(pool.tvlUsd) || pool.tvlUsd < config.minTvlUsd) {
-      reject(`tvl ${pool.tvlUsd} < ${config.minTvlUsd}`);
+      reject(`tvl ${pool.tvlUsd} < ${config.minTvlUsd}`, "tvl");
       continue;
     }
     if (pool.tvlUsd > config.maxTvlUsd) {
-      reject(`tvl ${pool.tvlUsd} > ${config.maxTvlUsd} (established, not a launch)`);
+      reject(`tvl ${pool.tvlUsd} > ${config.maxTvlUsd} (established, not a launch)`, "tvl");
       continue;
     }
     if (
@@ -118,7 +141,7 @@ export function gateAndRankLaunchPools(
       !Number.isFinite(pool.volume1hUsd) ||
       pool.volume1hUsd < config.minVolume1hUsd
     ) {
-      reject(`1h volume ${pool.volume1hUsd} < ${config.minVolume1hUsd}`);
+      reject(`1h volume ${pool.volume1hUsd} < ${config.minVolume1hUsd}`, "volume-1h");
       continue;
     }
     if (
@@ -126,7 +149,7 @@ export function gateAndRankLaunchPools(
       !Number.isFinite(pool.baseFeePct) ||
       pool.baseFeePct < config.minBaseFeePct
     ) {
-      reject(`base fee ${pool.baseFeePct} < ${config.minBaseFeePct}%`);
+      reject(`base fee ${pool.baseFeePct} < ${config.minBaseFeePct}%`, "base-fee");
       continue;
     }
     if (
@@ -134,17 +157,23 @@ export function gateAndRankLaunchPools(
       pool.binStep < config.minBinStep ||
       pool.binStep > config.maxBinStep
     ) {
-      reject(`binStep ${pool.binStep} outside [${config.minBinStep}, ${config.maxBinStep}]`);
+      reject(
+        `binStep ${pool.binStep} outside [${config.minBinStep}, ${config.maxBinStep}]`,
+        "bin-step",
+      );
       continue;
     }
     // Wash-turnover guard: 24h volume/TVL must land in (0, max].
     if (!Number.isFinite(pool.volume24hUsd) || pool.volume24hUsd <= 0) {
-      reject("no 24h volume (cannot compute turnover)");
+      reject("no 24h volume (cannot compute turnover)", "turnover");
       continue;
     }
     const volumeTurnover = pool.volume24hUsd / pool.tvlUsd;
     if (volumeTurnover > config.maxVolumeTurnover) {
-      reject(`volume turnover ${volumeTurnover.toFixed(1)} > ${config.maxVolumeTurnover} (wash)`);
+      reject(
+        `volume turnover ${volumeTurnover.toFixed(1)} > ${config.maxVolumeTurnover} (wash)`,
+        "turnover",
+      );
       continue;
     }
     // Token-leg safety, same policy as the market gate.
@@ -177,7 +206,7 @@ export function gateAndRankLaunchPools(
           config.minHolders,
         )
       ) {
-        reject(`leg ${leg.symbol ?? leg.mint} fails token safety`);
+        reject(`leg ${leg.symbol ?? leg.mint} fails token safety`, "token-safety");
         legRejected = true;
         break;
       }

--- a/engine/launch-gate.ts
+++ b/engine/launch-gate.ts
@@ -76,20 +76,28 @@ export type LaunchRejectCategory =
  * Top-N rejection categories with counts — the radar's observable answer to
  * "why did the universe admit nothing". Groups by the stable category, not
  * the value-embedded reason string (which would fragment one cause into a
- * thousand buckets). Pure, extracted for testability.
+ * thousand buckets). Each bucket keeps ONE representative reason so the
+ * near-miss margin survives ('age 5.9h > 6h' vs 'age 40h > 6h' — same
+ * bucket, distinguishable example). Pure, extracted for testability.
  */
 export function summarizeLaunchRejections(
-  rejected: ReadonlyArray<{ readonly category: LaunchRejectCategory }>,
+  rejected: ReadonlyArray<{ readonly category: LaunchRejectCategory; readonly reason: string }>,
   topN = 6,
-): ReadonlyArray<{ readonly category: LaunchRejectCategory; readonly count: number }> {
-  const counts = new Map<LaunchRejectCategory, number>();
+): ReadonlyArray<{
+  readonly category: LaunchRejectCategory;
+  readonly count: number;
+  readonly example: string;
+}> {
+  const counts = new Map<LaunchRejectCategory, { count: number; example: string }>();
   for (const r of rejected) {
-    counts.set(r.category, (counts.get(r.category) ?? 0) + 1);
+    const entry = counts.get(r.category);
+    if (entry === undefined) counts.set(r.category, { count: 1, example: r.reason });
+    else entry.count += 1;
   }
   return [...counts.entries()]
-    .sort((a, b) => b[1] - a[1])
+    .sort((a, b) => b[1].count - a[1].count)
     .slice(0, Math.max(topN, 1))
-    .map(([category, count]) => ({ category, count }));
+    .map(([category, { count, example }]) => ({ category, count, example }));
 }
 
 /** Gates and ranks one launch-radar snapshot. Pure; callers feed it the

--- a/engine/launch-gate.ts
+++ b/engine/launch-gate.ts
@@ -54,6 +54,25 @@ export interface LaunchGateResult {
   readonly rejected: ReadonlyArray<{ readonly address: string; readonly reason: string }>;
 }
 
+/**
+ * Top-N rejection reasons with counts — the radar's observable answer to
+ * "why did the universe admit nothing". A pure one-liner over the gate
+ * result, extracted for testability.
+ */
+export function summarizeLaunchRejections(
+  rejected: ReadonlyArray<{ readonly reason: string }>,
+  topN = 6,
+): ReadonlyArray<{ readonly reason: string; readonly count: number }> {
+  const counts = new Map<string, number>();
+  for (const r of rejected) {
+    counts.set(r.reason, (counts.get(r.reason) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, Math.max(topN, 1))
+    .map(([reason, count]) => ({ reason, count }));
+}
+
 /** Gates and ranks one launch-radar snapshot. Pure; callers feed it the
  *  adapter's `discoverHotPools` output. */
 export function gateAndRankLaunchPools(

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -4096,7 +4096,7 @@ export const program = Effect.gen(function* () {
           address: r.pool.address,
           pool: `${r.pool.tokenXSymbol ?? "?"}/${r.pool.tokenYSymbol ?? "?"}`,
           feeYield1hPct: r.feeYield1hPct,
-          feeYield: r.pool.feeYieldWindows,
+          feeYieldWindows: r.pool.feeYieldWindows,
           volumeWindows: r.pool.volumeWindows,
           volume1hUsd: r.volume1hUsd,
           ageHours:
@@ -5397,16 +5397,24 @@ export const program = Effect.gen(function* () {
               ? (datapiStats.feeTvlRatio1h / 100) * pool.tvlUsd
               : null;
           if (currentFees1hUsd === null) {
-            // Data-starved decay guard: with the Data API down (gecko or
-            // heuristic stats), the volume-decay rule cannot fire and the
-            // launch protection degrades to timebox + drawdown. That is an
-            // exceptional, protection-reducing state for an open launch
-            // position — warn per position (bounded: ≤ launch slot count).
-            logger.warn("Launch position: 1h fees unmeasured — volume-decay gate degraded", {
-              pool: pos.poolAddress,
-              position: pos.positionId,
-              statsSource: pool.statsSource,
-            });
+            // Data-starved decay guard: the volume-decay rule needs MEASURED
+            // datapi 1h fees. A non-datapi stats source (gecko/heuristic —
+            // the Data API is down) is a protection-reducing outage for an
+            // open launch position: warn per position (bounded: ≤ launch
+            // slot count). Datapi-up-but-window-missing (a young zero-fee
+            // pool or tvl <= 0) is routine — debug only.
+            if (pool.statsSource !== "datapi") {
+              logger.warn("Launch position: 1h fees unmeasured — volume-decay gate degraded", {
+                pool: pos.poolAddress,
+                position: pos.positionId,
+                statsSource: pool.statsSource,
+              });
+            } else {
+              logger.debug("Launch position: 1h fees unmeasured — volume-decay gate skipped", {
+                pool: pos.poolAddress,
+                position: pos.positionId,
+              });
+            }
           }
           const prevPeak = launchPeakFees1h.get(pos.positionId);
           if (

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -37,7 +37,7 @@ import { EntryPrepLive } from "./entry-prep-service.js";
 import { shouldDiscoverPools } from "./pool-policy.js";
 import { advanceScreenedCandidates } from "./candidate-discovery.js";
 import { gateAndRankMarketPools, type MarketPoolRank } from "./market-gate.js";
-import { gateAndRankLaunchPools } from "./launch-gate.js";
+import { gateAndRankLaunchPools, summarizeLaunchRejections } from "./launch-gate.js";
 import { transitionCandidate } from "./candidate-policy.js";
 import { getPrismUserConfigDir } from "./paths.js";
 
@@ -4052,7 +4052,7 @@ export const program = Effect.gen(function* () {
         }
         return;
       }
-      const { ranked } = gateAndRankLaunchPools(discovered, {
+      const gateResult = gateAndRankLaunchPools(discovered, {
         minTvlUsd: config.launchScanMinTvlUsd ?? 5_000,
         maxTvlUsd: config.launchScanMaxTvlUsd ?? 1_000_000,
         maxAgeHours: config.launchScanMaxAgeHours ?? 6,
@@ -4065,6 +4065,17 @@ export const program = Effect.gen(function* () {
         stablecoinMints: config.stablecoinMints ?? new Set<string>(),
         now,
       });
+      // The radar's observable answer to "why nothing admitted": top
+      // rejection reasons with counts. A 100%-rejection universe is
+      // diagnosable (age cap vs TVL cap vs token-safety floor) instead of a
+      // black box.
+      const rejections = summarizeLaunchRejections(gateResult.rejected);
+      if (gateResult.ranked.length === 0) {
+        logger.info("Launch radar: nothing admitted", {
+          universe: discovered.length,
+          rejections,
+        });
+      }
       // v2 execution lane: the admitted radar set becomes the executable
       // launch pool set, bounded to the top-K by fee yield so the per-cycle
       // RPC/decision cost stays proportional to LAUNCH_SCAN_TOP_K, not the
@@ -4072,18 +4083,21 @@ export const program = Effect.gen(function* () {
       // radar-only path leaves launchScanPools empty and behavior-identical.
       if (config.launchExecutionEnabled === true) {
         launchScanPools.clear();
-        for (const r of ranked.slice(0, config.launchScanTopK ?? 30)) {
+        for (const r of gateResult.ranked.slice(0, config.launchScanTopK ?? 30)) {
           launchScanPools.add(r.pool.address);
         }
       }
       logger.info("Launch radar", {
         universe: discovered.length,
-        admitted: ranked.length,
-        rejected: discovered.length - ranked.length,
-        top: ranked.slice(0, config.launchScanTopK ?? 30).map((r) => ({
+        admitted: gateResult.ranked.length,
+        rejected: discovered.length - gateResult.ranked.length,
+        rejections,
+        top: gateResult.ranked.slice(0, config.launchScanTopK ?? 30).map((r) => ({
           address: r.pool.address,
           pool: `${r.pool.tokenXSymbol ?? "?"}/${r.pool.tokenYSymbol ?? "?"}`,
           feeYield1hPct: r.feeYield1hPct,
+          feeYield: r.pool.feeYieldWindows,
+          volumeWindows: r.pool.volumeWindows,
           volume1hUsd: r.volume1hUsd,
           ageHours:
             r.pool.createdAtMs === undefined
@@ -5383,7 +5397,12 @@ export const program = Effect.gen(function* () {
               ? (datapiStats.feeTvlRatio1h / 100) * pool.tvlUsd
               : null;
           if (currentFees1hUsd === null) {
-            logger.debug("Launch position: 1h fees unmeasured — volume-decay gate skipped", {
+            // Data-starved decay guard: with the Data API down (gecko or
+            // heuristic stats), the volume-decay rule cannot fire and the
+            // launch protection degrades to timebox + drawdown. That is an
+            // exceptional, protection-reducing state for an open launch
+            // position — warn per position (bounded: ≤ launch slot count).
+            logger.warn("Launch position: 1h fees unmeasured — volume-decay gate degraded", {
               pool: pos.poolAddress,
               position: pos.positionId,
               statsSource: pool.statsSource,

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -36,6 +36,9 @@ import type { CopySignalApi } from "./copy-trading-signals.js";
 
 // ─── Adapter Service ─────────────────────────────────────────────────────────
 
+/** Data API fee/volume window labels (rolling windows over the last N). */
+export type DiscoveredWindow = "30m" | "1h" | "2h" | "4h" | "12h" | "24h";
+
 export interface DiscoveredPool {
   readonly address: string;
   readonly tvlUsd: number;
@@ -48,6 +51,12 @@ export interface DiscoveredPool {
   readonly volume1hUsd?: number;
   readonly fees1hUsd?: number;
   readonly feeYield1hPct?: number;
+  /** Rolling-window fee-yield curves (fee_tvl_ratio per window), for the
+   *  radar's multi-timeframe probes (30m/1h/2h/4h/12h/24h). Optional;
+   *  absent when the payload carries no windows. */
+  readonly feeYieldWindows?: Readonly<Partial<Record<DiscoveredWindow, number>>>;
+  /** Rolling-window volume curves, same labels. Optional. */
+  readonly volumeWindows?: Readonly<Partial<Record<DiscoveredWindow, number>>>;
   readonly baseFeePct?: number;
   readonly tokenX: string;
   readonly tokenY: string;


### PR DESCRIPTION
Makes the launch radar diagnosable and multi-timeframe. Motivated by the live observation: **0/137 pools admitted every refresh, with no visibility into why** — a black box.

## What changed
1. **Rolling-window probes**: `toDiscoveredPool` now carries `feeYieldWindows` + `volumeWindows` (30m/1h/2h/4h/12h/24h) from the SAME list payload — zero extra API calls. The radar log shows the full window curve per admitted pool, so wash patterns (a burst confined to one window) are visible.
2. **Rejection histogram**: `summarizeLaunchRejections` → the radar logs top-6 rejection reasons with counts when nothing admits. The 100%-rejection universe becomes diagnosable (age cap vs TVL cap vs token-safety floor vs binStep band).
3. **Decay degradation warn**: when the Data API is down, the launch volume-decay rule can't fire (1h fees unmeasured) — escalated from debug to a per-position warn. Timebox + drawdown remain the backstop.

## Deliberately NOT a hard window-spread gate
The Data API's windows are **rolling and overlapping** — a 10-min wash on a 1h-old pool shows a spread of ~2 (a 4x burst over a quarter of the window averages out), indistinguishable from real launch momentum. A spread rejection would reject the launches we want. Anti-scam stays on: token-safety legs, holders floor, turnover cap, and the time-boxed drawdown loss bound (now 0.15).

## Also applied (config, live + paper)
- `LAUNCH_EXIT_DRAWDOWN_PCT=0.15`, `LAUNCH_MAX_OPEN_POSITIONS=2`

## Verified
- API: windows confirmed in the live list payload; `created_at` and per-window sort keys return **empty** — the first-minutes catch is a universe-size bump (`LAUNCH_SCAN_UNIVERSE_SIZE` → 1000 at deploy), not a new sort.
- Tests: 3 summarizer cases; 1658/1658 suite; tsc 0; oxlint 0.

## Summary by Sourcery

Add multi-timeframe fee-yield and volume windows to launch discovery and expose rejection histograms and degraded decay protection in radar logs.

New Features:
- Include rolling fee-yield and volume windows for each discovered pool to support multi-timeframe launch radar probes.
- Summarize and log top launch-pool rejection reasons when no pools are admitted, making the 100%-rejection universe diagnosable.

Enhancements:
- Log detailed per-pool window curves and key metrics in launch radar output for better visibility into admitted pools.
- Warn when launch volume-decay protection is degraded due to missing 1h fee measurements from the Data API.
- Slightly refactor adapter balance snapshot timeout/catch piping without changing behavior.

Tests:
- Add unit tests for launch rejection summarization to verify counting, ordering, and top-N clamping behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rolling-window pool fee-yield and volume metrics for periods from 30 minutes to 24 hours.
  - Launch scanning now reports ranked pools and summarizes the most common rejection reasons.
  - Unmeasured launch-position fees now generate visible warnings.

- **Bug Fixes**
  - Improved launch-gate result handling for more consistent execution and reporting.

- **Tests**
  - Added coverage for rejection summaries, ranking, empty results, and minimum limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->