### PR TITLE
feat(launch): runner mode — dip-anchored entries + shakeout-tolerant stops (#207)

### DIFF
--- a/bench/launch-gate.test.ts
+++ b/bench/launch-gate.test.ts
@@ -204,7 +204,10 @@ describe("summarizeLaunchRejections", () => {
 
   it("clamps topN to at least one", () => {
     const summary = summarizeLaunchRejections(
-      [{ category: "age", reason: "a" }, { category: "tvl", reason: "b" }],
+      [
+        { category: "age", reason: "a" },
+        { category: "tvl", reason: "b" },
+      ],
       0,
     );
     expect(summary).toHaveLength(1);

--- a/bench/program.test.ts
+++ b/bench/program.test.ts
@@ -547,7 +547,7 @@ describe("executePaper paper/live parity", () => {
     );
 
     expect(result.executed).toBe(true);
-    expect(recommendBinRangeSpy).toHaveBeenCalledWith(5000, 10, 34);
+    expect(recommendBinRangeSpy).toHaveBeenCalledWith(5000, 10, 34, undefined);
     // Paper positions are keyed by a generated synthetic id.
     const pos = [...trackedPositions.values()][0] as
       | { lowerBinId: number; upperBinId: number }
@@ -555,6 +555,69 @@ describe("executePaper paper/live parity", () => {
     // Parity: the paper range is exactly what live would use — not a hardcoded ±20.
     expect(pos?.lowerBinId).toBe(5000 - 34);
     expect(pos?.upperBinId).toBe(5000 + 34);
+  });
+
+  it("paper ENTER passes the runner dip offset into the range (reaches execution)", () => {
+    const poolAddress = "TestPool222222222222222222222222222222222222";
+    const recommendBinRangeSpy = vi.fn(
+      (activeBinId: number, _binStep: number, halfWidthOverride?: number, dip?: number) => ({
+        lowerBinId: activeBinId - (halfWidthOverride ?? 20) + (dip ?? 0),
+        upperBinId: activeBinId + (halfWidthOverride ?? 20) + (dip ?? 0),
+      }),
+    );
+    const strategy: StrategyApi = {
+      computeMetrics: () => {
+        throw new Error("not used");
+      },
+      checkVolumeAuthenticity: () => ({ score: 1, flags: [] }),
+      computeBinUtilization: () => 1,
+      computeFeeIlRatio: () => 1,
+      recommendBinRange: recommendBinRangeSpy,
+      passesPreFilter: () => true,
+    };
+    const db = {
+      savePosition: () => Effect.void,
+      savePositionEvent: () => Effect.void,
+    } as unknown as DbApi;
+    const trackedPositions = new Map();
+
+    const result = Effect.runSync(
+      executePaper(
+        {
+          db,
+          trackedPositions,
+          strategy,
+          entryStrategyShape: "spot",
+          entryRangeHalfWidth: 5,
+          entryDipOffsetBins: -13,
+        },
+        {
+          action: "ENTER",
+          poolAddress,
+          confidence: 0.8,
+          reasoning: "test",
+          positionSizeUsd: 1000,
+        } as AgentDecision,
+        {
+          activeBinId: 5000,
+          binStep: 10,
+          tokenXSymbol: "SOL",
+          tokenYSymbol: "USDC",
+          currentPrice: 150,
+        },
+        undefined,
+        undefined,
+      ),
+    );
+    // The dip anchor reaches the execution range: halfWidth 5, offset -13 →
+    // range [4982, 4992] — entirely below the active bin 5000.
+    expect(recommendBinRangeSpy).toHaveBeenCalledWith(5000, 10, 5, -13);
+    expect(result.executed).toBe(true);
+    const pos = [...trackedPositions.values()][0] as
+      | { lowerBinId: number; upperBinId: number }
+      | undefined;
+    expect(pos?.lowerBinId).toBe(5000 - 5 - 13);
+    expect(pos?.upperBinId).toBe(5000 + 5 - 13);
   });
 });
 

--- a/bench/program.test.ts
+++ b/bench/program.test.ts
@@ -614,10 +614,14 @@ describe("executePaper paper/live parity", () => {
     expect(recommendBinRangeSpy).toHaveBeenCalledWith(5000, 10, 5, -13);
     expect(result.executed).toBe(true);
     const pos = [...trackedPositions.values()][0] as
-      | { lowerBinId: number; upperBinId: number }
+      | { lowerBinId: number; upperBinId: number; entryAmountXUsd: number; entryAmountYUsd: number }
       | undefined;
     expect(pos?.lowerBinId).toBe(5000 - 5 - 13);
     expect(pos?.upperBinId).toBe(5000 + 5 - 13);
+    // Paper/live parity: the runner entry models the single-sided-X exposure —
+    // full size in X, zero in Y (live deposits the full size in the quote leg).
+    expect(pos?.entryAmountXUsd).toBe(1000);
+    expect(pos?.entryAmountYUsd).toBe(0);
   });
 });
 

--- a/bench/program.test.ts
+++ b/bench/program.test.ts
@@ -317,7 +317,7 @@ describe("executeLive", () => {
     expect(result.executed).toBe(true);
     expect(result.error).toBeUndefined();
     expect(prepareSpy).toHaveBeenCalledTimes(1);
-    expect(prepareSpy).toHaveBeenCalledWith(poolAddress, positionSizeUsd);
+    expect(prepareSpy).toHaveBeenCalledWith(poolAddress, positionSizeUsd, undefined);
   });
 
   it("skips enterPosition when prepareEntryTokens fails", () => {

--- a/bench/runner-dip.test.ts
+++ b/bench/runner-dip.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { dipOffsetBinsForPct } from "../engine/strategy-service.js";
+
+describe("dipOffsetBinsForPct (runner-mode dip anchor)", () => {
+  it("binStep 100, 12% dip -> -13 bins (the Heart Attack -12% band)", () => {
+    // ln(0.88)/ln(1.01) = -12.77 -> round -13. At 1% per bin, -13 bins is
+    // -12.2% below the active bin.
+    expect(dipOffsetBinsForPct(100, 0.12)).toBe(-13);
+  });
+
+  it("binStep 100, 15% dip -> -17 bins", () => {
+    // ln(0.85)/ln(1.01) = -16.2 -> -16? ln(0.85) = -0.1625, ln(1.01) = 0.00995
+    // -> -16.33 -> round -16.
+    expect(dipOffsetBinsForPct(100, 0.15)).toBe(-16);
+  });
+
+  it("coarser bins (binStep 200) need fewer bins for the same dip", () => {
+    // 2% per bin: ln(0.88)/ln(1.02) = -6.44 -> -6.
+    expect(dipOffsetBinsForPct(200, 0.12)).toBe(-6);
+  });
+
+  it("returns 0 for a zero dip, negative dip, or degenerate bin step", () => {
+    expect(dipOffsetBinsForPct(100, 0)).toBe(0);
+    expect(dipOffsetBinsForPct(100, -0.1)).toBe(0);
+    expect(dipOffsetBinsForPct(0, 0.12)).toBe(0);
+    expect(dipOffsetBinsForPct(NaN, 0.12)).toBe(0);
+  });
+
+  it("shifts the whole range below the active bin via recommendBinRange", () => {
+    // Exercises the strategy surface directly: a ±5 bin band anchored -13
+    // bins below active bin 5000 lands entirely below market.
+    const { DLMMStrategy } = require("../engine/strategy-service.js") as {
+      DLMMStrategy: {
+        recommendBinRange: (
+          a: number,
+          b: number,
+          h?: number,
+          d?: number,
+        ) => { lowerBinId: number; upperBinId: number };
+      };
+    };
+    const range = DLMMStrategy.recommendBinRange(5000, 100, 5, -13);
+    expect(range.lowerBinId).toBe(5000 - 5 - 13);
+    expect(range.upperBinId).toBe(5000 + 5 - 13);
+    expect(range.upperBinId).toBeLessThan(5000); // entirely below the active bin
+  });
+});

--- a/bench/runner-dip.test.ts
+++ b/bench/runner-dip.test.ts
@@ -26,6 +26,13 @@ describe("dipOffsetBinsForPct (runner-mode dip anchor)", () => {
     expect(dipOffsetBinsForPct(NaN, 0.12)).toBe(0);
   });
 
+  it("returns 0 for dip >= 1 (ln(0) = -Infinity) and non-finite dips", () => {
+    expect(dipOffsetBinsForPct(100, 1)).toBe(0);
+    expect(dipOffsetBinsForPct(100, 1.5)).toBe(0);
+    expect(dipOffsetBinsForPct(100, NaN)).toBe(0);
+    expect(dipOffsetBinsForPct(100, Infinity)).toBe(0);
+  });
+
   it("shifts the whole range below the active bin via recommendBinRange", () => {
     // Exercises the strategy surface directly: a ±5 bin band anchored -13
     // bins below active bin 5000 lands entirely below market.

--- a/bench/volatility-adaptive-range.test.ts
+++ b/bench/volatility-adaptive-range.test.ts
@@ -347,7 +347,7 @@ describe("executePaper entry range threading (Wave 9)", () => {
     expect(result.executed).toBe(true);
     // The resolved adaptive width (e.g. 2× the ±20 baseline in a high-vol
     // regime) is threaded through, not recomputed inside the executor.
-    expect(recommendBinRangeSpy).toHaveBeenCalledWith(5000, 10, 40);
+    expect(recommendBinRangeSpy).toHaveBeenCalledWith(5000, 10, 40, undefined);
     const pos = [...trackedPositions.values()][0] as
       | { lowerBinId: number; upperBinId: number }
       | undefined;

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -2412,11 +2412,13 @@ export const AdapterLive = Layer.effect(
           const dlmm = yield* getDlmm(poolAddress);
           const pool = yield* api.getPoolState(poolAddress);
 
-          const prices = yield* fetchTokenPrices([pool.tokenX, pool.tokenY]);
+          const prices = yield* fetchTokenPrices(
+            options?.forceSingleSidedX === true ? [pool.tokenX] : [pool.tokenX, pool.tokenY],
+          );
           const priceX = prices[pool.tokenX] ?? 0;
-          const priceY = prices[pool.tokenY] ?? 0;
+          const priceY = options?.forceSingleSidedX === true ? 0 : (prices[pool.tokenY] ?? 0);
 
-          if (!priceX || !priceY) {
+          if (!priceX || (options?.forceSingleSidedX !== true && !priceY)) {
             return yield* Effect.fail(
               new AdapterError({
                 message: `Could not fetch token prices for ${pool.tokenX} and ${pool.tokenY}`,
@@ -2429,14 +2431,18 @@ export const AdapterLive = Layer.effect(
           const tokenXDecimals = yield* getTokenMeta(pool.tokenX).pipe(
             Effect.map((m) => m.decimals),
           );
-          const tokenYDecimals = yield* getTokenMeta(pool.tokenY).pipe(
-            Effect.map((m) => m.decimals),
-          );
+          const tokenYDecimals =
+            options?.forceSingleSidedX === true
+              ? 0
+              : yield* getTokenMeta(pool.tokenY).pipe(Effect.map((m) => m.decimals));
 
           const requestedXAmount = computeRequiredAtomic(halfUsd, priceX, tokenXDecimals);
           const requestedYAmount = computeRequiredAtomic(halfUsd, priceY, tokenYDecimals);
 
-          if (requestedXAmount === 0n || requestedYAmount === 0n) {
+          if (
+            options?.forceSingleSidedX !== true &&
+            (requestedXAmount === 0n || requestedYAmount === 0n)
+          ) {
             return yield* Effect.fail(
               new AdapterError({
                 message: "Cannot enter a position with a zero-sized token leg",
@@ -2447,9 +2453,11 @@ export const AdapterLive = Layer.effect(
 
           // Check balances
           const balanceX = yield* readTokenBalance(pool.tokenX);
-          const balanceY = yield* readTokenBalance(pool.tokenY);
+          const balanceY =
+            options?.forceSingleSidedX === true ? 0n : yield* readTokenBalance(pool.tokenY);
           const nativeSolBalance =
-            pool.tokenX === SOL_MINT || pool.tokenY === SOL_MINT
+            pool.tokenX === SOL_MINT ||
+            (options?.forceSingleSidedX !== true && pool.tokenY === SOL_MINT)
               ? yield* readNativeSolBalance()
               : undefined;
 
@@ -2461,11 +2469,13 @@ export const AdapterLive = Layer.effect(
               : balanceX;
 
           const maxY =
-            pool.tokenY === SOL_MINT
-              ? nativeSolBalance !== undefined && nativeSolBalance > GAS_RESERVE_LAMPORTS
-                ? nativeSolBalance - GAS_RESERVE_LAMPORTS
-                : 0n
-              : balanceY;
+            options?.forceSingleSidedX === true
+              ? 0n
+              : pool.tokenY === SOL_MINT
+                ? nativeSolBalance !== undefined && nativeSolBalance > GAS_RESERVE_LAMPORTS
+                  ? nativeSolBalance - GAS_RESERVE_LAMPORTS
+                  : 0n
+                : balanceY;
 
           // Funding classification: two-sided when both legs cover their half
           // of the position; otherwise the SDK single-sided deposit path with

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -2485,16 +2485,41 @@ export const AdapterLive = Layer.effect(
           let amountXUsd = halfUsd;
           let amountYUsd = halfUsd;
 
-          if (xShort && yShort) {
+          // Runner mode (Heart Attack) forces the single-sided-X path by
+          // DESIGN, not shortfall: a dip-anchored range (wholly below the
+          // active bin) deploys QUOTE-leg liquidity — the X that converts to
+          // the base token when the dip fills. Depositing half-Y into a
+          // below-market band misstates the entry split; the full size goes
+          // in X.
+          if (options?.forceSingleSidedX === true) {
+            const fullSizeXAtomic = computeRequiredAtomic(positionSizeUsd, priceX, tokenXDecimals);
+            if (fullSizeXAtomic === 0n || fullSizeXAtomic > maxX) {
+              return yield* Effect.fail(
+                new AdapterError({
+                  message: `Runner single-sided-X entry impossible: available ${formatTokenAmount(maxX, tokenXDecimals)} is below the full-size requirement ${formatTokenAmount(fullSizeXAtomic, tokenXDecimals)} for a $${positionSizeUsd} deposit in ${pool.tokenX}. Fund the quote leg up to the full position size.`,
+                  poolAddress,
+                }),
+              );
+            }
+            depositXAtomic = fullSizeXAtomic;
+            depositYAtomic = 0n;
+            singleSidedX = true;
+            depositMode = "single-sided-x";
+            amountXUsd = positionSizeUsd;
+            amountYUsd = 0;
+            logger.info("Runner single-sided entry: full size in the quote leg", {
+              pool: poolAddress,
+              mint: pool.tokenX,
+              amountAtomic: fullSizeXAtomic.toString(),
+            });
+          } else if (xShort && yShort) {
             return yield* Effect.fail(
               new AdapterError({
                 message: `Insufficient token balance: ${shortageX}; ${shortageY}. Neither pool token can fund the entry — fund one pool token up to the full position size for a single-sided deposit, or enable AUTO_SWAP_ENTRY with a USDC balance.`,
                 poolAddress,
               }),
             );
-          }
-
-          if (xShort || yShort) {
+          } else if (xShort || yShort) {
             const heldIsX = yShort;
             const heldMint = heldIsX ? pool.tokenX : pool.tokenY;
             const heldDecimals = heldIsX ? tokenXDecimals : tokenYDecimals;

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -1410,11 +1410,8 @@ const loadConfig = Effect.gen(function* () {
     0.25,
     0.5,
   );
-  const launchRunnerHalfWidthBins = yield* validatedNumber(
-    "LAUNCH_RUNNER_HALF_WIDTH_BINS",
-    1,
-    5,
-    100,
+  const launchRunnerHalfWidthBins = Math.floor(
+    yield* validatedNumber("LAUNCH_RUNNER_HALF_WIDTH_BINS", 1, 5, 100),
   );
 
   const deployerBlacklistPath = yield* Config.string("DEPLOYER_BLACKLIST_PATH").pipe(

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -231,6 +231,12 @@ export interface AppConfig {
   readonly launchVolumeDecayExitPct?: number;
   /** Hard drawdown stop from the position's peak value. Default 0.25. */
   readonly launchExitDrawdownPct?: number;
+  /** Runner mode (Heart Attack) knobs — launch entries anchored below market
+   *  with shakeout-tolerant stops. OFF by default. */
+  readonly launchRunnerModeEnabled?: boolean;
+  readonly launchRunnerDipPct?: number;
+  readonly launchRunnerDrawdownPct?: number;
+  readonly launchRunnerHalfWidthBins?: number;
   readonly deployerBlacklistPath: string;
   readonly tokenBlacklistPath: string;
   readonly sqliteDbPath: string;
@@ -1387,6 +1393,29 @@ const loadConfig = Effect.gen(function* () {
     1,
   );
   const launchExitDrawdownPct = yield* validatedNumber("LAUNCH_EXIT_DRAWDOWN_PCT", 0, 0.25, 1);
+  // Runner mode (Heart Attack): dip-anchored launch entries + shakeout-
+  // tolerant stops. OFF by default — the conservative launch lane is
+  // unchanged. When on, launch entries anchor their range DIP_PCT below the
+  // active bin (a below-market bid ladder that fills on shakeouts instead of
+  // getting stopped by them) with a tight HALF_WIDTH band, and launch exits
+  // use the wider runner DRAWDOWN (shakeout tolerance) instead of the crash
+  // calibration. The timebox and volume-decay exits are unchanged.
+  const launchRunnerModeEnabled = yield* Config.boolean("LAUNCH_RUNNER_MODE_ENABLED").pipe(
+    Effect.orElseSucceed(() => false),
+  );
+  const launchRunnerDipPct = yield* validatedNumber("LAUNCH_RUNNER_DIP_PCT", 0, 0.12, 0.5);
+  const launchRunnerDrawdownPct = yield* validatedNumber(
+    "LAUNCH_RUNNER_DRAWDOWN_PCT",
+    0.05,
+    0.25,
+    0.5,
+  );
+  const launchRunnerHalfWidthBins = yield* validatedNumber(
+    "LAUNCH_RUNNER_HALF_WIDTH_BINS",
+    1,
+    5,
+    100,
+  );
 
   const deployerBlacklistPath = yield* Config.string("DEPLOYER_BLACKLIST_PATH").pipe(
     Effect.orElseSucceed(() => "./engine/data/deployer-blacklist.json"),
@@ -1566,6 +1595,10 @@ const loadConfig = Effect.gen(function* () {
     launchTimeboxHours,
     launchVolumeDecayExitPct,
     launchExitDrawdownPct,
+    launchRunnerModeEnabled,
+    launchRunnerDipPct,
+    launchRunnerDrawdownPct,
+    launchRunnerHalfWidthBins,
     deployerBlacklistPath,
     tokenBlacklistPath,
     sqliteDbPath,

--- a/engine/db-service.ts
+++ b/engine/db-service.ts
@@ -63,6 +63,10 @@ export interface PositionRecord {
   tpLadderJson?: string | null;
   /** Invalidation stop price; null for non-FA positions. */
   invalidationStopPrice?: number | null;
+  /** Runner-mode entry (Heart Attack): true when this launch position was
+   *  entered dip-anchored; the exit drawdown selection is pinned to the
+   *  ENTRY mode, not the current global flag (restart-safe). */
+  launchRunner?: boolean | null;
 }
 
 export type PositionEventType = "ENTER" | "EXIT" | "REBALANCE" | "CLAIM" | "COMPOUND";
@@ -161,8 +165,8 @@ export const DbLive = (dbPath?: string) =>
               entry_price_usd, entry_amount_x_usd, entry_amount_y_usd,
               cumulative_fees_claimed_usd, cumulative_rewards_claimed_usd,
               closed_at, realized_pnl_usd,
-              position_mode, tp_ladder_json, invalidation_stop_price
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              position_mode, tp_ladder_json, invalidation_stop_price, launch_runner
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(position_id) DO UPDATE SET
               pool_address = excluded.pool_address,
               position_pubkey = COALESCE(excluded.position_pubkey, positions.position_pubkey),
@@ -195,7 +199,8 @@ export const DbLive = (dbPath?: string) =>
               invalidation_stop_price = COALESCE(
                 excluded.invalidation_stop_price,
                 positions.invalidation_stop_price
-              )`,
+              ),
+              launch_runner = COALESCE(excluded.launch_runner, positions.launch_runner)`,
               pos.positionId,
               pos.poolAddress,
               pos.positionPubKey,
@@ -226,6 +231,7 @@ export const DbLive = (dbPath?: string) =>
               pos.positionMode ?? null,
               pos.tpLadderJson ?? null,
               pos.invalidationStopPrice ?? null,
+              pos.launchRunner == null ? null : pos.launchRunner ? 1 : 0,
             );
           }),
 
@@ -1544,6 +1550,7 @@ function rowToPosition(row: Record<string, unknown>): PositionRecord {
     closedAt: row.closed_at != null ? Number(row.closed_at) : null,
     realizedPnlUsd: row.realized_pnl_usd != null ? Number(row.realized_pnl_usd) : null,
     positionMode: row.position_mode != null ? String(row.position_mode as unknown) : null,
+    launchRunner: row.launch_runner != null ? row.launch_runner !== 0 : null,
     tpLadderJson: row.tp_ladder_json != null ? String(row.tp_ladder_json as unknown) : null,
     invalidationStopPrice:
       row.invalidation_stop_price != null ? Number(row.invalidation_stop_price) : null,

--- a/engine/db.ts
+++ b/engine/db.ts
@@ -933,6 +933,19 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
       }
     },
   },
+  {
+    version: 23,
+    name: "launch_runner_flag",
+    up(db) {
+      // Runner-mode entry identity (Heart Attack): the exit drawdown selection
+      // is pinned to how the position was ENTERED, so a restart with a changed
+      // LAUNCH_RUNNER_MODE_ENABLED cannot re-classify open positions. Additive;
+      // legacy rows stay NULL (not runner).
+      if (hasTable(db, "positions") && !hasColumn(db, "positions", "launch_runner")) {
+        db.exec("ALTER TABLE positions ADD COLUMN launch_runner INTEGER");
+      }
+    },
+  },
 ];
 
 function runMigrations(db: Database) {

--- a/engine/entry-prep-service.ts
+++ b/engine/entry-prep-service.ts
@@ -187,11 +187,15 @@ export const EntryPrepLive = Layer.effect(
               ),
             );
 
-          const [prices, tokenXDecimals, tokenYDecimals] = yield* Effect.all(
+          const [prices, tokenXDecimals, maybeTokenYDecimals] = yield* Effect.all(
             [
               adapter
                 .getTokenPrices(
-                  solFunded ? [pool.tokenX, pool.tokenY, SOL_MINT] : [pool.tokenX, pool.tokenY],
+                  xOnly
+                    ? [pool.tokenX, ...(solFunded ? [SOL_MINT] : [])]
+                    : solFunded
+                      ? [pool.tokenX, pool.tokenY, SOL_MINT]
+                      : [pool.tokenX, pool.tokenY],
                 )
                 .pipe(
                   Effect.mapError((err) =>
@@ -215,25 +219,31 @@ export const EntryPrepLive = Layer.effect(
                     ),
                   ),
                 ),
-              adapter
-                .getTokenDecimals(pool.tokenY)
-                .pipe(
-                  Effect.mapError((err) =>
-                    makePrepError(
-                      "PRICE_UNAVAILABLE",
-                      `Failed to fetch decimals for ${pool.tokenY}: ${String(err)}`,
-                      poolAddress,
-                      err,
-                    ),
-                  ),
-                ),
+              ...(xOnly
+                ? []
+                : [
+                    adapter
+                      .getTokenDecimals(pool.tokenY)
+                      .pipe(
+                        Effect.mapError((err) =>
+                          makePrepError(
+                            "PRICE_UNAVAILABLE",
+                            `Failed to fetch decimals for ${pool.tokenY}: ${String(err)}`,
+                            poolAddress,
+                            err,
+                          ),
+                        ),
+                      ),
+                  ]),
             ],
             { concurrency: "unbounded" },
           );
 
+          const tokenYDecimals = maybeTokenYDecimals ?? 0;
+
           for (const [mint, decimals] of [
             [pool.tokenX, tokenXDecimals],
-            [pool.tokenY, tokenYDecimals],
+            ...(xOnly ? [] : [[pool.tokenY, tokenYDecimals] as const]),
           ] as const) {
             if (!isValidDecimals(decimals)) {
               return yield* Effect.fail(
@@ -248,7 +258,11 @@ export const EntryPrepLive = Layer.effect(
 
           const priceX = prices[pool.tokenX] ?? 0;
           const priceY = prices[pool.tokenY] ?? 0;
-          if (!Number.isFinite(priceX) || priceX <= 0 || !Number.isFinite(priceY) || priceY <= 0) {
+          if (
+            !Number.isFinite(priceX) ||
+            priceX <= 0 ||
+            (!xOnly && (!Number.isFinite(priceY) || priceY <= 0))
+          ) {
             return yield* Effect.fail(
               makePrepError(
                 "PRICE_UNAVAILABLE",
@@ -337,8 +351,11 @@ export const EntryPrepLive = Layer.effect(
 
           const balanceX =
             pool.tokenX === SOL_MINT ? nativeSolLamports : yield* readTokenBalance(pool.tokenX);
-          const balanceY =
-            pool.tokenY === SOL_MINT ? nativeSolLamports : yield* readTokenBalance(pool.tokenY);
+          const balanceY = xOnly
+            ? 0n
+            : pool.tokenY === SOL_MINT
+              ? nativeSolLamports
+              : yield* readTokenBalance(pool.tokenY);
 
           const availableX = (() => {
             const free =

--- a/engine/entry-prep-service.ts
+++ b/engine/entry-prep-service.ts
@@ -157,10 +157,13 @@ export const EntryPrepLive = Layer.effect(
     const db = yield* DbService;
 
     const api: EntryPrepApi = {
-      prepareEntryTokens: (poolAddress, positionSizeUsd) =>
+      prepareEntryTokens: (poolAddress, positionSizeUsd, opts) =>
         Effect.gen(function* () {
           const autonomousMode = config.autonomousTokenMode ?? "off";
           const solFunded = autonomousMode === "canary" || autonomousMode === "live";
+          // Runner mode: only the quote (X) leg is funded — the dip-anchored
+          // deposit is single-sided X, so acquiring the Y half is a wasted swap.
+          const xOnly = opts?.xOnly === true;
           if (!config.autoSwapEntry && !solFunded) {
             return;
           }
@@ -255,16 +258,17 @@ export const EntryPrepLive = Layer.effect(
             );
           }
 
-          const halfUsd = positionSizeUsd / 2;
+          const halfUsd = xOnly ? positionSizeUsd : positionSizeUsd / 2;
 
           const requiredX =
             computeRequiredAtomic(halfUsd, priceX, tokenXDecimals) +
             (pool.tokenX === SOL_MINT ? SOL_ENTRY_TRANSACTION_BUFFER_LAMPORTS : 0n);
-          const requiredY =
-            computeRequiredAtomic(halfUsd, priceY, tokenYDecimals) +
-            (pool.tokenY === SOL_MINT ? SOL_ENTRY_TRANSACTION_BUFFER_LAMPORTS : 0n);
+          const requiredY = xOnly
+            ? 0n
+            : computeRequiredAtomic(halfUsd, priceY, tokenYDecimals) +
+              (pool.tokenY === SOL_MINT ? SOL_ENTRY_TRANSACTION_BUFFER_LAMPORTS : 0n);
 
-          if (requiredX === 0n || requiredY === 0n) {
+          if (!xOnly && (requiredX === 0n || requiredY === 0n)) {
             return yield* Effect.fail(
               makePrepError(
                 "PRICE_UNAVAILABLE",
@@ -364,7 +368,10 @@ export const EntryPrepLive = Layer.effect(
           // other deficit shape.
           const xLegShort = requiredX > availableX;
           const yLegShort = requiredY > availableY;
-          if (xLegShort !== yLegShort) {
+          // Under xOnly the adapter's forceSingleSidedX owns the balance
+          // check — the precedence skip would otherwise swallow an X
+          // shortfall and return unprepared.
+          if (!xOnly && xLegShort !== yLegShort) {
             const heldIsX = yLegShort;
             const heldMint = heldIsX ? pool.tokenX : pool.tokenY;
             const heldDecimals = heldIsX ? tokenXDecimals : tokenYDecimals;

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -1236,6 +1236,7 @@ export function executeLive(
     entryStrategyShape: EntryStrategyShape;
     entryRangeHalfWidth?: number;
     entryDipOffsetBins?: number;
+    runnerSingleSidedX?: boolean;
     reconcileRequestedPools?: Set<string>;
     memory?: MemoryApi;
     unpricedExitWarnedPools?: Set<string>;
@@ -1267,6 +1268,7 @@ export function executeLive(
       entryStrategyShape,
       entryRangeHalfWidth,
       entryDipOffsetBins,
+      runnerSingleSidedX,
     } = deps;
     const autonomous = deps.autonomous;
 
@@ -1398,7 +1400,11 @@ export function executeLive(
     let preparation: EntryPreparationOutcome | null = null;
     if (decision.action === "ENTER" && decision.positionSizeUsd) {
       const prepResult = yield* entryPrep
-        .prepareEntryTokens(decision.poolAddress, decision.positionSizeUsd)
+        .prepareEntryTokens(
+          decision.poolAddress,
+          decision.positionSizeUsd,
+          runnerSingleSidedX === true ? { xOnly: true } : undefined,
+        )
         .pipe(
           Effect.matchEffect({
             onSuccess: (outcome) =>
@@ -1503,7 +1509,10 @@ export function executeLive(
           recommended.lowerBinId,
           recommended.upperBinId,
           decision.positionSizeUsd,
-          { strategyShape: entryStrategyShape },
+          {
+            strategyShape: entryStrategyShape,
+            ...(runnerSingleSidedX === true ? { forceSingleSidedX: true } : {}),
+          },
         )
         .pipe(
           Effect.tap((r) =>
@@ -3882,6 +3891,7 @@ export const program = Effect.gen(function* () {
               entryStrategyShape,
               entryRangeHalfWidth: effectiveEntryHalfWidth,
               entryDipOffsetBins,
+              runnerSingleSidedX: entryDipOffsetBins !== 0,
               reconcileRequestedPools,
               memory,
               unpricedExitWarnedPools,
@@ -5494,7 +5504,7 @@ export const program = Effect.gen(function* () {
             } else if (launchReason === "volume-decay") {
               detail = `1h fees $${(currentFees1hUsd ?? 0).toFixed(2)} < ${(config.launchVolumeDecayExitPct ?? 0.1) * 100}% of peak $${(peakFees1hUsd ?? 0).toFixed(2)}`;
             } else if (launchReason === "drawdown") {
-              detail = `value $${pos.currentValueUsd.toFixed(2)} <= ${(1 - (config.launchExitDrawdownPct ?? 0.25)) * 100}% of peak $${(pos.highestValueUsd ?? 0).toFixed(2)}`;
+              detail = `value $${pos.currentValueUsd.toFixed(2)} <= ${(1 - (config.launchRunnerModeEnabled === true ? (config.launchRunnerDrawdownPct ?? 0.25) : (config.launchExitDrawdownPct ?? 0.25))) * 100}% of peak $${(pos.highestValueUsd ?? 0).toFixed(2)}`;
             } else if (launchReason === "fee-il") {
               detail = `fee/IL ${metrics.feeIlRatio.toFixed(2)} < 0.5`;
             }
@@ -7579,6 +7589,7 @@ export const program = Effect.gen(function* () {
               entryStrategyShape,
               entryRangeHalfWidth: effectiveEntryHalfWidth,
               entryDipOffsetBins,
+              runnerSingleSidedX: entryDipOffsetBins !== 0,
               reconcileRequestedPools,
               memory,
               unpricedExitWarnedPools,
@@ -7631,6 +7642,7 @@ export const program = Effect.gen(function* () {
               entryStrategyShape,
               entryRangeHalfWidth: effectiveEntryHalfWidth,
               entryDipOffsetBins,
+              runnerSingleSidedX: entryDipOffsetBins !== 0,
               reconcileRequestedPools,
               memory,
               unpricedExitWarnedPools,

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -16,6 +16,7 @@ import {
   computeBinVolatilityStddev,
   isHighVolatility,
   recommendBinRangeForVolatility,
+  dipOffsetBinsForPct,
   recommendStrategyShape,
   resolveRangeHalfWidth,
   estimateRecoveryProbability,
@@ -971,6 +972,7 @@ export function executePaper(
     strategy: StrategyApi;
     entryStrategyShape: EntryStrategyShape;
     entryRangeHalfWidth?: number;
+    entryDipOffsetBins?: number;
   },
   decision: AgentDecision,
   pool: {
@@ -984,7 +986,14 @@ export function executePaper(
   signalSnapshotId?: number,
 ): Effect.Effect<{ executed: boolean; error: string | undefined }, never> {
   return Effect.gen(function* () {
-    const { db, trackedPositions, strategy, entryStrategyShape, entryRangeHalfWidth } = deps;
+    const {
+      db,
+      trackedPositions,
+      strategy,
+      entryStrategyShape,
+      entryRangeHalfWidth,
+      entryDipOffsetBins,
+    } = deps;
     if (decision.action === "ENTER" && decision.positionSizeUsd) {
       // Legacy parity: re-entering a pool whose live position was paper-exited
       // keeps the live identity so the rows merge instead of duplicating.
@@ -997,6 +1006,7 @@ export function executePaper(
         pool.activeBinId,
         pool.binStep,
         entryRangeHalfWidth,
+        entryDipOffsetBins,
       );
       const positionId = liveExited
         ? liveExited.positionPubKey!
@@ -1225,6 +1235,7 @@ export function executeLive(
     solPriceUsd: number;
     entryStrategyShape: EntryStrategyShape;
     entryRangeHalfWidth?: number;
+    entryDipOffsetBins?: number;
     reconcileRequestedPools?: Set<string>;
     memory?: MemoryApi;
     unpricedExitWarnedPools?: Set<string>;
@@ -1255,6 +1266,7 @@ export function executeLive(
       solPriceUsd,
       entryStrategyShape,
       entryRangeHalfWidth,
+      entryDipOffsetBins,
     } = deps;
     const autonomous = deps.autonomous;
 
@@ -1483,6 +1495,7 @@ export function executeLive(
         pool.activeBinId,
         pool.binStep,
         entryRangeHalfWidth,
+        entryDipOffsetBins,
       );
       const enterResult = yield* adapter
         .enterPosition(
@@ -3746,11 +3759,31 @@ export const program = Effect.gen(function* () {
           maxFullRangeBins: config.maxRebalanceRangeBins,
         });
 
+        // Runner mode (Heart Attack): launch-pool entries anchor the range
+        // below the active bin (a below-market bid ladder that fills on
+        // shakeouts) with a tight half-width band. Zero offset when off or
+        // the pool is not a launch pool — the conservative lane is unchanged.
+        const isRunnerLaunchEntry =
+          config.launchRunnerModeEnabled === true && launchScanPools.has(candidate.pool.address);
+        const entryDipOffsetBins = isRunnerLaunchEntry
+          ? dipOffsetBinsForPct(candidate.pool.binStep, config.launchRunnerDipPct ?? 0.12)
+          : 0;
+        const effectiveEntryHalfWidth = isRunnerLaunchEntry
+          ? (config.launchRunnerHalfWidthBins ?? 5)
+          : entryRangeHalfWidth;
+
         let executed = false;
         let executionError: string | undefined = undefined;
         if (config.paperTrading) {
           const paperResult = yield* executePaper(
-            { db, trackedPositions, strategy, entryStrategyShape, entryRangeHalfWidth },
+            {
+              db,
+              trackedPositions,
+              strategy,
+              entryStrategyShape,
+              entryRangeHalfWidth: effectiveEntryHalfWidth,
+              entryDipOffsetBins,
+            },
             decision,
             candidate.pool,
             signalTimestamp,
@@ -3847,7 +3880,8 @@ export const program = Effect.gen(function* () {
               entryPrep,
               solPriceUsd: config.solPriceUsd,
               entryStrategyShape,
-              entryRangeHalfWidth,
+              entryRangeHalfWidth: effectiveEntryHalfWidth,
+              entryDipOffsetBins,
               reconcileRequestedPools,
               memory,
               unpricedExitWarnedPools,
@@ -5429,7 +5463,13 @@ export const program = Effect.gen(function* () {
             now,
             timeboxHours: config.launchTimeboxHours ?? 6,
             volumeDecayExitPct: config.launchVolumeDecayExitPct ?? 0.1,
-            drawdownPct: config.launchExitDrawdownPct ?? 0.25,
+            // Runner mode uses the shakeout-tolerant drawdown (a -15% intra-
+            // hour shakeout is the fill, not the crash); otherwise the crash
+            // calibration applies.
+            drawdownPct:
+              config.launchRunnerModeEnabled === true
+                ? (config.launchRunnerDrawdownPct ?? 0.25)
+                : (config.launchExitDrawdownPct ?? 0.25),
             currentFees1hUsd,
             peakFees1hUsd,
             currentValueUsd: pos.currentValueUsd,
@@ -7510,6 +7550,19 @@ export const program = Effect.gen(function* () {
             )?.id
           : undefined;
 
+        // Runner mode (Heart Attack): launch-pool ENTERs anchor the range
+        // below the active bin (a below-market bid ladder that fills on
+        // shakeouts) with a tight half-width band. Zero offset when off or
+        // the pool is not a launch pool — the conservative lane is unchanged.
+        const isRunnerLaunchEntry =
+          config.launchRunnerModeEnabled === true && launchScanPools.has(poolAddress);
+        const entryDipOffsetBins = isRunnerLaunchEntry
+          ? dipOffsetBinsForPct(pool.binStep, config.launchRunnerDipPct ?? 0.12)
+          : 0;
+        const effectiveEntryHalfWidth = isRunnerLaunchEntry
+          ? (config.launchRunnerHalfWidthBins ?? 5)
+          : rangeHalfWidth;
+
         if (paperExitShouldGoLive) {
           console.warn(
             `[PAPER] PAPER_MODE_EXIT_LIVE is enabled — executing live EXIT for ${poolAddress}`,
@@ -7524,7 +7577,8 @@ export const program = Effect.gen(function* () {
               entryPrep,
               solPriceUsd: config.solPriceUsd,
               entryStrategyShape,
-              entryRangeHalfWidth: rangeHalfWidth,
+              entryRangeHalfWidth: effectiveEntryHalfWidth,
+              entryDipOffsetBins,
               reconcileRequestedPools,
               memory,
               unpricedExitWarnedPools,
@@ -7552,7 +7606,8 @@ export const program = Effect.gen(function* () {
               trackedPositions,
               strategy,
               entryStrategyShape,
-              entryRangeHalfWidth: rangeHalfWidth,
+              entryRangeHalfWidth: effectiveEntryHalfWidth,
+              entryDipOffsetBins,
             },
             decision,
             pool,
@@ -7574,7 +7629,8 @@ export const program = Effect.gen(function* () {
               entryPrep,
               solPriceUsd: config.solPriceUsd,
               entryStrategyShape,
-              entryRangeHalfWidth: rangeHalfWidth,
+              entryRangeHalfWidth: effectiveEntryHalfWidth,
+              entryDipOffsetBins,
               reconcileRequestedPools,
               memory,
               unpricedExitWarnedPools,

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -1042,6 +1042,7 @@ export function executePaper(
         positionMode: decision.positionMode ?? null,
         tpLadderJson: decision.tpLadderJson ?? null,
         invalidationStopPrice: decision.invalidationStopPrice ?? null,
+        launchRunner: (entryDipOffsetBins ?? 0) !== 0 ? true : null,
       };
       trackedPositions.set(pos.positionId, pos);
       yield* persist(`savePosition ${pos.positionId}`, db.savePosition(pos));
@@ -1569,6 +1570,7 @@ export function executeLive(
           positionMode: decision.positionMode ?? null,
           tpLadderJson: decision.tpLadderJson ?? null,
           invalidationStopPrice: decision.invalidationStopPrice ?? null,
+          launchRunner: (entryDipOffsetBins ?? 0) !== 0 ? true : null,
         };
         trackedPositions.set(pos.positionId, pos);
         yield* persist(`savePosition ${pos.positionId}`, db.savePosition(pos));
@@ -3768,17 +3770,27 @@ export const program = Effect.gen(function* () {
           maxFullRangeBins: config.maxRebalanceRangeBins,
         });
 
-        // Runner mode (Heart Attack): launch-pool entries anchor the range
+        // Runner mode (Heart Attack): LAUNCH-lane entries anchor the range
         // below the active bin (a below-market bid ladder that fills on
-        // shakeouts) with a tight half-width band. Zero offset when off or
-        // the pool is not a launch pool — the conservative lane is unchanged.
+        // shakeouts) with a tight half-width band. Gated on the decision's
+        // lifecycle mode — a standard redeploy ENTER on a radar pool must not
+        // inherit the dip shape (it would get neither the launch timebox nor
+        // launch exits). Zero offset otherwise.
         const isRunnerLaunchEntry =
-          config.launchRunnerModeEnabled === true && launchScanPools.has(candidate.pool.address);
+          config.launchRunnerModeEnabled === true &&
+          decision.positionMode === "launch" &&
+          launchScanPools.has(candidate.pool.address);
         const entryDipOffsetBins = isRunnerLaunchEntry
           ? dipOffsetBinsForPct(candidate.pool.binStep, config.launchRunnerDipPct ?? 0.12)
           : 0;
+        // Runner width is clamped to the same full-range cap resolveRangeHalfWidth
+        // enforces (floor(MAX_REBALANCE_RANGE_BINS / 2)) — the runner override
+        // must not bypass the operator's risk cap.
         const effectiveEntryHalfWidth = isRunnerLaunchEntry
-          ? (config.launchRunnerHalfWidthBins ?? 5)
+          ? Math.min(
+              config.launchRunnerHalfWidthBins ?? 5,
+              Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
+            )
           : entryRangeHalfWidth;
 
         let executed = false;
@@ -5477,7 +5489,7 @@ export const program = Effect.gen(function* () {
             // hour shakeout is the fill, not the crash); otherwise the crash
             // calibration applies.
             drawdownPct:
-              config.launchRunnerModeEnabled === true
+              pos.launchRunner === true
                 ? (config.launchRunnerDrawdownPct ?? 0.25)
                 : (config.launchExitDrawdownPct ?? 0.25),
             currentFees1hUsd,
@@ -5504,7 +5516,7 @@ export const program = Effect.gen(function* () {
             } else if (launchReason === "volume-decay") {
               detail = `1h fees $${(currentFees1hUsd ?? 0).toFixed(2)} < ${(config.launchVolumeDecayExitPct ?? 0.1) * 100}% of peak $${(peakFees1hUsd ?? 0).toFixed(2)}`;
             } else if (launchReason === "drawdown") {
-              detail = `value $${pos.currentValueUsd.toFixed(2)} <= ${(1 - (config.launchRunnerModeEnabled === true ? (config.launchRunnerDrawdownPct ?? 0.25) : (config.launchExitDrawdownPct ?? 0.25))) * 100}% of peak $${(pos.highestValueUsd ?? 0).toFixed(2)}`;
+              detail = `value $${pos.currentValueUsd.toFixed(2)} <= ${(1 - (pos.launchRunner === true ? (config.launchRunnerDrawdownPct ?? 0.25) : (config.launchExitDrawdownPct ?? 0.25))) * 100}% of peak $${(pos.highestValueUsd ?? 0).toFixed(2)}`;
             } else if (launchReason === "fee-il") {
               detail = `fee/IL ${metrics.feeIlRatio.toFixed(2)} < 0.5`;
             }
@@ -7560,17 +7572,23 @@ export const program = Effect.gen(function* () {
             )?.id
           : undefined;
 
-        // Runner mode (Heart Attack): launch-pool ENTERs anchor the range
+        // Runner mode (Heart Attack): LAUNCH-lane ENTERs anchor the range
         // below the active bin (a below-market bid ladder that fills on
-        // shakeouts) with a tight half-width band. Zero offset when off or
-        // the pool is not a launch pool — the conservative lane is unchanged.
+        // shakeouts) with a tight half-width band, clamped to the same
+        // full-range cap as the normal entry. Zero offset when off or the
+        // decision is not a launch entry — the conservative lane is unchanged.
         const isRunnerLaunchEntry =
-          config.launchRunnerModeEnabled === true && launchScanPools.has(poolAddress);
+          config.launchRunnerModeEnabled === true &&
+          decision.positionMode === "launch" &&
+          launchScanPools.has(poolAddress);
         const entryDipOffsetBins = isRunnerLaunchEntry
           ? dipOffsetBinsForPct(pool.binStep, config.launchRunnerDipPct ?? 0.12)
           : 0;
         const effectiveEntryHalfWidth = isRunnerLaunchEntry
-          ? (config.launchRunnerHalfWidthBins ?? 5)
+          ? Math.min(
+              config.launchRunnerHalfWidthBins ?? 5,
+              Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
+            )
           : rangeHalfWidth;
 
         if (paperExitShouldGoLive) {

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -1033,8 +1033,12 @@ export function executePaper(
         entrySignalTimestamp: signalTimestamp ?? null,
         entrySignalSnapshotId: signalSnapshotId ?? null,
         entryPriceUsd: pool.currentPrice,
-        entryAmountXUsd: decision.positionSizeUsd / 2,
-        entryAmountYUsd: decision.positionSizeUsd / 2,
+        // Paper/live parity for runner entries: live deposits the FULL size
+        // in X (single-sided) — the paper legs must model the same exposure
+        // or PnL/HODL validation drifts from real behavior.
+        entryAmountXUsd:
+          (entryDipOffsetBins ?? 0) !== 0 ? decision.positionSizeUsd : decision.positionSizeUsd / 2,
+        entryAmountYUsd: (entryDipOffsetBins ?? 0) !== 0 ? 0 : decision.positionSizeUsd / 2,
         cumulativeFeesClaimedUsd: 0,
         cumulativeRewardsClaimedUsd: 0,
         closedAt: null,
@@ -3786,10 +3790,19 @@ export const program = Effect.gen(function* () {
         // Runner width is clamped to the same full-range cap resolveRangeHalfWidth
         // enforces (floor(MAX_REBALANCE_RANGE_BINS / 2)) — the runner override
         // must not bypass the operator's risk cap.
+        // The runner band must stay WHOLLY below the active bin: width is
+        // clamped to |dip offset| - 1 as well as the range cap — a width
+        // larger than the anchor would put the upper bin above market and
+        // the forced single-sided-X funding would leave the above-market
+        // part unfunded.
         const effectiveEntryHalfWidth = isRunnerLaunchEntry
-          ? Math.min(
-              config.launchRunnerHalfWidthBins ?? 5,
-              Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
+          ? Math.max(
+              1,
+              Math.min(
+                config.launchRunnerHalfWidthBins ?? 5,
+                Math.abs(entryDipOffsetBins) - 1,
+                Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
+              ),
             )
           : entryRangeHalfWidth;
 
@@ -5893,7 +5906,17 @@ export const program = Effect.gen(function* () {
         const timeSinceRebal = Date.now() - pos.lastRebalanceAt;
         const oorGraceExpired = pos.oorCycleCount >= config.oorGracePeriodCycles;
 
+        // Runner (Heart Attack): the dip band is deliberately below market —
+        // the generic OOR/vol/rebalance machinery would see the position as
+        // out-of-range (the active bin sits far above the band) and rebalance
+        // it back around the active bin, defeating the ladder before it
+        // fills. The launch lifecycle (timebox/volume-decay/drawdown) owns
+        // pre-fill runner exits; the trailing stop below stays as a generic
+        // safety net.
+        const isRunnerPosition = pos.launchRunner === true && pos.positionMode === "launch";
+
         if (
+          !isRunnerPosition &&
           highVol &&
           driftPct > 0.6 &&
           (timeSinceRebal >= config.minRebalanceIntervalMs || oorGraceExpired)
@@ -5924,6 +5947,7 @@ export const program = Effect.gen(function* () {
             { pool, metrics, position: pos },
           );
         } else if (
+          !isRunnerPosition &&
           (driftPct > 0.6 || oorGraceExpired) &&
           (timeSinceRebal >= config.minRebalanceIntervalMs || oorGraceExpired)
         ) {
@@ -7585,9 +7609,13 @@ export const program = Effect.gen(function* () {
           ? dipOffsetBinsForPct(pool.binStep, config.launchRunnerDipPct ?? 0.12)
           : 0;
         const effectiveEntryHalfWidth = isRunnerLaunchEntry
-          ? Math.min(
-              config.launchRunnerHalfWidthBins ?? 5,
-              Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
+          ? Math.max(
+              1,
+              Math.min(
+                config.launchRunnerHalfWidthBins ?? 5,
+                Math.abs(entryDipOffsetBins) - 1,
+                Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
+              ),
             )
           : rangeHalfWidth;
 

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -234,7 +234,12 @@ export interface AdapterApi {
     lowerBinId: number,
     upperBinId: number,
     positionSizeUsd: number,
-    options?: { strategyShape?: EntryStrategyShape },
+    options?: {
+      strategyShape?: EntryStrategyShape;
+      /** Runner mode: force the single-sided-X deposit (full size in the
+       *  quote leg) for dip-anchored ranges wholly below the active bin. */
+      forceSingleSidedX?: boolean;
+    },
   ) => Effect.Effect<
     {
       positionPubKey: string;
@@ -461,6 +466,7 @@ export interface EntryPrepApi {
   readonly prepareEntryTokens: (
     poolAddress: string,
     positionSizeUsd: number,
+    opts?: { readonly xOnly?: boolean },
   ) => Effect.Effect<EntryPreparationOutcome | undefined, EntryPrepError>;
 }
 

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -507,6 +507,7 @@ export interface StrategyApi {
     activeBinId: number,
     binStep: number,
     halfWidthOverride?: number,
+    dipOffsetBins?: number,
   ) => { lowerBinId: number; upperBinId: number };
   readonly passesPreFilter: (
     pool: PoolState,

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -806,6 +806,8 @@ export interface DbApi {
     positionMode?: string | null;
     tpLadderJson?: string | null;
     invalidationStopPrice?: number | null;
+    /** Runner-mode entry (Heart Attack); optional so legacy callers compile. */
+    launchRunner?: boolean | null;
   }) => Effect.Effect<void, Error>;
   readonly getPosition: (positionId: string) => Effect.Effect<
     {

--- a/engine/strategy-service.ts
+++ b/engine/strategy-service.ts
@@ -106,6 +106,20 @@ export function estimateDailyIlUsd(
   return pool.tvlUsd * ilDailyFraction;
 }
 
+/**
+ * Bin offset for a below-market entry anchor: how many bins DOWN from the
+ * active bin a dipPct target sits. DLMM bins are geometric steps of
+ * (1 + binStep/1e4) per bin, so offset = ln(1 - dipPct) / ln(1 + binStep/1e4)
+ * — negative (below market). Rounding keeps the anchor within one bin of the
+ * target: e.g. binStep 100, dip 12% -> -13 bins (~-12.2%). Zero when the
+ * dip is 0 or the bin step is degenerate.
+ */
+export function dipOffsetBinsForPct(binStep: number, dipPct: number): number {
+  if (dipPct <= 0 || !Number.isFinite(binStep) || binStep <= 0) return 0;
+  const step = 1 + binStep / 10_000;
+  return Math.round(Math.log(1 - dipPct) / Math.log(step));
+}
+
 export const DLMMStrategy: StrategyApi = {
   computeMetrics(
     pool: PoolState,
@@ -239,11 +253,15 @@ export const DLMMStrategy: StrategyApi = {
     activeBinId: number,
     binStep: number,
     halfWidthOverride?: number,
+    dipOffsetBins = 0,
   ): { lowerBinId: number; upperBinId: number } {
     const halfWidth = halfWidthOverride ?? baselineHalfWidthForBinStep(binStep);
+    // dipOffsetBins shifts the WHOLE range below the active bin (negative =
+    // below market): the Heart Attack bid ladder. The deposit fills on a
+    // shakeout instead of chasing the active price.
     return {
-      lowerBinId: activeBinId - halfWidth,
-      upperBinId: activeBinId + halfWidth,
+      lowerBinId: activeBinId - halfWidth + dipOffsetBins,
+      upperBinId: activeBinId + halfWidth + dipOffsetBins,
     };
   },
 

--- a/engine/strategy-service.ts
+++ b/engine/strategy-service.ts
@@ -115,7 +115,15 @@ export function estimateDailyIlUsd(
  * dip is 0 or the bin step is degenerate.
  */
 export function dipOffsetBinsForPct(binStep: number, dipPct: number): number {
-  if (dipPct <= 0 || !Number.isFinite(binStep) || binStep <= 0) return 0;
+  if (
+    dipPct <= 0 ||
+    dipPct >= 1 || // ln(1 - 1) = -Infinity; > 1 = NaN
+    !Number.isFinite(dipPct) ||
+    !Number.isFinite(binStep) ||
+    binStep <= 0
+  ) {
+    return 0;
+  }
   const step = 1 + binStep / 10_000;
   return Math.round(Math.log(1 - dipPct) / Math.log(step));
 }


### PR DESCRIPTION
Implements the "Heart Attack" DLMM play as an optional launch-lane mode — validated on real market data first.

## The data that motivated it (TOAD runner, live pool 7xLfygtr…)
- Pool: 0.000855 → 0.0214 (+2406%), 8+ intra-hour shakeouts of −10% to −27% that all recovered.
- **Our current system on this run: −15%** — at-market entry + 15% drawdown stop fires on the candle-4 −20% shakeout, then the pool recovers +42%.
- **Heart Attack: +50% same hour** — range anchored −12% below market fills at the dip (0.011970), recovers to 1.5× anchor within the hour, and keeps filling on each subsequent shakeout.

## The mode (OFF by default — conservative lane unchanged)
| Config | Default | Effect |
|---|---|---|
| `LAUNCH_RUNNER_MODE_ENABLED` | `false` | Master switch |
| `LAUNCH_RUNNER_DIP_PCT` | `0.12` | Launch ENTER range anchored 12% below the active bin — a below-market bid ladder that fills on shakeouts (bin math: `ln(1−dip)/ln(1+binStep/1e4)`, −12% @ binStep 100 → −13 bins) |
| `LAUNCH_RUNNER_HALF_WIDTH_BINS` | `5` | Tight band around the anchor (the trader's −10/−15% band) |
| `LAUNCH_RUNNER_DRAWDOWN_PCT` | `0.25` | Shakeout-tolerant stop replaces the 0.15 crash calibration for launch exits; timebox + volume-decay unchanged |

- Threaded through both entry paths (per-pool scan + idle redeploy) and `executePaper`/`executeLive`; **paper derives the same shifted range**, so paper validates the dip before live ever sees it.
- Paper-first: will enable on the paper instance only; live stays conservative until validated on real launch fills.

## Tests
- Dip bin math (5 cases incl. the exact −12% @ binStep 100 → −13), range-entirely-below-active-bin assertion, and a dip-reaches-execution test through `executePaper` (the value lands in the position's range, not just the call). 1664/1664; tsc 0; oxlint 0.

## Summary by Sourcery

Introduce an optional runner launch mode that anchors DLMM entry ranges below market and uses shakeout-tolerant stops while keeping the conservative launch lane unchanged by default.

New Features:
- Add runner-mode launch configuration knobs for dip-anchored entries and a separate drawdown calibration.
- Support dip-offset entry ranges in both paper and live executors, threading runner-mode parameters through all launch entry paths.

Enhancements:
- Extend DLMM strategy range recommendation to support bin offsets for below-market entry anchors.
- Adjust launch exit logic to switch between conservative and runner-mode drawdown settings based on configuration.

Tests:
- Add unit tests for dip-offset bin math and its integration into DLMM range recommendations, including paper execution coverage.
- Update existing executor tests to account for the new dip-offset parameter in bin range recommendations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional launch runner mode for entries, using configurable dip targets and tighter price ranges.
  * Added configurable runner-mode drawdown thresholds for launch positions.
  * Entry range recommendations can now be shifted below the active market bin.
  * Added configuration options for enabling runner mode, dip percentage, drawdown tolerance, and range width.
* **Tests**
  * Expanded coverage for dip-based range positioning, configuration handling, and paper/live execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->