### PR TITLE
feat(launch): runner scale-in — re-anchor dip band + top up as price falls (#208)

### DIFF
--- a/bench/decision-loop-exit.test.ts
+++ b/bench/decision-loop-exit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Effect, Layer } from "effect";
 import { StrategyLive } from "../engine/strategy-service.js";
 import { program } from "../engine/program.js";
@@ -33,6 +33,7 @@ import {
   type MeteoraPoolStats,
 } from "../engine/services.js";
 import type { PoolSnapshot } from "../engine/types.js";
+import type { PositionRecord } from "../engine/db-service.js";
 import type { AgentRuntimeContext } from "../engine/agent-transport.js";
 import { defaultAppConfig, makePool, makeBinArray, makePosition } from "./helpers.js";
 import { stringifySafe } from "../engine/bigint-json.js";
@@ -644,5 +645,99 @@ describe("agent position context wiring", () => {
     // value + fees + rewards − deposited = 0
     expect(capturedContext?.position?.unrealizedPnlUsd).toBe(0);
     expect(capturedContext?.position?.hoursHeld).toBeGreaterThanOrEqual(0);
+  }, 15_000);
+});
+
+describe("runner scale-in wiring (Heart Attack step 2)", () => {
+  const POOL = "ScaleInPool111111111111111111111111111111111111";
+
+  it("re-anchors the band and top-ups via the atomic rebalance when the price falls a step", async () => {
+    const rebalanceSpy = vi.fn(() =>
+      Effect.succeed({ positionPubKey: "mock-pos", txSignatures: ["mock-tx"] }),
+    );
+    const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const adapter = makeAdapter(
+      {
+        [POOL]: makePool({
+          address: POOL,
+          tokenX: USDC_MINT,
+          tokenXSymbol: "USDC",
+          currentPrice: 93,
+          tvlUsd: 500_000,
+        }),
+      },
+      {
+        rebalancePosition: rebalanceSpy,
+        hasWallet: () => true,
+        // USDC-quoted pool: the top-up spends USDC (no SOL-leg budget
+        // interaction — the SOL batch gate only applies to SOL legs).
+        getTokenPrices: () => Effect.succeed({ [USDC_MINT]: 1 }),
+        getTokenDecimals: () => Effect.succeed(6),
+      },
+    );
+    const layer = makeTestLayer({
+      adapter,
+      configOverrides: {
+        watchlistPools: [POOL],
+        paperTrading: false,
+        launchRunnerModeEnabled: true,
+        launchRunnerScaleInEnabled: true,
+        launchRunnerScaleInStepPct: 0.05,
+        launchRunnerScaleInSizePct: 0.25,
+        launchPositionMaxSizeUsd: 100,
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      const position = makePosition({
+        poolAddress: POOL,
+        positionMode: "launch",
+        launchRunner: true,
+        launchRunnerAnchorPrice: 100,
+        launchRunnerSteps: 0,
+        positionPubKey: "mock-pos",
+        depositedUsd: 1_000,
+        currentValueUsd: 1_000,
+      });
+      yield* db.savePosition(position);
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const saved = yield* db.getPosition(position.positionId);
+      const audit = yield* AuditService;
+      const decisions = yield* audit.getRecentDecisions(50);
+      return { saved, decisions };
+    });
+    const { saved, decisions } = await Effect.runPromise(
+      Effect.provide(test, layer) as unknown as Effect.Effect<
+        { saved: PositionRecord | null; decisions: ReadonlyArray<DecisionRow> },
+        Error,
+        never
+      >,
+    );
+
+    // The rebalance fired with the dip-anchored range + a quote-only top-up:
+    // dip 12% @ binStep 10 -> offset -128 bins; width min(5, 127, 25) = 5.
+    expect(rebalanceSpy).toHaveBeenCalledTimes(1);
+    const [pool, pubkey, lower, upper, topUp] = rebalanceSpy.mock.calls[0] as unknown as [
+      string,
+      string,
+      number,
+      number,
+      { amountXAtomic: bigint; amountYAtomic: bigint },
+    ];
+    expect(pool).toBe(POOL);
+    expect(pubkey).toBe("mock-pos");
+    expect(lower).toBe(5000 - 5 - 128);
+    expect(upper).toBe(5000 + 5 - 128);
+    expect(topUp.amountYAtomic).toBe(0n);
+    expect(topUp.amountXAtomic).toBeGreaterThan(0n);
+    // topUp = min(0.25 x $10k wallet, pool headroom, $100 ceiling) = $100 ->
+    // 100 USDC x 1e6 micro-units.
+    expect(topUp.amountXAtomic).toBe(100_000_000n);
+    // The step is persisted: a restart cannot re-scale the position.
+    expect(saved?.launchRunnerSteps).toBe(1);
+    expect(saved?.launchRunnerAnchorPrice).toBe(93);
+    const scaleIn = decisions.find((d) => d.reasoning.includes("[launch-scale-in]"));
+    expect(scaleIn, "scale-in must be audited").toBeDefined();
   }, 15_000);
 });

--- a/bench/helpers.ts
+++ b/bench/helpers.ts
@@ -86,6 +86,12 @@ export function makePosition(overrides: Partial<PositionRecord> = {}): PositionR
     cumulativeRewardsClaimedUsd: overrides.cumulativeRewardsClaimedUsd ?? 0,
     closedAt: overrides.closedAt ?? null,
     realizedPnlUsd: overrides.realizedPnlUsd ?? null,
+    positionMode: overrides.positionMode ?? null,
+    tpLadderJson: overrides.tpLadderJson ?? null,
+    invalidationStopPrice: overrides.invalidationStopPrice ?? null,
+    launchRunner: overrides.launchRunner ?? null,
+    launchRunnerSteps: overrides.launchRunnerSteps ?? null,
+    launchRunnerAnchorPrice: overrides.launchRunnerAnchorPrice ?? null,
   };
 }
 

--- a/bench/launch-position.test.ts
+++ b/bench/launch-position.test.ts
@@ -5,6 +5,8 @@ import { describe, it, expect } from "vitest";
 import {
   launchPositionExit,
   launchEntrySizeUsd,
+  scaleInTopUpUsd,
+  shouldScaleInRunner,
   type LaunchPositionExitInput,
 } from "../engine/launch-position.js";
 
