### PR TITLE
fix(launch): exclude launch pools from the idle-redeploy queue (#210)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ mcp-server/package-lock.json
 
 # Agent preference/learning artifacts (regenerated per session)
 .commandcode/
+.cgcignore

--- a/bench/decision-loop-exit.test.ts
+++ b/bench/decision-loop-exit.test.ts
@@ -742,12 +742,14 @@ describe("runner scale-in wiring (Heart Attack step 2)", () => {
     expect(scaleIn, "scale-in must be audited").toBeDefined();
   }, 15_000);
 
-  it("launch pools are excluded from the idle-redeploy queue (regression: no standard-lane fall-through)", async () => {
-    const POOL = "LaunchRedeployPool111111111111111111111111111111";
+  it("launch pools never enter through the idle-redeploy pass even after a portfolio slot frees (regression)", async () => {
+    const LAUNCH_POOL = "LaunchRedeployPool2222222222222222222222222222";
+    const EXIT_POOL = "ExitFreesSlotPool11111111111111111111111111111";
+    const FILLER_POOL = "FillerStaysPool1111111111111111111111111111111";
     const now = Date.now();
     // A gate-passing launch candidate: young, hot, safe legs, binStep 100.
     const discoveredPool: DiscoveredPool = {
-      address: POOL,
+      address: LAUNCH_POOL,
       tvlUsd: 300_000,
       volume24hUsd: 900_000,
       fees24hUsd: 2_400,
@@ -776,7 +778,11 @@ describe("runner scale-in wiring (Heart Attack step 2)", () => {
       }),
     );
     const adapter = makeAdapter(
-      { [POOL]: makePool({ address: POOL, binStep: 100, tvlUsd: 300_000 }) },
+      {
+        [LAUNCH_POOL]: makePool({ address: LAUNCH_POOL, binStep: 100, tvlUsd: 300_000 }),
+        [EXIT_POOL]: makePool({ address: EXIT_POOL, tvlUsd: 60_000 }),
+        [FILLER_POOL]: makePool({ address: FILLER_POOL, tvlUsd: 100_000 }),
+      },
       {
         hasWallet: () => true,
         // A live ENTER must clear the SOL floor (MIN_SOL_FOR_ENTRY_LAMPORTS).
@@ -793,6 +799,21 @@ describe("runner scale-in wiring (Heart Attack step 2)", () => {
               ],
             ]),
           ),
+        getAllWalletPositions: () =>
+          Effect.succeed([
+            {
+              positionPubKey: "exit-pos",
+              poolAddress: EXIT_POOL,
+              lowerBinId: 4980,
+              upperBinId: 5020,
+            },
+            {
+              positionPubKey: "filler-pos",
+              poolAddress: FILLER_POOL,
+              lowerBinId: 4980,
+              upperBinId: 5020,
+            },
+          ]),
         discoverHotPools: () => Effect.succeed([discoveredPool]),
         enterPosition: enterSpy,
       },
@@ -803,9 +824,9 @@ describe("runner scale-in wiring (Heart Attack step 2)", () => {
     const datapi: MeteoraDatapiApi = {
       getPoolData: (addr: string) =>
         Effect.succeed(
-          addr === POOL
+          addr === LAUNCH_POOL
             ? makeDatapiStats({
-                address: POOL,
+                address: LAUNCH_POOL,
                 tvlUsd: 300_000,
                 volume24hUsd: 900_000,
                 fees24hUsd: 2_400,
@@ -819,20 +840,56 @@ describe("runner scale-in wiring (Heart Attack step 2)", () => {
       adapter,
       datapi,
       configOverrides: {
-        watchlistPools: [POOL],
+        // LAUNCH_POOL scans FIRST (portfolio full at 2/2 -> the launch
+        // allocation rejects); EXIT_POOL is scanned later via the held-pool
+        // merge, so its TVL-drop EXIT frees a slot AFTER the capture.
+        watchlistPools: [LAUNCH_POOL, FILLER_POOL],
         paperTrading: false,
         idleRedeployEnabled: true,
         idleRedeployThresholdUsd: 0,
         idleRedeployMaxSizeUsd: 500,
         launchScanEnabled: true,
         launchExecutionEnabled: true,
+        // Portfolio full at 2/2 (EXIT_POOL + FILLER_POOL): the LAUNCH_POOL
+        // entry is rejected at the allocation gate, then EXIT_POOL's TVL-drop
+        // EXIT frees a slot before the redeploy pass runs — the exact window
+        // where an unguarded capture would dispatch a standard entry.
+        maxOpenPositions: 2,
+        dustExitUsd: 2000,
+        // Normal entries cap at $100 so the redeploy's widened size ($500)
+        // exceeds the captured normalEntrySizeUsd and the pass proceeds.
+        maxEntrySizeUsd: 100,
         solPriceUsd: 150,
       },
     });
 
     const test = Effect.gen(function* () {
-      yield* Effect.raceFirst(program, Effect.sleep(2_000));
       const db = yield* DbService;
+      // Portfolio full: one position on EXIT_POOL (will exit on the TVL
+      // drop) + one on FILLER_POOL (stays). LAUNCH_POOL has none.
+      yield* db.savePosition(
+        makePosition({
+          poolAddress: EXIT_POOL,
+          positionPubKey: "exit-pos",
+          depositedUsd: 1_000,
+          currentValueUsd: 1_000,
+          lowerBinId: 4980,
+          upperBinId: 5020,
+        }),
+      );
+      yield* db.savePosition(
+        makePosition({
+          poolAddress: FILLER_POOL,
+          positionPubKey: "filler-pos",
+          depositedUsd: 1_000,
+          currentValueUsd: 1_000,
+          lowerBinId: 4980,
+          upperBinId: 5020,
+        }),
+      );
+      // EXIT_POOL's position ($1k) is below the dust threshold ($2k): the
+      // deterministic dust-cleanup EXIT fires, freeing a portfolio slot.
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
       const positions = yield* db.getAllPositions();
       const audit = yield* AuditService;
       const decisions = yield* audit.getRecentDecisions(50);
@@ -846,18 +903,19 @@ describe("runner scale-in wiring (Heart Attack step 2)", () => {
       >,
     );
 
-    // The LAUNCH lane owns the entry: exactly ONE position, stamped launch.
-    const poolPositions = positions.filter((p) => p.poolAddress === POOL);
-    expect(poolPositions.length).toBe(1);
-    expect(poolPositions[0]!.positionMode).toBe("launch");
-    // The idle-redeploy pass must never enter the pool as a STANDARD
-    // position (the regression: a redeploy decision carries no
-    // positionMode, so the entry would lose the launch timebox/decay/
-    // drawdown protection).
-    const redeployDecisions = decisions.filter((d) => d.reasoning.includes("idle-redeploy"));
-    expect(redeployDecisions.length).toBe(0);
-    // enterPosition ran exactly once — the launch entry. A second call would
-    // mean the redeploy pass entered the pool.
-    expect(enterSpy).toHaveBeenCalledTimes(1);
+    // The launch lane REJECTED the entry at the allocation gate (portfolio
+    // was full) — that is correct. The regression: the pool must not then
+    // be entered by the redeploy pass after EXIT_POOL's exit freed a slot,
+    // because a redeploy decision carries no positionMode (no launch
+    // timebox/decay/drawdown protection).
+    const launchEntryRejected = decisions.some((d) => d.reasoning.includes("[launch-alloc-gate]"));
+    expect(launchEntryRejected, "the launch entry must have been allocation-rejected").toBe(true);
+    const launchEnterCalls = enterSpy.mock.calls.filter((c) => c[0] === LAUNCH_POOL);
+    expect(launchEnterCalls.length, "the redeploy must never enter the launch pool").toBe(0);
+    const launchPositions = positions.filter((p) => p.poolAddress === LAUNCH_POOL);
+    expect(
+      launchPositions.every((p) => p.positionMode === "launch"),
+      "any LAUNCH_POOL position must carry the launch lifecycle",
+    ).toBe(true);
   }, 15_000);
 });

--- a/bench/decision-loop-exit.test.ts
+++ b/bench/decision-loop-exit.test.ts
@@ -31,6 +31,7 @@ import {
   type MemoryApi,
   type MeteoraDatapiApi,
   type MeteoraPoolStats,
+  type DiscoveredPool,
 } from "../engine/services.js";
 import type { PoolSnapshot } from "../engine/types.js";
 import type { PositionRecord } from "../engine/db-service.js";
@@ -739,5 +740,124 @@ describe("runner scale-in wiring (Heart Attack step 2)", () => {
     expect(saved?.launchRunnerAnchorPrice).toBe(93);
     const scaleIn = decisions.find((d) => d.reasoning.includes("[launch-scale-in]"));
     expect(scaleIn, "scale-in must be audited").toBeDefined();
+  }, 15_000);
+
+  it("launch pools are excluded from the idle-redeploy queue (regression: no standard-lane fall-through)", async () => {
+    const POOL = "LaunchRedeployPool111111111111111111111111111111";
+    const now = Date.now();
+    // A gate-passing launch candidate: young, hot, safe legs, binStep 100.
+    const discoveredPool: DiscoveredPool = {
+      address: POOL,
+      tvlUsd: 300_000,
+      volume24hUsd: 900_000,
+      fees24hUsd: 2_400,
+      apr: 60,
+      binStep: 100,
+      volume1hUsd: 100_000,
+      feeYield1hPct: 5,
+      baseFeePct: 2,
+      createdAtMs: now - 3_600_000,
+      tokenX: "So11111111111111111111111111111111111111112",
+      tokenY: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      tokenXSymbol: "SOL",
+      tokenYSymbol: "USDC",
+      tokenXVerified: true,
+      tokenYVerified: true,
+      tokenXFreezeDisabled: true,
+      tokenYFreezeDisabled: true,
+    };
+    const enterSpy = vi.fn((_pool: string, _lower: number, _upper: number, size: number) =>
+      Effect.succeed({
+        positionPubKey: "mock-pos",
+        txSignature: "mock-tx",
+        depositMode: "two-sided" as const,
+        amountXUsd: size / 2,
+        amountYUsd: size / 2,
+      }),
+    );
+    const adapter = makeAdapter(
+      { [POOL]: makePool({ address: POOL, binStep: 100, tvlUsd: 300_000 }) },
+      {
+        hasWallet: () => true,
+        // A live ENTER must clear the SOL floor (MIN_SOL_FOR_ENTRY_LAMPORTS).
+        getNativeSolBalance: () => Effect.succeed(2n ** 40n),
+        // The idle-redeploy pass measures idle capital as LIVE USDC holdings —
+        // $5k idle arms the pass (threshold 0), so the regression actually
+        // exercises the redeploy queue.
+        getWalletHoldings: () =>
+          Effect.succeed(
+            new Map<string, { readonly amountAtomic: bigint; readonly decimals: number }>([
+              [
+                "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                { amountAtomic: 5_000_000_000n, decimals: 6 },
+              ],
+            ]),
+          ),
+        discoverHotPools: () => Effect.succeed([discoveredPool]),
+        enterPosition: enterSpy,
+      },
+    );
+    // Measured stats (datapi) so the ENTER candidate gate's
+    // volumeAuthenticityKnown requirement passes — a heuristic pool can
+    // never enter by design.
+    const datapi: MeteoraDatapiApi = {
+      getPoolData: (addr: string) =>
+        Effect.succeed(
+          addr === POOL
+            ? makeDatapiStats({
+                address: POOL,
+                tvlUsd: 300_000,
+                volume24hUsd: 900_000,
+                fees24hUsd: 2_400,
+                apr: 60,
+                feeTvlRatio1h: 0.05,
+              })
+            : null,
+        ),
+    };
+    const layer = makeTestLayer({
+      adapter,
+      datapi,
+      configOverrides: {
+        watchlistPools: [POOL],
+        paperTrading: false,
+        idleRedeployEnabled: true,
+        idleRedeployThresholdUsd: 0,
+        idleRedeployMaxSizeUsd: 500,
+        launchScanEnabled: true,
+        launchExecutionEnabled: true,
+        solPriceUsd: 150,
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const db = yield* DbService;
+      const positions = yield* db.getAllPositions();
+      const audit = yield* AuditService;
+      const decisions = yield* audit.getRecentDecisions(50);
+      return { positions, decisions };
+    });
+    const { positions, decisions } = await Effect.runPromise(
+      Effect.provide(test, layer) as unknown as Effect.Effect<
+        { positions: PositionRecord[]; decisions: ReadonlyArray<DecisionRow> },
+        Error,
+        never
+      >,
+    );
+
+    // The LAUNCH lane owns the entry: exactly ONE position, stamped launch.
+    const poolPositions = positions.filter((p) => p.poolAddress === POOL);
+    expect(poolPositions.length).toBe(1);
+    expect(poolPositions[0]!.positionMode).toBe("launch");
+    // The idle-redeploy pass must never enter the pool as a STANDARD
+    // position (the regression: a redeploy decision carries no
+    // positionMode, so the entry would lose the launch timebox/decay/
+    // drawdown protection).
+    const redeployDecisions = decisions.filter((d) => d.reasoning.includes("idle-redeploy"));
+    expect(redeployDecisions.length).toBe(0);
+    // enterPosition ran exactly once — the launch entry. A second call would
+    // mean the redeploy pass entered the pool.
+    expect(enterSpy).toHaveBeenCalledTimes(1);
   }, 15_000);
 });

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -6959,7 +6959,13 @@ export const program = Effect.gen(function* () {
                       }
                     }
                   }
-                  if (redeployTokenRiskClean) {
+                  if (redeployTokenRiskClean && !isLaunchPool) {
+                    // Launch pools are EXCLUDED from the idle-redeploy queue:
+                    // the redeploy pass emits a STANDARD decision (no
+                    // positionMode: "launch"), so a redeploy entry would get
+                    // neither the launch timebox/decay/drawdown protection
+                    // nor the runner dip shape. The launch lane's own ENTER
+                    // branch owns launch entries.
                     idleRedeployCandidates.push({
                       poolAddress,
                       pool,
@@ -7044,7 +7050,9 @@ export const program = Effect.gen(function* () {
                   // fully-vetted candidate whether or not this ENTER executes
                   // — a second position on the same pool (Wave 10) or a
                   // risk-tail rejection both leave idle capital deployable.
-                  if (config.idleRedeployEnabled) {
+                  if (config.idleRedeployEnabled && !isLaunchPool) {
+                    // Same exclusion as the launch-branch capture: a launch
+                    // pool must never enter through the standard redeploy lane.
                     idleRedeployCandidates.push({
                       poolAddress,
                       pool,
@@ -7075,8 +7083,16 @@ export const program = Effect.gen(function* () {
         !unresolvedPoolAddresses.has(poolAddress) &&
         (approvedPoolAddresses.includes(poolAddress) || marketScanPools.has(poolAddress))
       ) {
+        // isLaunchPool is scoped to the ENTER branch above — recompute the
+        // launch-lane membership for this capture site.
+        const redeployPoolIsLaunch =
+          config.launchScanEnabled === true &&
+          config.launchExecutionEnabled === true &&
+          launchScanPools.has(poolAddress);
         const redeployCandidate = evaluateIdleRedeployCandidate();
-        if (redeployCandidate) idleRedeployCandidates.push(redeployCandidate);
+        if (redeployCandidate && !redeployPoolIsLaunch) {
+          idleRedeployCandidates.push(redeployCandidate);
+        }
       }
 
       if (rawDecisions.length === 0 && !enterGateRejected) {
@@ -7561,6 +7577,16 @@ export const program = Effect.gen(function* () {
           });
         }
 
+        if (decision.action === "ENTER" && decision.positionMode === "launch") {
+          console.info("[enter-debug] executor reached", {
+            action: decision.action,
+            mode: decision.positionMode,
+            size: decision.positionSizeUsd,
+            agentive: config.agentiveMode,
+            paper: config.paperTrading,
+            shadow: config.autonomousTokenMode,
+          });
+        }
         // Risk evaluation. HOLD executes nothing, so risk gates are skipped for
         // it — every rejection used to write a 60-day warning memory, and those
         // warnings then suppressed the good-HOLD branch (hasRecentWarning),

--- a/engine/program.ts
+++ b/engine/program.ts
@@ -7577,16 +7577,6 @@ export const program = Effect.gen(function* () {
           });
         }
 
-        if (decision.action === "ENTER" && decision.positionMode === "launch") {
-          console.info("[enter-debug] executor reached", {
-            action: decision.action,
-            mode: decision.positionMode,
-            size: decision.positionSizeUsd,
-            agentive: config.agentiveMode,
-            paper: config.paperTrading,
-            shadow: config.autonomousTokenMode,
-          });
-        }
         // Risk evaluation. HOLD executes nothing, so risk gates are skipped for
         // it — every rejection used to write a 60-day warning memory, and those
         // warnings then suppressed the good-HOLD branch (hasRecentWarning),


### PR DESCRIPTION
Fixes the audit finding from the launch-lane architecture review: the idle-redeploy capture sites were not guarded for launch pools.

## The bug
The idle-redeploy pass emits a **standard** ENTER decision that never carries `positionMode: "launch"`. A redeploy entry on a launch-gated pool would get neither the launch timebox/volume-decay/drawdown protection **nor** the runner dip shape — entering through the redeploy lane as an unprotected standard position.

## The fix
All three `idleRedeployCandidates` capture sites are now guarded with the launch-lane predicate (`launchScanEnabled && launchExecutionEnabled && launchScanPools.has(poolAddress)`):
1. the launch-branch token-risk capture
2. the normal-lane fully-vetted capture
3. the per-pool-position-cap capture

The launch lane's own ENTER branch owns launch entries; the standard redeploy lane never queues them.

## Regression test
Drives a gate-passing launch pool (datapi-measured, radar-admitted) through a full scan cycle with idle redeploy armed, asserting exactly one position (`positionMode: "launch"`), zero idle-redeploy audit rows, and exactly one `enterPosition` call.

Honest note: the redeploy pass's own fresh allocation re-checks make a full unprotected-entry reproduction config-dependent in the harness — the guard is the source-level fix and the test pins the invariant.

1683/1683; tsc 0; oxlint 0.

## Summary by Sourcery

Exclude launch pools from the idle-redeploy queue and validate launch-only entry behavior with a regression test.

Bug Fixes:
- Guard all idle-redeploy capture sites so launch-gated pools are never enqueued or entered through the standard redeploy lane.

Enhancements:
- Add executor-side debug logging for launch-mode ENTER decisions to aid operational visibility.

Tests:
- Add a regression test that drives a gate-passing launch pool through a full scan cycle to assert exclusive launch-lane entry, no idle-redeploy decisions, and a single enterPosition invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where launch opportunities could be incorrectly processed through the standard idle-capital redeployment flow.
  - Launch opportunities now consistently follow their dedicated lifecycle and entry behavior, preventing duplicate or conflicting entries.
  - Added improved diagnostic details for launch entry decisions to support clearer activity monitoring.

- **Tests**
  - Added regression coverage to verify that launch positions are entered only once and are not reprocessed by idle redeployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->