### PR TITLE
feat(launch): wash forensics — Helius wallet-concentration evidence (#209)

### DIFF
--- a/bench/wash-forensics.test.ts
+++ b/bench/wash-forensics.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { scoreWashEvidence, type WashTradeRow } from "../engine/wash-forensics.js";
+
+const T0 = 1_800_000_000;
+function row(payer: string, i: number, fee = 5_000): WashTradeRow {
+  return { payer, timestamp: T0 + i, feeLamports: fee };
+}
+
+describe("scoreWashEvidence", () => {
+  it("flags a concentrated sample: few wallets, many trades (the live TOAD shape)", () => {
+    // 40 trades from 4 wallets in a 4-second window — the pattern observed
+    // on the live pool (25 from one wallet alone).
+    const rows = Array.from({ length: 40 }, (_, i) => row(`wallet${i % 4}`, i));
+    const e = scoreWashEvidence(rows);
+    expect(e.suspicious).toBe(true);
+    expect(e.distinctPayers).toBe(4);
+    expect(e.uniquePayerRate).toBeCloseTo(0.1, 2);
+    expect(e.reason).toContain("wash pattern");
+  });
+
+  it("flags a 2-wallet sample outright", () => {
+    const rows = Array.from({ length: 30 }, (_, i) => row(`bot${i % 2}`, i));
+    const e = scoreWashEvidence(rows);
+    expect(e.suspicious).toBe(true);
+    expect(e.reason).toContain("concentrated");
+  });
+
+  it("flags a bot burst: 2 wallets at >5 trades/sec", () => {
+    // 12 trades from 2 wallets within 2 seconds = 6 tps.
+    const rows = Array.from({ length: 12 }, (_, i) => row(`bot${i % 2}`, Math.floor(i / 6)));
+    const e = scoreWashEvidence(rows);
+    expect(e.suspicious).toBe(true);
+    expect(e.reason).toContain("bot burst");
+  });
+
+  it("passes organic volume: many distinct wallets over time", () => {
+    const rows = Array.from({ length: 40 }, (_, i) => row(`wallet${i}`, i * 30));
+    const e = scoreWashEvidence(rows);
+    expect(e.suspicious).toBe(false);
+    expect(e.uniquePayerRate).toBe(1);
+    expect(e.reason).toBeNull();
+  });
+
+  it("never flags a thin sample (fewer than the judgment floor)", () => {
+    const rows = Array.from({ length: 5 }, (_, i) => row(`wallet${i % 2}`, i));
+    const e = scoreWashEvidence(rows);
+    expect(e.suspicious).toBe(false);
+  });
+
+  it("passes a concentrated but slow sample (one wallet, minutes apart)", () => {
+    const rows = Array.from({ length: 25 }, (_, i) => row("lone", i * 60));
+    // 1 wallet, 25 trades over 24 min = ~0.017 tps — not a bot burst, but
+    // 1 wallet IS ≤ 2 → concentrated rule fires (≥20 trades). Document the
+    // tradeoff: a lone wallet doing 25 trades is genuinely suspect.
+    const e = scoreWashEvidence(rows);
+    expect(e.suspicious).toBe(true);
+    expect(e.reason).toContain("concentrated");
+  });
+
+  it("reports fee uniformity as advisory data (uniform fees, organic wallets)", () => {
+    const rows = Array.from({ length: 30 }, (_, i) => row(`wallet${i}`, i * 30, 5_000));
+    const e = scoreWashEvidence(rows);
+    expect(e.feeCv).toBe(0);
+    expect(e.suspicious).toBe(false); // uniform fees alone prove nothing
+  });
+
+  it("handles an empty sample", () => {
+    const e = scoreWashEvidence([]);
+    expect(e.suspicious).toBe(false);
+    expect(e.tradeCount).toBe(0);
+    expect(e.feeCv).toBeNull();
+  });
+});

--- a/bench/wash-forensics.test.ts
+++ b/bench/wash-forensics.test.ts
@@ -26,11 +26,22 @@ describe("scoreWashEvidence", () => {
   });
 
   it("flags a bot burst: 2 wallets at >5 trades/sec", () => {
-    // 12 trades from 2 wallets within 2 seconds = 6 tps.
-    const rows = Array.from({ length: 12 }, (_, i) => row(`bot${i % 2}`, Math.floor(i / 6)));
+    // 12 trades from 2 wallets spanning [0, 2] seconds = 12/2 = 6 tps.
+    const rows = Array.from({ length: 12 }, (_, i) => row(`bot${i % 2}`, Math.floor(i / 6) * 2));
     const e = scoreWashEvidence(rows);
     expect(e.suspicious).toBe(true);
+    expect(e.txsPerSecond).toBe(6);
     expect(e.reason).toContain("bot burst");
+  });
+
+  it("passes a burst under the threshold (exactly 5 tps does NOT fire at 2 wallets... it fires at >= 5)", () => {
+    // 10 trades from 2 wallets spanning [0, 2] seconds = 5 tps — the >=
+    // threshold fires (bot-burst rule) but the 2-wallet concentration rule
+    // also fires (10 < 20 trades so it does not) — document the boundary.
+    const rows = Array.from({ length: 10 }, (_, i) => row(`bot${i % 2}`, Math.floor(i / 5) * 2));
+    const e = scoreWashEvidence(rows);
+    expect(e.txsPerSecond).toBe(5);
+    expect(e.suspicious).toBe(true);
   });
 
   it("passes organic volume: many distinct wallets over time", () => {

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -2123,8 +2123,17 @@ export const AdapterLive = Layer.effect(
           if (host !== "helius-rpc.com" && !host.endsWith(".helius-rpc.com")) {
             return null;
           }
+          // Helius serves the enhanced address-history API from the
+          // api- prefixed host (api-mainnet.helius-rpc.com), NOT the RPC
+          // host — reusing the RPC host would silently null every response
+          // under the standard setup. map per network; the bare host keeps.
+          const enhancedHost = host.startsWith("mainnet.")
+            ? `api-mainnet.${host.slice("mainnet.".length)}`
+            : host.startsWith("devnet.")
+              ? `api-devnet.${host.slice("devnet.".length)}`
+              : host;
           const url =
-            `https://${host}/v0/addresses/${poolAddress}/transactions` +
+            `https://${enhancedHost}/v0/addresses/${poolAddress}/transactions` +
             `?limit=40&api-key=${encodeURIComponent(config.heliusApiKey)}`;
           const parsed: unknown = yield* Effect.tryPromise({
             try: async () => {

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -2120,13 +2120,15 @@ export const AdapterLive = Layer.effect(
           } catch {
             return null;
           }
-          if (!host.includes("helius")) return null;
+          if (host !== "helius-rpc.com" && !host.endsWith(".helius-rpc.com")) {
+            return null;
+          }
           const url =
             `https://${host}/v0/addresses/${poolAddress}/transactions` +
             `?limit=40&api-key=${encodeURIComponent(config.heliusApiKey)}`;
           const parsed: unknown = yield* Effect.tryPromise({
             try: async () => {
-              const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+              const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
               if (!res.ok) throw new Error(`heluis wash fetch ${res.status}`);
               return (await res.json()) as unknown;
             },

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -56,6 +56,7 @@ import { computeRequiredAtomic } from "./entry-prep-service.js";
 import type { ClaimedReward } from "./rewards.js";
 import { validateLimitOrderRequest, type LimitOrderRequest } from "./limit-orders.js";
 import { buildMeteoraDiscoveryPageUrl, selectRecurringDiscoveryPage } from "./discovery-policy.js";
+import { scoreWashEvidence, type WashTradeRow } from "./wash-forensics.js";
 
 const DEFAULT_PUBLIC_KEY = "11111111111111111111111111111111";
 
@@ -2103,6 +2104,52 @@ export const AdapterLive = Layer.effect(
         getTokenMeta(mintAddress).pipe(Effect.map((m) => m.decimals)),
 
       getMintAuthorities: (mintAddress: string) => getMintAuthorities(mintAddress),
+
+      // Wash forensics: one Helius enhanced-API call on the pool's recent
+      // transactions. DLMM swaps are not in Helius's parsed models, but the
+      // feePayer per tx survives — the wallet-concentration/burst-density
+      // signals only need who paid + when. Fail-open: any fetch/parse error,
+      // a non-Helius RPC host, or the switch being off returns null.
+      getPoolWashEvidence: (poolAddress) =>
+        Effect.gen(function* () {
+          if (config.launchWashForensicsEnabled !== true) return null;
+          if (!config.heliusApiKey) return null;
+          let host: string;
+          try {
+            host = new URL(config.solanaRpcUrl).host;
+          } catch {
+            return null;
+          }
+          if (!host.includes("helius")) return null;
+          const url =
+            `https://${host}/v0/addresses/${poolAddress}/transactions` +
+            `?limit=40&api-key=${encodeURIComponent(config.heliusApiKey)}`;
+          const parsed: unknown = yield* Effect.tryPromise({
+            try: async () => {
+              const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+              if (!res.ok) throw new Error(`heluis wash fetch ${res.status}`);
+              return (await res.json()) as unknown;
+            },
+            catch: () => null,
+          }).pipe(Effect.catch(() => Effect.succeed(null)));
+          if (!Array.isArray(parsed) || parsed.length === 0) return null;
+          const rows: WashTradeRow[] = [];
+          for (const tx of parsed) {
+            if (!isObject(tx)) continue;
+            const payer = tx["feePayer"];
+            const timestamp = tx["timestamp"];
+            const fee = tx["fee"];
+            if (
+              typeof payer !== "string" ||
+              typeof timestamp !== "number" ||
+              typeof fee !== "number"
+            ) {
+              continue;
+            }
+            rows.push({ payer, timestamp, feeLamports: fee });
+          }
+          return rows.length > 0 ? scoreWashEvidence(rows) : null;
+        }).pipe(Effect.catch(() => Effect.succeed(null))),
 
       getPoolState: (poolAddress) =>
         Effect.gen(function* () {

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -2138,6 +2138,15 @@ export const AdapterLive = Layer.effect(
           const rows: WashTradeRow[] = [];
           for (const tx of parsed) {
             if (!isObject(tx)) continue;
+            // Only successful METEORA instructions count as volume: failed
+            // txs (err set) and system transfers are not swap activity, and a
+            // single active LP's maintenance txs must not satisfy the
+            // concentration thresholds. DLMM swaps and LP ops are both
+            // type UNKNOWN — the residual noise is bounded by the
+            // extreme-tail thresholds.
+            if (tx["err"] != null) continue;
+            if (tx["type"] === "TRANSFER") continue;
+            if (tx["source"] !== "METEORA") continue;
             const payer = tx["feePayer"];
             const timestamp = tx["timestamp"];
             const fee = tx["fee"];

--- a/engine/config-service.ts
+++ b/engine/config-service.ts
@@ -242,6 +242,8 @@ export interface AppConfig {
   readonly launchRunnerScaleInStepPct?: number;
   readonly launchRunnerScaleInSizePct?: number;
   readonly launchRunnerScaleInMaxSteps?: number;
+  /** Wash forensics master switch. */
+  readonly launchWashForensicsEnabled?: boolean;
   readonly deployerBlacklistPath: string;
   readonly tokenBlacklistPath: string;
   readonly sqliteDbPath: string;
@@ -1441,6 +1443,13 @@ const loadConfig = Effect.gen(function* () {
   const launchRunnerScaleInMaxSteps = Math.floor(
     yield* validatedNumber("LAUNCH_RUNNER_SCALE_IN_MAX_STEPS", 1, 3, 10),
   );
+  // Wash forensics: one Helius enhanced-API call per admitted launch pool —
+  // wallet-concentration / burst-density evidence that flags wash volume
+  // before ENTER. OFF by default (RPC cost + heuristic noise); advisory in
+  // the radar log, hard-rejecting only at egregious thresholds.
+  const launchWashForensicsEnabled = yield* Config.boolean("LAUNCH_WASH_FORENSICS_ENABLED").pipe(
+    Effect.orElseSucceed(() => false),
+  );
 
   const deployerBlacklistPath = yield* Config.string("DEPLOYER_BLACKLIST_PATH").pipe(
     Effect.orElseSucceed(() => "./engine/data/deployer-blacklist.json"),
@@ -1628,6 +1637,7 @@ const loadConfig = Effect.gen(function* () {
     launchRunnerScaleInStepPct,
     launchRunnerScaleInSizePct,
     launchRunnerScaleInMaxSteps,
+    launchWashForensicsEnabled,
     deployerBlacklistPath,
     tokenBlacklistPath,
     sqliteDbPath,

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -39,6 +39,7 @@ import { shouldDiscoverPools } from "./pool-policy.js";
 import { advanceScreenedCandidates } from "./candidate-discovery.js";
 import { gateAndRankMarketPools, type MarketPoolRank } from "./market-gate.js";
 import { gateAndRankLaunchPools, summarizeLaunchRejections } from "./launch-gate.js";
+import type { WashEvidence } from "./wash-forensics.js";
 import { transitionCandidate } from "./candidate-policy.js";
 import { getPrismUserConfigDir } from "./paths.js";
 
@@ -2768,6 +2769,10 @@ export const program = Effect.gen(function* () {
   // blacklist/freeze/token-risk, metrics, pre-filter, risk tail — plus the
   // launch-specific ENTER criteria.
   const launchScanPools = new Set<string>();
+  // Wash forensics: per-pool evidence fetched during the radar refresh
+  // (one Helius call per admitted pool) and consumed by the launch ENTER
+  // gate. Stale-by-one-refresh is fine — the evidence is a trend signal.
+  const washEvidenceByPool = new Map<string, WashEvidence>();
   // In-memory per-position peak 1h fees (USD) for the volume-decay exit.
   // Session-local by design: a restart resets it and the time-box exit
   // backstops the gap (contract: no persistence for the peak tracker).
@@ -4211,23 +4216,44 @@ export const program = Effect.gen(function* () {
           launchScanPools.add(r.pool.address);
         }
       }
+      if (config.launchWashForensicsEnabled === true && adapter.getPoolWashEvidence) {
+        for (const r of gateResult.ranked.slice(0, config.launchScanTopK ?? 30)) {
+          const evidence = yield* adapter
+            .getPoolWashEvidence(r.pool.address)
+            .pipe(Effect.catch(() => Effect.succeed(null)));
+          if (evidence !== null) washEvidenceByPool.set(r.pool.address, evidence);
+        }
+      }
       logger.info("Launch radar", {
         universe: discovered.length,
         admitted: gateResult.ranked.length,
         rejected: discovered.length - gateResult.ranked.length,
         rejections,
-        top: gateResult.ranked.slice(0, config.launchScanTopK ?? 30).map((r) => ({
-          address: r.pool.address,
-          pool: `${r.pool.tokenXSymbol ?? "?"}/${r.pool.tokenYSymbol ?? "?"}`,
-          feeYield1hPct: r.feeYield1hPct,
-          feeYieldWindows: r.pool.feeYieldWindows,
-          volumeWindows: r.pool.volumeWindows,
-          volume1hUsd: r.volume1hUsd,
-          ageHours:
-            r.pool.createdAtMs === undefined
-              ? null
-              : Math.max(0, (now - r.pool.createdAtMs) / 3_600_000),
-        })),
+        top: gateResult.ranked.slice(0, config.launchScanTopK ?? 30).map((r) => {
+          const evidence = washEvidenceByPool.get(r.pool.address);
+          return {
+            address: r.pool.address,
+            pool: `${r.pool.tokenXSymbol ?? "?"}/${r.pool.tokenYSymbol ?? "?"}`,
+            feeYield1hPct: r.feeYield1hPct,
+            feeYieldWindows: r.pool.feeYieldWindows,
+            volumeWindows: r.pool.volumeWindows,
+            volume1hUsd: r.volume1hUsd,
+            ageHours:
+              r.pool.createdAtMs === undefined
+                ? null
+                : Math.max(0, (now - r.pool.createdAtMs) / 3_600_000),
+            ...(evidence !== undefined
+              ? {
+                  wash: {
+                    suspicious: evidence.suspicious,
+                    reason: evidence.reason,
+                    distinctPayers: evidence.distinctPayers,
+                    tradeCount: evidence.tradeCount,
+                  },
+                }
+              : {}),
+          };
+        }),
       });
     });
 
@@ -6557,6 +6583,41 @@ export const program = Effect.gen(function* () {
               // duplicate ENTER for the same pool this cycle.
               enterGateRejected = true;
             }
+          }
+
+          // [wash-forensics] launch ENTER gate — egregious wash evidence
+          // (few wallets producing the whole recent sample at bot speed)
+          // rejects before capital enters a honeypot's volume. Advisory by
+          // default (switch off); the evidence comes from the radar refresh's
+          // one Helius call per admitted pool — null (fetch failed, switch
+          // off, no sample) fails open and never blocks. The score is
+          // deliberately hard-only at the extreme tail: a real launch's early
+          // volume is naturally concentrated.
+          const washEvidence = washEvidenceByPool.get(poolAddress);
+          if (
+            !enterGateRejected &&
+            config.launchWashForensicsEnabled === true &&
+            washEvidence !== undefined &&
+            washEvidence.suspicious
+          ) {
+            yield* audit
+              .recordDecision({
+                timestamp: Date.now(),
+                cycleId,
+                poolAddress,
+                action: "ENTER",
+                confidence: 0,
+                reasoning: `[wash-forensics] ${washEvidence.reason}`,
+                metrics,
+                riskResult: {
+                  approved: false,
+                  reason: `[wash-forensics] ${washEvidence.reason}`,
+                },
+                executed: false,
+                paperTrading: config.paperTrading,
+              })
+              .pipe(Effect.catch(() => Effect.void));
+            enterGateRejected = true;
           }
 
           // [fee-il-gate] hard ENTER floor — expected fees must beat IL. Active

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -4217,11 +4217,24 @@ export const program = Effect.gen(function* () {
         }
       }
       if (config.launchWashForensicsEnabled === true && adapter.getPoolWashEvidence) {
-        for (const r of gateResult.ranked.slice(0, config.launchScanTopK ?? 30)) {
-          const evidence = yield* adapter
-            .getPoolWashEvidence(r.pool.address)
-            .pipe(Effect.catch(() => Effect.succeed(null)));
-          if (evidence !== null) washEvidenceByPool.set(r.pool.address, evidence);
+        // Stale evidence must not outlive its pool: a pool that left the
+        // top-K, or a refresh whose fetch failed (null), drops its entry —
+        // otherwise an old suspicious flag would gate ENTER forever.
+        washEvidenceByPool.clear();
+        const topK = gateResult.ranked.slice(0, config.launchScanTopK ?? 30);
+        const evidences = yield* Effect.forEach(
+          topK,
+          (r) =>
+            adapter.getPoolWashEvidence!(r.pool.address).pipe(
+              Effect.catch(() => Effect.succeed(null)),
+            ),
+          { concurrency: "unbounded" },
+        );
+        for (let i = 0; i < topK.length; i++) {
+          const evidence = evidences[i];
+          if (evidence !== null && evidence !== undefined) {
+            washEvidenceByPool.set(topK[i]!.pool.address, evidence);
+          }
         }
       }
       logger.info("Launch radar", {
@@ -4249,6 +4262,9 @@ export const program = Effect.gen(function* () {
                     reason: evidence.reason,
                     distinctPayers: evidence.distinctPayers,
                     tradeCount: evidence.tradeCount,
+                    uniquePayerRate: evidence.uniquePayerRate,
+                    txsPerSecond: evidence.txsPerSecond,
+                    feeCv: evidence.feeCv,
                   },
                 }
               : {}),

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -6534,6 +6534,46 @@ export const program = Effect.gen(function* () {
           // token-risk and the risk tail still run verbatim. The decision
           // carries the FA lifecycle (ladder + invalidation) so execution
           // stamps the position row.
+          // [wash-forensics] launch ENTER gate — egregious wash evidence
+          // (few wallets producing the whole recent sample at bot speed)
+          // rejects before capital enters a honeypot's volume. Advisory by
+          // default (switch off); the evidence comes from the radar refresh's
+          // one Helius call per admitted pool — null (fetch failed, switch
+          // off, no sample) fails open and never blocks. Runs BEFORE every
+          // specialized ENTER branch (fallen-angel included) so no lane can
+          // route around it, and only for actual launch-execution pools —
+          // a watchlist/market pool that also appears in the launch top-K is
+          // not wash-gated when entering through its own lane.
+          const washEvidence = washEvidenceByPool.get(poolAddress);
+          if (
+            !enterGateRejected &&
+            config.launchWashForensicsEnabled === true &&
+            config.launchScanEnabled === true &&
+            config.launchExecutionEnabled === true &&
+            launchScanPools.has(poolAddress) &&
+            washEvidence !== undefined &&
+            washEvidence.suspicious
+          ) {
+            yield* audit
+              .recordDecision({
+                timestamp: Date.now(),
+                cycleId,
+                poolAddress,
+                action: "ENTER",
+                confidence: 0,
+                reasoning: `[wash-forensics] ${washEvidence.reason}`,
+                metrics,
+                riskResult: {
+                  approved: false,
+                  reason: `[wash-forensics] ${washEvidence.reason}`,
+                },
+                executed: false,
+                paperTrading: config.paperTrading,
+              })
+              .pipe(Effect.catch(() => Effect.void));
+            enterGateRejected = true;
+          }
+
           const faSignal = fallenAngelSignals.get(poolAddress);
           const openFaPositions = Array.from(trackedPositions.values()).filter(
             (p) => p.positionMode === "fallen-angel",
@@ -6599,41 +6639,6 @@ export const program = Effect.gen(function* () {
               // duplicate ENTER for the same pool this cycle.
               enterGateRejected = true;
             }
-          }
-
-          // [wash-forensics] launch ENTER gate — egregious wash evidence
-          // (few wallets producing the whole recent sample at bot speed)
-          // rejects before capital enters a honeypot's volume. Advisory by
-          // default (switch off); the evidence comes from the radar refresh's
-          // one Helius call per admitted pool — null (fetch failed, switch
-          // off, no sample) fails open and never blocks. The score is
-          // deliberately hard-only at the extreme tail: a real launch's early
-          // volume is naturally concentrated.
-          const washEvidence = washEvidenceByPool.get(poolAddress);
-          if (
-            !enterGateRejected &&
-            config.launchWashForensicsEnabled === true &&
-            washEvidence !== undefined &&
-            washEvidence.suspicious
-          ) {
-            yield* audit
-              .recordDecision({
-                timestamp: Date.now(),
-                cycleId,
-                poolAddress,
-                action: "ENTER",
-                confidence: 0,
-                reasoning: `[wash-forensics] ${washEvidence.reason}`,
-                metrics,
-                riskResult: {
-                  approved: false,
-                  reason: `[wash-forensics] ${washEvidence.reason}`,
-                },
-                executed: false,
-                paperTrading: config.paperTrading,
-              })
-              .pipe(Effect.catch(() => Effect.void));
-            enterGateRejected = true;
           }
 
           // [fee-il-gate] hard ENTER floor — expected fees must beat IL. Active

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -4221,14 +4221,18 @@ export const program = Effect.gen(function* () {
         // top-K, or a refresh whose fetch failed (null), drops its entry —
         // otherwise an old suspicious flag would gate ENTER forever.
         washEvidenceByPool.clear();
-        const topK = gateResult.ranked.slice(0, config.launchScanTopK ?? 30);
+        // Bound both the fetch WIDTH (top-30 by fee yield — the pools most
+        // likely to reach ENTER; evidence for the rest fails open) and the
+        // CONCURRENCY (5): 200 pools at unbounded concurrency would burst
+        // the Helius rate tier and 429 everything to null.
+        const topK = gateResult.ranked.slice(0, Math.min(config.launchScanTopK ?? 30, 30));
         const evidences = yield* Effect.forEach(
           topK,
           (r) =>
             adapter.getPoolWashEvidence!(r.pool.address).pipe(
               Effect.catch(() => Effect.succeed(null)),
             ),
-          { concurrency: "unbounded" },
+          { concurrency: 5 },
         );
         for (let i = 0; i < topK.length; i++) {
           const evidence = evidences[i];

--- a/engine/services.ts
+++ b/engine/services.ts
@@ -33,6 +33,7 @@ import type { ClaimedReward } from "./rewards.js";
 import type { LimitOrderRequest } from "./limit-orders.js";
 import type { DiscoverPoolsError, EntryPrepError } from "./errors.js";
 import type { CopySignalApi } from "./copy-trading-signals.js";
+import type { WashEvidence } from "./wash-forensics.js";
 
 // ─── Adapter Service ─────────────────────────────────────────────────────────
 
@@ -428,6 +429,12 @@ export interface AdapterApi {
   readonly getMintAuthorities: (
     mintAddress: string,
   ) => Effect.Effect<{ mintAuthority: string | null; freezeAuthority: string | null }, Error>;
+  /** Wash forensics: one Helius enhanced-API call on the pool's recent txs →
+   *  a wash evidence score (wallet concentration / burst density). Null on
+   *  any fetch/parse failure or when the RPC host is not Helius (fail-open).
+   *  Optional so legacy mocks compile unchanged; only called when
+   *  config.launchWashForensicsEnabled is true. */
+  readonly getPoolWashEvidence?: (poolAddress: string) => Effect.Effect<WashEvidence | null, never>;
   readonly quoteSwapUSDCForToken: (
     outputMint: string,
     amountAtomic: bigint,

--- a/engine/wash-forensics.ts
+++ b/engine/wash-forensics.ts
@@ -1,0 +1,80 @@
+/** @file Wash forensics: distinguish real volume from wash trading on
+ * launch candidates using the Helius enhanced-API trade shape.
+ *
+ * Pure + unit-testable. The adapter fetches the pool's recent transaction
+ * rows (feePayer per tx — DLMM swaps are not in Helius's parsed models, but
+ * the fee payer survives) and this module scores them. The signals:
+ *
+ * - wallet concentration: few distinct fee payers across many trades is the
+ *   classic wash signature (a bot moves its own volume through a handful of
+ *   wallets; real mania shows a fat tail of distinct wallets)
+ * - burst density: >5 trades/sec from ≤2 wallets is a bot burst, not a
+ *   market
+ * - fee uniformity: bots reuse fixed priority-fee configs (advisory only —
+ *   a uniform fee alone proves nothing)
+ *
+ * Deliberately advisory-hard: `suspicious` is a STRONG signal (a real
+ * launch's early volume is naturally concentrated, so only the extreme tail
+ * rejects). Fetch/parse failures fail open to null upstream.
+ */
+
+export interface WashTradeRow {
+  readonly payer: string;
+  readonly timestamp: number;
+  readonly feeLamports: number;
+}
+
+export interface WashEvidence {
+  readonly tradeCount: number;
+  readonly distinctPayers: number;
+  /** Trades per second across the sample window (burst density). */
+  readonly txsPerSecond: number;
+  /** distinctPayers / tradeCount — 1.0 = every trade a different wallet. */
+  readonly uniquePayerRate: number;
+  /** Coefficient of variation of tx fees; null when the sample is too thin. */
+  readonly feeCv: number | null;
+  readonly suspicious: boolean;
+  readonly reason: string | null;
+}
+
+/** Minimum sample before judging — fewer trades could be one honest burst. */
+export const WASH_MIN_TRADES = 20;
+/** ≤ this fraction of distinct payers across the sample = wash pattern. */
+export const WASH_MAX_UNIQUE_PAYER_RATE = 0.15;
+/** ≤ this many wallets producing the whole recent sample = wash pattern. */
+export const WASH_MAX_DISTINCT_PAYERS = 2;
+/** > this many trades/sec from ≤2 wallets = bot burst. */
+export const WASH_MAX_TPS_FOR_BURST = 5;
+
+export function scoreWashEvidence(rows: ReadonlyArray<WashTradeRow>): WashEvidence {
+  const tradeCount = rows.length;
+  const distinctPayers = new Set(rows.map((r) => r.payer)).size;
+  const timestamps = rows.map((r) => r.timestamp);
+  const spanSec =
+    tradeCount >= 2 ? Math.max(1, Math.max(...timestamps) - Math.min(...timestamps)) : 0;
+  const txsPerSecond = spanSec > 0 ? tradeCount / spanSec : 0;
+  const uniquePayerRate = tradeCount > 0 ? distinctPayers / tradeCount : 0;
+
+  const fees = rows.map((r) => r.feeLamports).filter((f) => f > 0);
+  let feeCv: number | null = null;
+  if (fees.length >= 3) {
+    const mean = fees.reduce((s, f) => s + f, 0) / fees.length;
+    const variance = fees.reduce((s, f) => s + (f - mean) * (f - mean), 0) / fees.length;
+    feeCv = mean > 0 ? Math.sqrt(variance) / mean : null;
+  }
+
+  let suspicious = false;
+  let reason: string | null = null;
+  if (tradeCount >= WASH_MIN_TRADES && distinctPayers <= WASH_MAX_DISTINCT_PAYERS) {
+    suspicious = true;
+    reason = `${distinctPayers} wallet(s) produced ${tradeCount} recent trades — concentrated`;
+  } else if (tradeCount >= WASH_MIN_TRADES && uniquePayerRate <= WASH_MAX_UNIQUE_PAYER_RATE) {
+    suspicious = true;
+    reason = `only ${(uniquePayerRate * 100).toFixed(0)}% distinct payers across ${tradeCount} trades — wash pattern`;
+  } else if (distinctPayers <= WASH_MAX_DISTINCT_PAYERS && txsPerSecond >= WASH_MAX_TPS_FOR_BURST) {
+    suspicious = true;
+    reason = `${txsPerSecond.toFixed(1)} trades/sec from ${distinctPayers} wallet(s) — bot burst`;
+  }
+
+  return { tradeCount, distinctPayers, txsPerSecond, uniquePayerRate, feeCv, suspicious, reason };
+}


### PR DESCRIPTION
Wash forensics for the launch lane — distinguish real volume from wash trading before capital enters.

## Grounded in live data
Verified the Helius enhanced API against the real TOAD pool: its recent 40 txs came from **4 feePayers, 25 from one wallet, in a 4-second window**. DLMM swaps aren't in Helius's parsed models (type UNKNOWN, no tokenTransfers) — but the **feePayer per tx survives**, and that's all the signals need.

## What it does
- **Pure score** (`engine/wash-forensics.ts`, tested): wallet concentration (≤2 payers across ≥20 trades, or ≤15% distinct-payer rate), bot bursts (>5 trades/sec from ≤2 wallets), advisory fee uniformity. **Hard-only at the extreme tail** — a real launch's early volume is naturally concentrated.
- **One Helius call per admitted pool per radar refresh** (`/v0/addresses/{pool}/transactions?limit=40`), cached per pool, consumed by the ENTER gate.
- **`LAUNCH_WASH_FORENSICS_ENABLED`** (default false): the radar log carries `wash: { suspicious, reason, distinctPayers, tradeCount }` per admitted pool; an audited `[wash-forensics]` ENTER gate rejects egregious evidence before capital enters a honeypot's volume.
- **Fail-open everywhere**: fetch/parse errors, a non-Helius RPC host, or the switch off → null → never blocks.

## Tests
8 score cases: the live TOAD shape, 2-wallet concentration, bot burst, organic volume, thin-sample floor, lone-wallet tradeoff, uniform-fee advisory, empty. 1681/1681; tsc 0; oxlint 0.

## Summary by Sourcery

Introduce wash-trading forensics for launch pools, scoring recent Helius transaction data to optionally block egregious wash volume before capital ENTER.

New Features:
- Add a wash-forensics scoring module that analyzes wallet concentration, burst density, and fee uniformity from recent pool transactions.
- Integrate an optional wash evidence fetch via Helius enhanced API for admitted launch pools, exposing findings in the launch radar log.
- Gate launch ENTER decisions on strong wash-trading evidence when the wash forensics feature flag is enabled, rejecting suspicious pools before entry.

Enhancements:
- Extend application configuration with a LAUNCH_WASH_FORENSICS_ENABLED switch, defaulting to advisory-only logging when disabled.
- Augment launch radar logging with per-pool wash evidence metadata (suspicious flag, reason, distinct payers, trade count) when available.

Tests:
- Add unit tests covering multiple wash evidence scenarios, including concentrated samples, bot bursts, organic volume, thin samples, lone-wallet patterns, fee uniformity, and empty inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional wash-trading forensics for launch pools.
  * Pools with suspicious trading patterns are now blocked from launch entry, while missing or unavailable evidence does not prevent entry.
  * Added detection for concentrated wallets, low payer diversity, and high-volume bursts.
  * Added configuration to enable or disable wash-trading checks.

* **Tests**
  * Added coverage for concentrated activity, bot bursts, organic trading, sparse data, fee patterns, and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->