@@ -212,5 +214,65 @@ describe("launchEntrySizeUsd", () => {
 
   it("floors at 0 for a negative TVL", () => {
     expect(launchEntrySizeUsd({ walletUsd: 1_000, poolTvlUsd: -1, maxSizeUsd: 100 })).toBe(0);
+  });
+});
+
+describe("shouldScaleInRunner (Heart Attack step 2)", () => {
+  const base = { anchorPrice: 100, currentPrice: 100, stepPct: 0.05, steps: 0, maxSteps: 3 };
+
+  it("scales when the price fell a full step below the anchor", () => {
+    const d = shouldScaleInRunner({ ...base, currentPrice: 94 }); // -6% >= 5%
+    expect(d.scale).toBe(true);
+    expect(d.reason).toContain("step 1/3");
+  });
+
+  it("does not scale before the step threshold", () => {
+    const d = shouldScaleInRunner({ ...base, currentPrice: 97 }); // -3% < 5%
+    expect(d.scale).toBe(false);
+  });
+
+  it("stops at max steps", () => {
+    const d = shouldScaleInRunner({ ...base, currentPrice: 90, steps: 3, maxSteps: 3 });
+    expect(d.scale).toBe(false);
+    expect(d.reason).toContain("max steps");
+  });
+
+  it("never scales without a known anchor or price", () => {
+    expect(shouldScaleInRunner({ ...base, anchorPrice: 0 }).scale).toBe(false);
+    expect(shouldScaleInRunner({ ...base, currentPrice: 0 }).scale).toBe(false);
+  });
+
+  it("re-anchors at the new price on the next step (band tracks the dip)", () => {
+    // Step 1 fired at 94 -> anchor becomes 94; step 2 fires at <= 89.3.
+    expect(shouldScaleInRunner({ ...base, currentPrice: 94 }).scale).toBe(true);
+    expect(
+      shouldScaleInRunner({ ...base, anchorPrice: 94, currentPrice: 89, steps: 1 }).scale,
+    ).toBe(true);
+    expect(
+      shouldScaleInRunner({ ...base, anchorPrice: 94, currentPrice: 92, steps: 1 }).scale,
+    ).toBe(false);
+  });
+});
+
+describe("scaleInTopUpUsd", () => {
+  it("sizes min(sizePct x wallet, pool headroom, hard ceiling)", () => {
+    expect(
+      scaleInTopUpUsd({ walletUsd: 100, sizePct: 0.25, poolCapUsd: 50, maxTopUpUsd: 100 }),
+    ).toBe(25);
+    expect(
+      scaleInTopUpUsd({ walletUsd: 100, sizePct: 0.25, poolCapUsd: 10, maxTopUpUsd: 100 }),
+    ).toBe(10);
+    expect(
+      scaleInTopUpUsd({ walletUsd: 1000, sizePct: 0.25, poolCapUsd: 1000, maxTopUpUsd: 100 }),
+    ).toBe(100);
+  });
+
+  it("floors at 0 — no headroom means no top-up", () => {
+    expect(
+      scaleInTopUpUsd({ walletUsd: 100, sizePct: 0.25, poolCapUsd: 0, maxTopUpUsd: 100 }),
+    ).toBe(0);
+    expect(
+      scaleInTopUpUsd({ walletUsd: -50, sizePct: 0.25, poolCapUsd: 100, maxTopUpUsd: 100 }),
+    ).toBe(0);
   });
 });

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -237,6 +237,11 @@ export interface AppConfig {
   readonly launchRunnerDipPct?: number;
   readonly launchRunnerDrawdownPct?: number;
   readonly launchRunnerHalfWidthBins?: number;
+  /** Runner scale-in knobs (Heart Attack step 2). */
+  readonly launchRunnerScaleInEnabled?: boolean;
+  readonly launchRunnerScaleInStepPct?: number;
+  readonly launchRunnerScaleInSizePct?: number;
+  readonly launchRunnerScaleInMaxSteps?: number;
   readonly deployerBlacklistPath: string;
   readonly tokenBlacklistPath: string;
   readonly sqliteDbPath: string;
@@ -1413,6 +1418,29 @@ const loadConfig = Effect.gen(function* () {
   const launchRunnerHalfWidthBins = Math.floor(
     yield* validatedNumber("LAUNCH_RUNNER_HALF_WIDTH_BINS", 1, 5, 100),
   );
+  // Runner scale-in (Heart Attack step 2): when the price falls a full step
+  // below the band's anchor, re-anchor the band at dip% below the NEW price
+  // and top up the position with fresh quote capital (atomic rebalance
+  // redeposits the mixed basket + top-up). Persisted per position
+  // (launch_runner_steps / launch_runner_anchor_price), restart-safe.
+  const launchRunnerScaleInEnabled = yield* Config.boolean("LAUNCH_RUNNER_SCALE_IN_ENABLED").pipe(
+    Effect.orElseSucceed(() => true),
+  );
+  const launchRunnerScaleInStepPct = yield* validatedNumber(
+    "LAUNCH_RUNNER_SCALE_IN_STEP_PCT",
+    0.01,
+    0.05,
+    0.5,
+  );
+  const launchRunnerScaleInSizePct = yield* validatedNumber(
+    "LAUNCH_RUNNER_SCALE_IN_SIZE_PCT",
+    0.05,
+    0.25,
+    1,
+  );
+  const launchRunnerScaleInMaxSteps = Math.floor(
+    yield* validatedNumber("LAUNCH_RUNNER_SCALE_IN_MAX_STEPS", 1, 3, 10),
+  );
 
   const deployerBlacklistPath = yield* Config.string("DEPLOYER_BLACKLIST_PATH").pipe(
     Effect.orElseSucceed(() => "./engine/data/deployer-blacklist.json"),
@@ -1596,6 +1624,10 @@ const loadConfig = Effect.gen(function* () {
     launchRunnerDipPct,
     launchRunnerDrawdownPct,
     launchRunnerHalfWidthBins,
+    launchRunnerScaleInEnabled,
+    launchRunnerScaleInStepPct,
+    launchRunnerScaleInSizePct,
+    launchRunnerScaleInMaxSteps,
     deployerBlacklistPath,
     tokenBlacklistPath,
     sqliteDbPath,

--- a/engine/db-service.ts
+++ b/engine/db-service.ts
@@ -67,6 +67,10 @@ export interface PositionRecord {
    *  entered dip-anchored; the exit drawdown selection is pinned to the
    *  ENTRY mode, not the current global flag (restart-safe). */
   launchRunner?: boolean | null;
+  /** Runner scale-in state (Heart Attack step 2): steps taken + the band's
+   *  anchor price. Persisted so a restart cannot re-scale a filled position. */
+  launchRunnerSteps?: number | null;
+  launchRunnerAnchorPrice?: number | null;
 }
 
 export type PositionEventType = "ENTER" | "EXIT" | "REBALANCE" | "CLAIM" | "COMPOUND";
@@ -165,8 +169,9 @@ export const DbLive = (dbPath?: string) =>
               entry_price_usd, entry_amount_x_usd, entry_amount_y_usd,
               cumulative_fees_claimed_usd, cumulative_rewards_claimed_usd,
               closed_at, realized_pnl_usd,
-              position_mode, tp_ladder_json, invalidation_stop_price, launch_runner
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              position_mode, tp_ladder_json, invalidation_stop_price, launch_runner,
+              launch_runner_steps, launch_runner_anchor_price
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(position_id) DO UPDATE SET
               pool_address = excluded.pool_address,
               position_pubkey = COALESCE(excluded.position_pubkey, positions.position_pubkey),
@@ -200,7 +205,12 @@ export const DbLive = (dbPath?: string) =>
                 excluded.invalidation_stop_price,
                 positions.invalidation_stop_price
               ),
-              launch_runner = COALESCE(excluded.launch_runner, positions.launch_runner)`,
+              launch_runner = COALESCE(excluded.launch_runner, positions.launch_runner),
+              launch_runner_steps = COALESCE(excluded.launch_runner_steps, positions.launch_runner_steps),
+              launch_runner_anchor_price = COALESCE(
+                excluded.launch_runner_anchor_price,
+                positions.launch_runner_anchor_price
+              )`,
               pos.positionId,
               pos.poolAddress,
               pos.positionPubKey,
@@ -232,6 +242,8 @@ export const DbLive = (dbPath?: string) =>
               pos.tpLadderJson ?? null,
               pos.invalidationStopPrice ?? null,
               pos.launchRunner == null ? null : pos.launchRunner ? 1 : 0,
+              pos.launchRunnerSteps ?? null,
+              pos.launchRunnerAnchorPrice ?? null,
             );
           }),
 
@@ -1551,6 +1563,9 @@ function rowToPosition(row: Record<string, unknown>): PositionRecord {
     realizedPnlUsd: row.realized_pnl_usd != null ? Number(row.realized_pnl_usd) : null,
     positionMode: row.position_mode != null ? String(row.position_mode as unknown) : null,
     launchRunner: row.launch_runner != null ? row.launch_runner !== 0 : null,
+    launchRunnerSteps: row.launch_runner_steps != null ? Number(row.launch_runner_steps) : null,
+    launchRunnerAnchorPrice:
+      row.launch_runner_anchor_price != null ? Number(row.launch_runner_anchor_price) : null,
     tpLadderJson: row.tp_ladder_json != null ? String(row.tp_ladder_json as unknown) : null,
     invalidationStopPrice:
       row.invalidation_stop_price != null ? Number(row.invalidation_stop_price) : null,

--- a/engine/db.ts
+++ b/engine/db.ts
@@ -946,6 +946,23 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
       }
     },
   },
+  {
+    version: 24,
+    name: "launch_runner_scale_in",
+    up(db) {
+      // Runner scale-in state (Heart Attack step 2): how many top-up steps a
+      // runner position has taken and the price its band is currently anchored
+      // at. Persisted so a restart cannot re-scale an already-filled position
+      // or re-anchor a stale band. Legacy rows stay NULL (0 steps / unknown
+      // anchor — scale-in simply never fires without an anchor).
+      if (hasTable(db, "positions") && !hasColumn(db, "positions", "launch_runner_steps")) {
+        db.exec("ALTER TABLE positions ADD COLUMN launch_runner_steps INTEGER");
+      }
+      if (hasTable(db, "positions") && !hasColumn(db, "positions", "launch_runner_anchor_price")) {
+        db.exec("ALTER TABLE positions ADD COLUMN launch_runner_anchor_price REAL");
+      }
+    },
+  },
 ];
 
 function runMigrations(db: Database) {

--- a/engine/launch-position.ts
+++ b/engine/launch-position.ts
@@ -94,3 +94,75 @@ export interface LaunchEntrySizeInput {
 export function launchEntrySizeUsd(input: LaunchEntrySizeInput): number {
   return Math.max(0, Math.min(input.maxSizeUsd, 0.005 * input.poolTvlUsd, 0.5 * input.walletUsd));
 }
+
+export interface ScaleInDecisionInput {
+  /** The price the runner band was last anchored at (entry price, then each
+   *  scale-in's re-anchor). */
+  readonly anchorPrice: number;
+  /** Current pool price. */
+  readonly currentPrice: number;
+  /** Re-anchor when the price falls this fraction below the anchor. */
+  readonly stepPct: number;
+  /** Steps already taken on this position (persisted, restart-safe). */
+  readonly steps: number;
+  readonly maxSteps: number;
+}
+
+export interface ScaleInDecision {
+  readonly scale: boolean;
+  readonly reason: string | null;
+}
+
+/**
+ * Runner scale-in trigger: re-anchor the dip band + add capital when the
+ * price falls a full step below the last anchor, up to maxSteps. The band
+ * TRACKS the dip (re-anchored at dip% below the NEW price) — accumulating
+ * quote liquidity into the falling price instead of holding a stale band.
+ */
+export function shouldScaleInRunner(input: ScaleInDecisionInput): ScaleInDecision {
+  if (input.steps >= input.maxSteps) {
+    return { scale: false, reason: `max steps reached (${input.steps}/${input.maxSteps})` };
+  }
+  if (!Number.isFinite(input.anchorPrice) || input.anchorPrice <= 0) {
+    return { scale: false, reason: "anchor price unknown" };
+  }
+  if (input.currentPrice <= 0 || !Number.isFinite(input.currentPrice)) {
+    return { scale: false, reason: "current price unknown" };
+  }
+  const drop = 1 - input.currentPrice / input.anchorPrice;
+  if (drop < input.stepPct) {
+    return {
+      scale: false,
+      reason: `price drop ${(drop * 100).toFixed(2)}% < step ${(input.stepPct * 100).toFixed(0)}%`,
+    };
+  }
+  return {
+    scale: true,
+    reason: `price fell ${(drop * 100).toFixed(2)}% below anchor — re-anchoring + scaling in (step ${input.steps + 1}/${input.maxSteps})`,
+  };
+}
+
+export interface ScaleInTopUpInput {
+  /** Remaining quote capital in the wallet (USD). */
+  readonly walletUsd: number;
+  /** Fraction of the wallet added per step. */
+  readonly sizePct: number;
+  /** Remaining per-pool allocation headroom (USD) — the aggregate exposure
+   *  cap from the risk tail. */
+  readonly poolCapUsd: number;
+  /** Hard ceiling for one scale-in top-up. */
+  readonly maxTopUpUsd: number;
+}
+
+/**
+ * Scale-in top-up sizing: min(sizePct x wallet, per-pool headroom, hard
+ * ceiling), floored at 0. The per-pool allocation cap applies because a
+ * scale-in ADDS new capital to the pool's aggregate exposure (unlike the
+ * fee-compound top-up, which only reinvests already-owned fees).
+ */
+export function scaleInTopUpUsd(input: ScaleInTopUpInput): number {
+  return Math.max(
+    0,
+    Math.min(input.sizePct * input.walletUsd, input.poolCapUsd, input.maxTopUpUsd),
+  );
+}

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -112,7 +112,12 @@ import { identifyAssetMint } from "./fallen-angel-service.js";
 import { buildTpLadder, evaluateTpLadder, parseTpLadder, serializeTpLadder } from "./tp-ladder.js";
 import { getGeckoPoolOhlcv, type GeckoOhlcvSignals } from "./gecko-ohlcv-service.js";
 import { getRugCheckReport, type RugCheckReport } from "./rugcheck-service.js";
-import { launchEntrySizeUsd, launchPositionExit } from "./launch-position.js";
+import {
+  launchEntrySizeUsd,
+  launchPositionExit,
+  scaleInTopUpUsd,
+  shouldScaleInRunner,
+} from "./launch-position.js";
 import type {
   AgentDecision,
   AgentProposal,
@@ -1047,6 +1052,8 @@ export function executePaper(
         tpLadderJson: decision.tpLadderJson ?? null,
         invalidationStopPrice: decision.invalidationStopPrice ?? null,
         launchRunner: (entryDipOffsetBins ?? 0) !== 0 ? true : null,
+        launchRunnerSteps: (entryDipOffsetBins ?? 0) !== 0 ? 0 : null,
+        launchRunnerAnchorPrice: (entryDipOffsetBins ?? 0) !== 0 ? pool.currentPrice : null,
       };
       trackedPositions.set(pos.positionId, pos);
       yield* persist(`savePosition ${pos.positionId}`, db.savePosition(pos));
@@ -1575,6 +1582,8 @@ export function executeLive(
           tpLadderJson: decision.tpLadderJson ?? null,
           invalidationStopPrice: decision.invalidationStopPrice ?? null,
           launchRunner: (entryDipOffsetBins ?? 0) !== 0 ? true : null,
+          launchRunnerSteps: (entryDipOffsetBins ?? 0) !== 0 ? 0 : null,
+          launchRunnerAnchorPrice: (entryDipOffsetBins ?? 0) !== 0 ? pool.currentPrice : null,
         };
         trackedPositions.set(pos.positionId, pos);
         yield* persist(`savePosition ${pos.positionId}`, db.savePosition(pos));
@@ -5534,6 +5543,141 @@ export const program = Effect.gen(function* () {
               detail = `fee/IL ${metrics.feeIlRatio.toFixed(2)} < 0.5`;
             }
             launchLifecycle = { reasoning: `[launch-${launchReason}] ${detail}` };
+          } else if (
+            // ── Runner scale-in (Heart Attack step 2) ────────────────────────
+            // The dip band TRACKS the falling price: when the price falls a
+            // full step below the band's anchor, re-anchor at dip% below the
+            // NEW price and top up with fresh quote capital via the atomic
+            // rebalance (redeposits the mixed basket + top-up in one tx,
+            // preserving the position pubkey). Runs only when the exit did NOT
+            // fire this cycle — never scale into a dying position. Attached to
+            // the INNER exit-if (this position's launch lifecycle), not the
+            // outer launch-mode gate — otherwise it would run for non-launch
+            // positions, which never carry launchRunner.
+            pos.launchRunner === true &&
+            config.launchRunnerScaleInEnabled !== false &&
+            // Paper mode must never touch the live adapter (mirrors the
+            // compound path's paperTrading === false gate) — paper records
+            // would-be scale-ins via the audit decision below.
+            config.paperTrading === false
+          ) {
+            const scaleInDecision = shouldScaleInRunner({
+              anchorPrice: pos.launchRunnerAnchorPrice ?? 0,
+              currentPrice: pool.currentPrice,
+              stepPct: config.launchRunnerScaleInStepPct ?? 0.05,
+              steps: pos.launchRunnerSteps ?? 0,
+              maxSteps: config.launchRunnerScaleInMaxSteps ?? 3,
+            });
+            if (scaleInDecision.scale && pos.positionPubKey !== null) {
+              // Per-pool allocation headroom: a scale-in ADDS new capital to
+              // the pool's aggregate exposure — the same cap the risk tail
+              // applies to entries.
+              const poolExposureUsd = Array.from(trackedPositions.values())
+                .filter((p) => p.poolAddress === poolAddress)
+                .reduce((sum, p) => sum + p.currentValueUsd, 0);
+              const portfolioValueUsd =
+                lastWalletBalanceUsd +
+                Array.from(trackedPositions.values()).reduce(
+                  (sum, p) => sum + p.currentValueUsd,
+                  0,
+                );
+              const poolCapUsd = Math.max(
+                0,
+                (config.maxPerPoolAllocationPct ?? 0.4) * portfolioValueUsd - poolExposureUsd,
+              );
+              const topUpUsd = scaleInTopUpUsd({
+                walletUsd: lastWalletBalanceUsd,
+                sizePct: config.launchRunnerScaleInSizePct ?? 0.25,
+                poolCapUsd,
+                maxTopUpUsd: config.launchPositionMaxSizeUsd ?? 100,
+              });
+              const tokenXDecimals = yield* adapter
+                .getTokenDecimals(pool.tokenX)
+                .pipe(Effect.catch(() => Effect.succeed(null)));
+              const priceX = (yield* adapter
+                .getTokenPrices([pool.tokenX])
+                .pipe(Effect.catch(() => Effect.succeed({} as Record<string, number>))))[
+                pool.tokenX
+              ];
+              if (topUpUsd >= 5 && tokenXDecimals !== null && priceX != null && priceX > 0) {
+                const topUpAtomicX = BigInt(Math.floor((topUpUsd / priceX) * 10 ** tokenXDecimals));
+                // The batch SOL budget (SOL-funded wallets) applies to scale-in
+                // top-ups the same way it applies to entries — a top-up that
+                // does not fit is skipped, never forced.
+                const solLamports = pool.tokenX === SOL_MINT ? topUpAtomicX : 0n;
+                if (solLamports > 0n && entrySolBudgetLamports < solLamports) {
+                  logger.info("Runner scale-in skipped — SOL budget insufficient", {
+                    pool: poolAddress,
+                    position: pos.positionId,
+                  });
+                } else if (topUpAtomicX > 0n) {
+                  if (solLamports > 0n) entrySolBudgetLamports -= solLamports;
+                  const dipOffset = dipOffsetBinsForPct(
+                    pool.binStep,
+                    config.launchRunnerDipPct ?? 0.12,
+                  );
+                  const runnerWidth = Math.max(
+                    1,
+                    Math.min(
+                      config.launchRunnerHalfWidthBins ?? 5,
+                      Math.abs(dipOffset) - 1,
+                      Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
+                    ),
+                  );
+                  const newLowerBinId = pool.activeBinId - runnerWidth + dipOffset;
+                  const newUpperBinId = pool.activeBinId + runnerWidth + dipOffset;
+                  const scaleInResult = yield* adapter
+                    .rebalancePosition(
+                      poolAddress,
+                      pos.positionPubKey,
+                      newLowerBinId,
+                      newUpperBinId,
+                      { amountXAtomic: topUpAtomicX, amountYAtomic: 0n },
+                    )
+                    .pipe(
+                      Effect.tap((r) =>
+                        Effect.sync(() =>
+                          logger.info("Runner scale-in executed", {
+                            pool: poolAddress,
+                            position: pos.positionId,
+                            topUpUsd,
+                            step: (pos.launchRunnerSteps ?? 0) + 1,
+                            range: [newLowerBinId, newUpperBinId],
+                            pubkey: r.positionPubKey,
+                          }),
+                        ),
+                      ),
+                      Effect.catch((err) => {
+                        logger.warn("Runner scale-in failed", {
+                          pool: poolAddress,
+                          position: pos.positionId,
+                          error: err instanceof Error ? err.message : String(err),
+                        });
+                        return Effect.succeed(null);
+                      }),
+                    );
+                  if (scaleInResult !== null) {
+                    pos.launchRunnerAnchorPrice = pool.currentPrice;
+                    pos.launchRunnerSteps = (pos.launchRunnerSteps ?? 0) + 1;
+                    yield* persist(`savePosition ${pos.positionId}`, db.savePosition(pos));
+                    yield* audit
+                      .recordDecision({
+                        timestamp: Date.now(),
+                        cycleId,
+                        poolAddress,
+                        action: "REBALANCE",
+                        confidence: 1,
+                        reasoning: `[launch-scale-in] ${scaleInDecision.reason}`,
+                        metrics,
+                        riskResult: { approved: true, reason: "[launch-scale-in]" },
+                        executed: true,
+                        paperTrading: config.paperTrading,
+                      })
+                      .pipe(Effect.catch(() => Effect.void));
+                  }
+                }
+              }
+            }
           }
         }
 

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -5379,6 +5379,17 @@ export const program = Effect.gen(function* () {
         }
       }
 
+      // Runner scale-in (Heart Attack step 2): the lifecycle block EVALUATES
+      // the trigger (band re-anchor + top-up sizing); the actual rebalance is
+      // deferred to the execution tail so it runs AFTER every exit gate has
+      // had its say and behind the safety-pause/mode guards. A position whose
+      // final decision is EXIT never scales in this cycle.
+      let launchScaleInPending: {
+        readonly positionId: string;
+        readonly topUpUsd: number;
+        readonly reason: string;
+      } | null = null;
+
       for (const pos of poolPositions) {
         let decision: AgentDecision | null = null;
 
@@ -5555,11 +5566,7 @@ export const program = Effect.gen(function* () {
             // outer launch-mode gate — otherwise it would run for non-launch
             // positions, which never carry launchRunner.
             pos.launchRunner === true &&
-            config.launchRunnerScaleInEnabled !== false &&
-            // Paper mode must never touch the live adapter (mirrors the
-            // compound path's paperTrading === false gate) — paper records
-            // would-be scale-ins via the audit decision below.
-            config.paperTrading === false
+            config.launchRunnerScaleInEnabled !== false
           ) {
             const scaleInDecision = shouldScaleInRunner({
               anchorPrice: pos.launchRunnerAnchorPrice ?? 0,
@@ -5594,87 +5601,49 @@ export const program = Effect.gen(function* () {
               const tokenXDecimals = yield* adapter
                 .getTokenDecimals(pool.tokenX)
                 .pipe(Effect.catch(() => Effect.succeed(null)));
+              // Live price only — a hardcoded fallback must never size a
+              // top-up (useFallback: false; an unavailable price tops out at
+              // 0 and the top-up is skipped).
               const priceX = (yield* adapter
-                .getTokenPrices([pool.tokenX])
+                .getTokenPrices([pool.tokenX], { useFallback: false })
                 .pipe(Effect.catch(() => Effect.succeed({} as Record<string, number>))))[
                 pool.tokenX
               ];
-              if (topUpUsd >= 5 && tokenXDecimals !== null && priceX != null && priceX > 0) {
-                const topUpAtomicX = BigInt(Math.floor((topUpUsd / priceX) * 10 ** tokenXDecimals));
-                // The batch SOL budget (SOL-funded wallets) applies to scale-in
-                // top-ups the same way it applies to entries — a top-up that
-                // does not fit is skipped, never forced.
-                const solLamports = pool.tokenX === SOL_MINT ? topUpAtomicX : 0n;
-                if (solLamports > 0n && entrySolBudgetLamports < solLamports) {
-                  logger.info("Runner scale-in skipped — SOL budget insufficient", {
-                    pool: poolAddress,
-                    position: pos.positionId,
-                  });
-                } else if (topUpAtomicX > 0n) {
-                  if (solLamports > 0n) entrySolBudgetLamports -= solLamports;
-                  const dipOffset = dipOffsetBinsForPct(
-                    pool.binStep,
-                    config.launchRunnerDipPct ?? 0.12,
-                  );
-                  const runnerWidth = Math.max(
-                    1,
-                    Math.min(
-                      config.launchRunnerHalfWidthBins ?? 5,
-                      Math.abs(dipOffset) - 1,
-                      Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
-                    ),
-                  );
-                  const newLowerBinId = pool.activeBinId - runnerWidth + dipOffset;
-                  const newUpperBinId = pool.activeBinId + runnerWidth + dipOffset;
-                  const scaleInResult = yield* adapter
-                    .rebalancePosition(
+              const topUpAtomicX =
+                tokenXDecimals !== null && priceX != null && priceX > 0
+                  ? BigInt(Math.floor((topUpUsd / priceX) * 10 ** tokenXDecimals))
+                  : 0n;
+              if (topUpUsd >= 5 && topUpAtomicX > 0n) {
+                // EVALUATION ONLY — the actual rebalance executes in the
+                // per-pool execution tail, AFTER every exit gate (W15,
+                // IL-dominance, TVL-drop, volume-auth, fee/IL, trailing
+                // stop) has had its say, and behind the same safety-pause /
+                // mode guards as every other action. Paper mode advances the
+                // trigger state + audits the would-be scale-in here so paper
+                // validates the band-tracking over cycles.
+                launchScaleInPending = {
+                  positionId: pos.positionId,
+                  topUpUsd,
+                  reason: scaleInDecision.reason ?? "price step reached",
+                };
+                if (config.paperTrading) {
+                  pos.launchRunnerAnchorPrice = pool.currentPrice;
+                  pos.launchRunnerSteps = (pos.launchRunnerSteps ?? 0) + 1;
+                  yield* persist(`savePosition ${pos.positionId}`, db.savePosition(pos));
+                  yield* audit
+                    .recordDecision({
+                      timestamp: Date.now(),
+                      cycleId,
                       poolAddress,
-                      pos.positionPubKey,
-                      newLowerBinId,
-                      newUpperBinId,
-                      { amountXAtomic: topUpAtomicX, amountYAtomic: 0n },
-                    )
-                    .pipe(
-                      Effect.tap((r) =>
-                        Effect.sync(() =>
-                          logger.info("Runner scale-in executed", {
-                            pool: poolAddress,
-                            position: pos.positionId,
-                            topUpUsd,
-                            step: (pos.launchRunnerSteps ?? 0) + 1,
-                            range: [newLowerBinId, newUpperBinId],
-                            pubkey: r.positionPubKey,
-                          }),
-                        ),
-                      ),
-                      Effect.catch((err) => {
-                        logger.warn("Runner scale-in failed", {
-                          pool: poolAddress,
-                          position: pos.positionId,
-                          error: err instanceof Error ? err.message : String(err),
-                        });
-                        return Effect.succeed(null);
-                      }),
-                    );
-                  if (scaleInResult !== null) {
-                    pos.launchRunnerAnchorPrice = pool.currentPrice;
-                    pos.launchRunnerSteps = (pos.launchRunnerSteps ?? 0) + 1;
-                    yield* persist(`savePosition ${pos.positionId}`, db.savePosition(pos));
-                    yield* audit
-                      .recordDecision({
-                        timestamp: Date.now(),
-                        cycleId,
-                        poolAddress,
-                        action: "REBALANCE",
-                        confidence: 1,
-                        reasoning: `[launch-scale-in] ${scaleInDecision.reason}`,
-                        metrics,
-                        riskResult: { approved: true, reason: "[launch-scale-in]" },
-                        executed: true,
-                        paperTrading: config.paperTrading,
-                      })
-                      .pipe(Effect.catch(() => Effect.void));
-                  }
+                      action: "REBALANCE",
+                      confidence: 1,
+                      reasoning: `[launch-scale-in] ${scaleInDecision.reason}`,
+                      metrics,
+                      riskResult: { approved: true, reason: "[launch-scale-in]" },
+                      executed: false,
+                      paperTrading: true,
+                    })
+                    .pipe(Effect.catch(() => Effect.void));
                 }
               }
             }
@@ -8054,6 +8023,179 @@ export const program = Effect.gen(function* () {
         }
 
         finalDecisions.push(decision);
+      }
+
+      // ── Runner scale-in execution (Heart Attack step 2) ──────────────────
+      // Deferred from the lifecycle block: runs only after the FULL exit
+      // chain (W15, IL-dominance, TVL-drop, volume-auth, fee/IL, trailing
+      // stop) found no EXIT for the position this cycle, and behind the same
+      // safety-pause / mode guards as every other live action (a pause or
+      // shadow mode can never be bypassed by an inline adapter call).
+      if (launchScaleInPending !== null) {
+        const pending = launchScaleInPending;
+        const targetPos = positionsForPool(trackedPositions, poolAddress).find(
+          (p) => p.positionId === pending.positionId,
+        );
+        const exitedThisCycle = finalDecisions.some(
+          (d) => d.positionId === pending.positionId && d.action === "EXIT",
+        );
+        if (
+          targetPos !== undefined &&
+          targetPos.positionPubKey !== null &&
+          !exitedThisCycle &&
+          !config.paperTrading
+        ) {
+          const pauseBlockReason = safetyPauseBlockReason(
+            autonomousExecution?.mode,
+            activeSafetyPause,
+            "REBALANCE",
+          );
+          const supervisedBlocksScaleIn = config.agentProposalMode === "supervised";
+          if (
+            pauseBlockReason === null &&
+            !supervisedBlocksScaleIn &&
+            config.autonomousTokenMode !== "shadow"
+          ) {
+            const tokenXDecimals = yield* adapter
+              .getTokenDecimals(pool.tokenX)
+              .pipe(Effect.catch(() => Effect.succeed(null)));
+            const priceX = (yield* adapter
+              .getTokenPrices([pool.tokenX], { useFallback: false })
+              .pipe(Effect.catch(() => Effect.succeed({} as Record<string, number>))))[pool.tokenX];
+            const topUpAtomicX =
+              tokenXDecimals !== null && priceX != null && priceX > 0
+                ? BigInt(Math.floor((pending.topUpUsd / priceX) * 10 ** tokenXDecimals))
+                : 0n;
+            const solLamports = pool.tokenX === SOL_MINT ? topUpAtomicX : 0n;
+            if (topUpAtomicX > 0n && !(solLamports > 0n && entrySolBudgetLamports < solLamports)) {
+              // Acquire the quote leg: autonomous SOL-funded wallets swap
+              // SOL -> quote via the xOnly prep (never the Y half).
+              const entryPrepSvc = yield* EntryPrepService;
+              const prepResult = yield* entryPrepSvc
+                .prepareEntryTokens(poolAddress, pending.topUpUsd, { xOnly: true })
+                .pipe(Effect.catch(() => Effect.succeed(null)));
+              if (prepResult === null) {
+                logger.warn("Runner scale-in skipped — quote prep failed", {
+                  pool: poolAddress,
+                  position: pending.positionId,
+                });
+              } else {
+                if (solLamports > 0n) entrySolBudgetLamports -= solLamports;
+                const dipOffset = dipOffsetBinsForPct(
+                  pool.binStep,
+                  config.launchRunnerDipPct ?? 0.12,
+                );
+                const runnerWidth = Math.max(
+                  1,
+                  Math.min(
+                    config.launchRunnerHalfWidthBins ?? 5,
+                    Math.abs(dipOffset) - 1,
+                    Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
+                  ),
+                );
+                const newLowerBinId = pool.activeBinId - runnerWidth + dipOffset;
+                const newUpperBinId = pool.activeBinId + runnerWidth + dipOffset;
+                const scaleInResult = yield* adapter
+                  .rebalancePosition(
+                    poolAddress,
+                    targetPos.positionPubKey,
+                    newLowerBinId,
+                    newUpperBinId,
+                    { amountXAtomic: topUpAtomicX, amountYAtomic: 0n },
+                  )
+                  .pipe(
+                    Effect.tap((r) =>
+                      Effect.sync(() =>
+                        logger.info("Runner scale-in executed", {
+                          pool: poolAddress,
+                          position: pending.positionId,
+                          topUpUsd: pending.topUpUsd,
+                          step: (targetPos.launchRunnerSteps ?? 0) + 1,
+                          range: [newLowerBinId, newUpperBinId],
+                          pubkey: r.positionPubKey,
+                        }),
+                      ),
+                    ),
+                    Effect.catch((err) => {
+                      logger.warn("Runner scale-in failed", {
+                        pool: poolAddress,
+                        position: pending.positionId,
+                        error: err instanceof Error ? err.message : String(err),
+                      });
+                      return Effect.succeed(null);
+                    }),
+                  );
+                if (scaleInResult !== null) {
+                  // The top-up is FRESH capital: it grows the cost basis and
+                  // the current mark (currentValue + topUp = post-rebalance
+                  // on-chain value) in lockstep — the same invariant the
+                  // compound path applies (applyCompoundToCostBasis).
+                  const basis = applyCompoundToCostBasis({
+                    depositedUsd: targetPos.depositedUsd,
+                    currentValueUsd: targetPos.currentValueUsd,
+                    highestValueUsd: targetPos.highestValueUsd,
+                    compoundedFeesUsd: pending.topUpUsd,
+                  });
+                  const updated: PositionRecord = {
+                    ...targetPos,
+                    ...basis,
+                    // The runner entry is single-sided X: the top-up adds to
+                    // the X basis (the HODL benchmark leg).
+                    entryAmountXUsd: (targetPos.entryAmountXUsd ?? 0) + pending.topUpUsd,
+                    lowerBinId: newLowerBinId,
+                    upperBinId: newUpperBinId,
+                    positionId: scaleInResult.positionPubKey,
+                    positionPubKey: scaleInResult.positionPubKey,
+                    launchRunnerAnchorPrice: pool.currentPrice,
+                    launchRunnerSteps: (targetPos.launchRunnerSteps ?? 0) + 1,
+                    lastRebalanceAt: Date.now(),
+                  };
+                  if (updated.positionId !== targetPos.positionId) {
+                    // Defensive re-key: the identity and its row move with the
+                    // pubkey (same contract as the atomic rebalance path).
+                    trackedPositions.delete(targetPos.positionId);
+                    yield* persist(
+                      `deletePosition ${targetPos.positionId}`,
+                      db.deletePosition(targetPos.positionId),
+                    );
+                  }
+                  trackedPositions.set(updated.positionId, updated);
+                  yield* persist(`savePosition ${updated.positionId}`, db.savePosition(updated));
+                  // The top-up spent wallet capital: refresh the balance so
+                  // the rest of the cycle sizes against the post-scale-in
+                  // wallet (mirrors the ENTER/EXIT tail).
+                  lastWalletBalanceUsd = yield* adapter
+                    .getWalletBalanceUsd()
+                    .pipe(Effect.catch(() => Effect.succeed(lastWalletBalanceUsd)));
+                  yield* audit
+                    .recordDecision({
+                      timestamp: Date.now(),
+                      cycleId,
+                      poolAddress,
+                      action: "REBALANCE",
+                      confidence: 1,
+                      reasoning: `[launch-scale-in] ${pending.reason}`,
+                      metrics,
+                      riskResult: { approved: true, reason: "[launch-scale-in]" },
+                      executed: true,
+                      paperTrading: false,
+                    })
+                    .pipe(Effect.catch(() => Effect.void));
+                }
+              }
+            }
+          } else {
+            logger.info("Runner scale-in skipped — guarded (pause/mode)", {
+              pool: poolAddress,
+              position: pending.positionId,
+              pauseReason: safetyPauseBlockReason(
+                autonomousExecution?.mode,
+                activeSafetyPause,
+                "REBALANCE",
+              ),
+            });
+          }
+        }
       }
 
       return finalDecisions;

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -1125,10 +1125,31 @@ export function executePaper(
     } else if (decision.action === "REBALANCE" && decision.rebalanceParams) {
       const current = resolveTargetPosition(trackedPositions, decision);
       if (current) {
+        // Runner scale-in: the top-up is FRESH capital — grow the cost basis
+        // and the mark in lockstep (same invariant the live executor applies)
+        // and advance the band anchor + step count.
+        const topUpUsd = decision.rebalanceParams.topUpUsd ?? 0;
+        const scaled = applyCompoundToCostBasis({
+          depositedUsd: current.depositedUsd,
+          currentValueUsd: current.currentValueUsd,
+          highestValueUsd: current.highestValueUsd,
+          compoundedFeesUsd: topUpUsd,
+        });
         const updated: PositionRecord = {
           ...current,
+          ...scaled,
+          entryAmountXUsd:
+            current.launchRunner === true
+              ? (current.entryAmountXUsd ?? 0) + topUpUsd
+              : current.entryAmountXUsd,
           lowerBinId: decision.rebalanceParams.newLowerBinId,
           upperBinId: decision.rebalanceParams.newUpperBinId,
+          ...(current.launchRunner === true && decision.rebalanceParams.topUp !== undefined
+            ? {
+                launchRunnerAnchorPrice: pool.currentPrice,
+                launchRunnerSteps: (current.launchRunnerSteps ?? 0) + 1,
+              }
+            : {}),
           lastRebalanceAt: Date.now(),
         };
         trackedPositions.set(updated.positionId, updated);
@@ -1146,6 +1167,7 @@ export function executePaper(
             metadata: {
               newLowerBinId: decision.rebalanceParams.newLowerBinId,
               newUpperBinId: decision.rebalanceParams.newUpperBinId,
+              ...(decision.rebalanceParams.topUp !== undefined ? { scaleIn: true, topUpUsd } : {}),
             },
             createdAt: Date.now(),
           })
@@ -2205,6 +2227,7 @@ export function executeLive(
             pos.positionPubKey,
             decision.rebalanceParams.newLowerBinId,
             decision.rebalanceParams.newUpperBinId,
+            decision.rebalanceParams.topUp,
           )
           .pipe(
             Effect.tap((r) =>
@@ -2228,14 +2251,37 @@ export function executeLive(
           );
 
         if (rebalanceResult.result) {
+          // Runner scale-in: the top-up is FRESH capital — grow the cost
+          // basis and the mark in lockstep (currentValue + topUp = the
+          // post-rebalance on-chain value; depositedUsd tracks the added
+          // capital so PnL never treats it as profit), credit the X basis and
+          // advance the band anchor + step count.
+          const topUpUsd = decision.rebalanceParams.topUpUsd ?? 0;
+          const scaled = applyCompoundToCostBasis({
+            depositedUsd: pos.depositedUsd,
+            currentValueUsd: pos.currentValueUsd,
+            highestValueUsd: pos.highestValueUsd,
+            compoundedFeesUsd: topUpUsd,
+          });
           const updated: PositionRecord = {
             ...pos,
+            ...scaled,
+            entryAmountXUsd:
+              decision.rebalanceParams.topUp !== undefined
+                ? (pos.entryAmountXUsd ?? 0) + topUpUsd
+                : pos.entryAmountXUsd,
             // Atomic rebalance preserves the position account: the pubkey,
             // entry basis and cumulative fee accounting all survive.
             positionId: rebalanceResult.result.positionPubKey,
             positionPubKey: rebalanceResult.result.positionPubKey,
             lowerBinId: decision.rebalanceParams.newLowerBinId,
             upperBinId: decision.rebalanceParams.newUpperBinId,
+            ...(decision.rebalanceParams.topUp !== undefined
+              ? {
+                  launchRunnerAnchorPrice: pool.currentPrice,
+                  launchRunnerSteps: (pos.launchRunnerSteps ?? 0) + 1,
+                }
+              : {}),
             lastFeeClaimAt: Date.now(),
             lastRebalanceAt: Date.now(),
           };
@@ -5379,17 +5425,6 @@ export const program = Effect.gen(function* () {
         }
       }
 
-      // Runner scale-in (Heart Attack step 2): the lifecycle block EVALUATES
-      // the trigger (band re-anchor + top-up sizing); the actual rebalance is
-      // deferred to the execution tail so it runs AFTER every exit gate has
-      // had its say and behind the safety-pause/mode guards. A position whose
-      // final decision is EXIT never scales in this cycle.
-      let launchScaleInPending: {
-        readonly positionId: string;
-        readonly topUpUsd: number;
-        readonly reason: string;
-      } | null = null;
-
       for (const pos of poolPositions) {
         let decision: AgentDecision | null = null;
 
@@ -5614,36 +5649,55 @@ export const program = Effect.gen(function* () {
                   ? BigInt(Math.floor((topUpUsd / priceX) * 10 ** tokenXDecimals))
                   : 0n;
               if (topUpUsd >= 5 && topUpAtomicX > 0n) {
-                // EVALUATION ONLY — the actual rebalance executes in the
-                // per-pool execution tail, AFTER every exit gate (W15,
-                // IL-dominance, TVL-drop, volume-auth, fee/IL, trailing
-                // stop) has had its say, and behind the same safety-pause /
-                // mode guards as every other action. Paper mode advances the
-                // trigger state + audits the would-be scale-in here so paper
-                // validates the band-tracking over cycles.
-                launchScaleInPending = {
-                  positionId: pos.positionId,
-                  topUpUsd,
-                  reason: scaleInDecision.reason ?? "price step reached",
-                };
-                if (config.paperTrading) {
-                  pos.launchRunnerAnchorPrice = pool.currentPrice;
-                  pos.launchRunnerSteps = (pos.launchRunnerSteps ?? 0) + 1;
-                  yield* persist(`savePosition ${pos.positionId}`, db.savePosition(pos));
-                  yield* audit
-                    .recordDecision({
-                      timestamp: Date.now(),
-                      cycleId,
-                      poolAddress,
-                      action: "REBALANCE",
-                      confidence: 1,
-                      reasoning: `[launch-scale-in] ${scaleInDecision.reason}`,
-                      metrics,
-                      riskResult: { approved: true, reason: "[launch-scale-in]" },
-                      executed: false,
-                      paperTrading: true,
+                // Reserve the SOL the top-up costs (autonomous canary/live
+                // swaps SOL for a non-SOL quote leg): skip — never force —
+                // when the batch budget cannot cover it, exactly like ENTER.
+                const solCostLamports = solFundedEntryMode
+                  ? estimateEntrySolLamports({
+                      positionSizeUsd: topUpUsd,
+                      solPriceUsd: config.solPriceUsd,
+                      poolHasSolLeg: pool.tokenX === SOL_MINT || pool.tokenY === SOL_MINT,
+                      solFunded: true,
                     })
-                    .pipe(Effect.catch(() => Effect.void));
+                  : 0n;
+                if (solCostLamports > 0n && entrySolBudgetLamports < solCostLamports) {
+                  logger.info("Runner scale-in skipped — SOL budget insufficient", {
+                    pool: poolAddress,
+                    position: pos.positionId,
+                  });
+                } else {
+                  if (solCostLamports > 0n) entrySolBudgetLamports -= solCostLamports;
+                  const dipOffset = dipOffsetBinsForPct(
+                    pool.binStep,
+                    config.launchRunnerDipPct ?? 0.12,
+                  );
+                  const runnerWidth = Math.max(
+                    1,
+                    Math.min(
+                      config.launchRunnerHalfWidthBins ?? 5,
+                      Math.abs(dipOffset) - 1,
+                      Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
+                    ),
+                  );
+                  // EMIT a position-targeted REBALANCE decision: the normal
+                  // executor runs it through risk.evaluate (safety pause),
+                  // the agent overlay (veto can HOLD it, supervised requires
+                  // approval, full validates) and the paper/live dispatch —
+                  // after every exit gate has had its say this cycle.
+                  decision = {
+                    action: "REBALANCE",
+                    poolAddress,
+                    positionId: pos.positionId,
+                    confidence: 1,
+                    reasoning: `[launch-scale-in] ${scaleInDecision.reason ?? "price step reached"}`,
+                    rebalanceParams: {
+                      newLowerBinId: pool.activeBinId - runnerWidth + dipOffset,
+                      newUpperBinId: pool.activeBinId + runnerWidth + dipOffset,
+                      slippageBps: config.maxSwapSlippageBps ?? 50,
+                      topUp: { amountXAtomic: topUpAtomicX, amountYAtomic: 0n },
+                      topUpUsd,
+                    },
+                  };
                 }
               }
             }
@@ -8023,179 +8077,6 @@ export const program = Effect.gen(function* () {
         }
 
         finalDecisions.push(decision);
-      }
-
-      // ── Runner scale-in execution (Heart Attack step 2) ──────────────────
-      // Deferred from the lifecycle block: runs only after the FULL exit
-      // chain (W15, IL-dominance, TVL-drop, volume-auth, fee/IL, trailing
-      // stop) found no EXIT for the position this cycle, and behind the same
-      // safety-pause / mode guards as every other live action (a pause or
-      // shadow mode can never be bypassed by an inline adapter call).
-      if (launchScaleInPending !== null) {
-        const pending = launchScaleInPending;
-        const targetPos = positionsForPool(trackedPositions, poolAddress).find(
-          (p) => p.positionId === pending.positionId,
-        );
-        const exitedThisCycle = finalDecisions.some(
-          (d) => d.positionId === pending.positionId && d.action === "EXIT",
-        );
-        if (
-          targetPos !== undefined &&
-          targetPos.positionPubKey !== null &&
-          !exitedThisCycle &&
-          !config.paperTrading
-        ) {
-          const pauseBlockReason = safetyPauseBlockReason(
-            autonomousExecution?.mode,
-            activeSafetyPause,
-            "REBALANCE",
-          );
-          const supervisedBlocksScaleIn = config.agentProposalMode === "supervised";
-          if (
-            pauseBlockReason === null &&
-            !supervisedBlocksScaleIn &&
-            config.autonomousTokenMode !== "shadow"
-          ) {
-            const tokenXDecimals = yield* adapter
-              .getTokenDecimals(pool.tokenX)
-              .pipe(Effect.catch(() => Effect.succeed(null)));
-            const priceX = (yield* adapter
-              .getTokenPrices([pool.tokenX], { useFallback: false })
-              .pipe(Effect.catch(() => Effect.succeed({} as Record<string, number>))))[pool.tokenX];
-            const topUpAtomicX =
-              tokenXDecimals !== null && priceX != null && priceX > 0
-                ? BigInt(Math.floor((pending.topUpUsd / priceX) * 10 ** tokenXDecimals))
-                : 0n;
-            const solLamports = pool.tokenX === SOL_MINT ? topUpAtomicX : 0n;
-            if (topUpAtomicX > 0n && !(solLamports > 0n && entrySolBudgetLamports < solLamports)) {
-              // Acquire the quote leg: autonomous SOL-funded wallets swap
-              // SOL -> quote via the xOnly prep (never the Y half).
-              const entryPrepSvc = yield* EntryPrepService;
-              const prepResult = yield* entryPrepSvc
-                .prepareEntryTokens(poolAddress, pending.topUpUsd, { xOnly: true })
-                .pipe(Effect.catch(() => Effect.succeed(null)));
-              if (prepResult === null) {
-                logger.warn("Runner scale-in skipped — quote prep failed", {
-                  pool: poolAddress,
-                  position: pending.positionId,
-                });
-              } else {
-                if (solLamports > 0n) entrySolBudgetLamports -= solLamports;
-                const dipOffset = dipOffsetBinsForPct(
-                  pool.binStep,
-                  config.launchRunnerDipPct ?? 0.12,
-                );
-                const runnerWidth = Math.max(
-                  1,
-                  Math.min(
-                    config.launchRunnerHalfWidthBins ?? 5,
-                    Math.abs(dipOffset) - 1,
-                    Math.floor((config.maxRebalanceRangeBins ?? 100) / 2),
-                  ),
-                );
-                const newLowerBinId = pool.activeBinId - runnerWidth + dipOffset;
-                const newUpperBinId = pool.activeBinId + runnerWidth + dipOffset;
-                const scaleInResult = yield* adapter
-                  .rebalancePosition(
-                    poolAddress,
-                    targetPos.positionPubKey,
-                    newLowerBinId,
-                    newUpperBinId,
-                    { amountXAtomic: topUpAtomicX, amountYAtomic: 0n },
-                  )
-                  .pipe(
-                    Effect.tap((r) =>
-                      Effect.sync(() =>
-                        logger.info("Runner scale-in executed", {
-                          pool: poolAddress,
-                          position: pending.positionId,
-                          topUpUsd: pending.topUpUsd,
-                          step: (targetPos.launchRunnerSteps ?? 0) + 1,
-                          range: [newLowerBinId, newUpperBinId],
-                          pubkey: r.positionPubKey,
-                        }),
-                      ),
-                    ),
-                    Effect.catch((err) => {
-                      logger.warn("Runner scale-in failed", {
-                        pool: poolAddress,
-                        position: pending.positionId,
-                        error: err instanceof Error ? err.message : String(err),
-                      });
-                      return Effect.succeed(null);
-                    }),
-                  );
-                if (scaleInResult !== null) {
-                  // The top-up is FRESH capital: it grows the cost basis and
-                  // the current mark (currentValue + topUp = post-rebalance
-                  // on-chain value) in lockstep — the same invariant the
-                  // compound path applies (applyCompoundToCostBasis).
-                  const basis = applyCompoundToCostBasis({
-                    depositedUsd: targetPos.depositedUsd,
-                    currentValueUsd: targetPos.currentValueUsd,
-                    highestValueUsd: targetPos.highestValueUsd,
-                    compoundedFeesUsd: pending.topUpUsd,
-                  });
-                  const updated: PositionRecord = {
-                    ...targetPos,
-                    ...basis,
-                    // The runner entry is single-sided X: the top-up adds to
-                    // the X basis (the HODL benchmark leg).
-                    entryAmountXUsd: (targetPos.entryAmountXUsd ?? 0) + pending.topUpUsd,
-                    lowerBinId: newLowerBinId,
-                    upperBinId: newUpperBinId,
-                    positionId: scaleInResult.positionPubKey,
-                    positionPubKey: scaleInResult.positionPubKey,
-                    launchRunnerAnchorPrice: pool.currentPrice,
-                    launchRunnerSteps: (targetPos.launchRunnerSteps ?? 0) + 1,
-                    lastRebalanceAt: Date.now(),
-                  };
-                  if (updated.positionId !== targetPos.positionId) {
-                    // Defensive re-key: the identity and its row move with the
-                    // pubkey (same contract as the atomic rebalance path).
-                    trackedPositions.delete(targetPos.positionId);
-                    yield* persist(
-                      `deletePosition ${targetPos.positionId}`,
-                      db.deletePosition(targetPos.positionId),
-                    );
-                  }
-                  trackedPositions.set(updated.positionId, updated);
-                  yield* persist(`savePosition ${updated.positionId}`, db.savePosition(updated));
-                  // The top-up spent wallet capital: refresh the balance so
-                  // the rest of the cycle sizes against the post-scale-in
-                  // wallet (mirrors the ENTER/EXIT tail).
-                  lastWalletBalanceUsd = yield* adapter
-                    .getWalletBalanceUsd()
-                    .pipe(Effect.catch(() => Effect.succeed(lastWalletBalanceUsd)));
-                  yield* audit
-                    .recordDecision({
-                      timestamp: Date.now(),
-                      cycleId,
-                      poolAddress,
-                      action: "REBALANCE",
-                      confidence: 1,
-                      reasoning: `[launch-scale-in] ${pending.reason}`,
-                      metrics,
-                      riskResult: { approved: true, reason: "[launch-scale-in]" },
-                      executed: true,
-                      paperTrading: false,
-                    })
-                    .pipe(Effect.catch(() => Effect.void));
-                }
-              }
-            }
-          } else {
-            logger.info("Runner scale-in skipped — guarded (pause/mode)", {
-              pool: poolAddress,
-              position: pending.positionId,
-              pauseReason: safetyPauseBlockReason(
-                autonomousExecution?.mode,
-                activeSafetyPause,
-                "REBALANCE",
-              ),
-            });
-          }
-        }
       }
 
       return finalDecisions;

--- a/engine/risk-service.ts
+++ b/engine/risk-service.ts
@@ -182,7 +182,11 @@ export function evaluateRisk(
         reason: `Rebalance range ${rangeWidth} bins exceeds max ${riskConfig.maxRebalanceRangeBins}`,
       };
     }
+    // A runner scale-in (topUp present) re-anchors the band BELOW the active
+    // bin by design — the below-market dip ladder is the point. The
+    // containment check applies only to ordinary rebalances.
     if (
+      decision.rebalanceParams.topUp === undefined &&
       ctx.activeBinId !== undefined &&
       Number.isFinite(ctx.activeBinId) &&
       (ctx.activeBinId < newLowerBinId || ctx.activeBinId > newUpperBinId)

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -844,6 +844,9 @@ export interface DbApi {
       positionMode?: string | null;
       tpLadderJson?: string | null;
       invalidationStopPrice?: number | null;
+      launchRunner?: boolean | null;
+      launchRunnerSteps?: number | null;
+      launchRunnerAnchorPrice?: number | null;
     } | null,
     Error
   >;
@@ -879,6 +882,9 @@ export interface DbApi {
       positionMode?: string | null;
       tpLadderJson?: string | null;
       invalidationStopPrice?: number | null;
+      launchRunner?: boolean | null;
+      launchRunnerSteps?: number | null;
+      launchRunnerAnchorPrice?: number | null;
     }>,
     Error
   >;
@@ -914,6 +920,9 @@ export interface DbApi {
       positionMode?: string | null;
       tpLadderJson?: string | null;
       invalidationStopPrice?: number | null;
+      launchRunner?: boolean | null;
+      launchRunnerSteps?: number | null;
+      launchRunnerAnchorPrice?: number | null;
     }>,
     Error
   >;
@@ -962,6 +971,9 @@ export interface DbApi {
       positionMode?: string | null;
       tpLadderJson?: string | null;
       invalidationStopPrice?: number | null;
+      launchRunner?: boolean | null;
+      launchRunnerSteps?: number | null;
+      launchRunnerAnchorPrice?: number | null;
     }>,
     Error
   >;

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -808,6 +808,9 @@ export interface DbApi {
     invalidationStopPrice?: number | null;
     /** Runner-mode entry (Heart Attack); optional so legacy callers compile. */
     launchRunner?: boolean | null;
+    /** Runner scale-in state; optional so legacy callers compile. */
+    launchRunnerSteps?: number | null;
+    launchRunnerAnchorPrice?: number | null;
   }) => Effect.Effect<void, Error>;
   readonly getPosition: (positionId: string) => Effect.Effect<
     {

--- a/engine/types.ts
+++ b/engine/types.ts
@@ -299,6 +299,12 @@ export interface RebalanceParams {
   newLowerBinId: number;
   newUpperBinId: number;
   slippageBps: number;
+  /** Atomic top-up redeposited with the rebalance (runner scale-in adds fresh
+   *  quote capital; the compound path tops up just-claimed fees). */
+  topUp?: { amountXAtomic: bigint; amountYAtomic: bigint };
+  /** USD value of the top-up (cost-basis bookkeeping — the executor must not
+   *  re-derive sizing). */
+  topUpUsd?: number;
 }
 
 export interface AgentDecision {


### PR DESCRIPTION
The Heart Attack's second half — "I gradually increased the size." When the price falls a full step below the runner band's anchor, re-anchor the band at dip% below the **new** price and top up the position with fresh quote capital via the atomic rebalance (redeposits the mixed basket + top-up in one tx, preserving the position pubkey).

## The seams, resolved deliberately
1. **W6 topUp relaxation**: the atomic-rebalance `topUp` was caller-side compound-only (just-claimed fees). Scale-in is a **new caller branch** funding from wallet quote capital; the compound branch is untouched.
2. **Persisted state**: `launch_runner_steps` + `launch_runner_anchor_price` (migration v24, PositionRecord + db-service plumbed, stamped at entry, updated per step) — a restart cannot re-scale a filled position or re-anchor a stale band.
3. **Budget interaction**: a SOL-leg top-up draws `entrySolBudgetLamports` (the batch wallet-reserve gate) — a top-up that doesn't fit is skipped, never forced. Step size is capped by the per-pool allocation headroom (aggregate `maxPerPoolAllocationPct` exposure).
4. **Paper mode** gates the whole branch (`paperTrading === false`, mirroring the compound path) — paper never touches the live adapter.
5. Attached to the **inner** launch-exit if: scale-in runs only when the exit did NOT fire — never scale into a dying position.

## Config
`LAUNCH_RUNNER_SCALE_IN_ENABLED` (true), `STEP_PCT` (0.05), `SIZE_PCT` (0.25), `MAX_STEPS` (3).

## Tests
- Pure policy: trigger math, max-steps cap, band-tracks-the-dip re-anchor, top-up sizing vs wallet/headroom/ceiling.
- **Wiring test**: drives a runner position through the full scan cycle with a price drop and asserts the atomic rebalance executes with the dip-anchored range + quote-only top-up, and that the step persists (a wiring test that would have caught the dead-`else if` the pure helpers can't).
- 1673/1673; tsc 0; oxlint 0.

## Summary by Sourcery

Add configurable runner scale-in behavior for launch positions, including dip-tracking band re-anchoring, quote-funded top-ups, and persisted step state with database migration and wiring through the main program loop.

New Features:
- Introduce runner scale-in trigger and top-up sizing helpers to re-anchor the dip band and add capital when price drops a configured step below the last anchor.
- Add runner scale-in execution path in the live program that performs atomic rebalances with quote-only top-ups, subject to per-pool exposure caps, wallet balance, and SOL budget constraints.
- Expose configuration knobs for runner scale-in enablement, price step threshold, per-step size percentage, and maximum steps.

Enhancements:
- Persist runner scale-in state per position (steps taken and anchor price) via new PositionRecord fields and database migration to make behavior restart-safe.
- Initialize runner scale-in state for new launch runner positions in both paper and live execution paths.
- Extend DB and helper APIs to handle the new runner scale-in fields, and audit scale-in decisions as rebalances for observability.

Tests:
- Add unit tests for runner scale-in trigger logic and top-up sizing to validate step thresholds, max-steps limits, and headroom handling.
- Add a wiring test that runs a launch runner through a price-drop cycle to verify atomic rebalance execution, dip-anchored range selection, quote-only top-up sizing, persisted step state, and audit logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable scale-in support for launch-runner positions when prices fall by defined steps.
  - Rebalances positions atomically while respecting wallet funds, pool allocation, position limits, and maximum scale-in steps.
  - Tracks runner anchors and scale-in progress across restarts.
  - Records successful scale-in rebalances for audit visibility.

- **Bug Fixes**
  - Added safeguards for missing, invalid, negative, or insufficient pricing and funding conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->