### PR TITLE
perf(adapter): memoize the active bin + bin array per pool — RPC dedup (#211)

### DIFF
--- a/bench/adapter-active-bin-memo.test.ts
+++ b/bench/adapter-active-bin-memo.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Active-bin memoization (RPC dedup): getPoolState + getBinArray previously
+ * fetched the active bin TWICE per pool per cycle, and getBinsAroundActiveBin
+ * re-fetched the same bin array getActiveBin just loaded (~3 wasted RPCs).
+ * The short-TTL memo must make the within-cycle pair share ONE SDK fetch.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Keypair, Connection, PublicKey } from "@solana/web3.js";
+import bs58 from "bs58";
+import { Effect, Layer } from "effect";
+import { AdapterService } from "../engine/services.js";
+import { AdapterLive } from "../engine/adapter-service.js";
+import { ConfigService } from "../engine/config-service.js";
+import { AuditLive } from "../engine/audit-service.js";
+import { DbLive } from "../engine/db-service.js";
+import { defaultAppConfig } from "./helpers.js";
+
+const POOL_ADDRESS = Keypair.generate().publicKey.toBase58();
+const TOKEN_X = Keypair.generate().publicKey;
+const TOKEN_Y = Keypair.generate().publicKey;
+const ACTIVE_BIN_ID = 5000;
+const BIN_STEP = 10;
+
+const walletKeypair = Keypair.generate();
+const walletPrivateKey = bs58.encode(walletKeypair.secretKey);
+
+function makeFakeDlmm() {
+  return {
+    lbPair: {
+      activeId: ACTIVE_BIN_ID,
+      binStep: BIN_STEP,
+      tokenXMint: TOKEN_X,
+      tokenYMint: TOKEN_Y,
+      reserveX: Keypair.generate().publicKey,
+      reserveY: Keypair.generate().publicKey,
+    },
+    tokenX: { publicKey: TOKEN_X, mint: { decimals: 9 } },
+    tokenY: { publicKey: TOKEN_Y, mint: { decimals: 6 } },
+    getActiveBin: vi.fn(async () => ({ binId: ACTIVE_BIN_ID, price: "150" })),
+    getBinsAroundActiveBin: vi.fn(async () => ({
+      activeBin: ACTIVE_BIN_ID,
+      bins: [{ binId: ACTIVE_BIN_ID, price: "150", xAmount: 1n, yAmount: 1n, supply: 1n }],
+    })),
+  };
+}
+
+const dlmmState = vi.hoisted(() => ({
+  current: null as ReturnType<typeof makeFakeDlmm> | null,
+}));
+
+vi.mock("@meteora-ag/dlmm", async (importActual) => {
+  const actual = await importActual<typeof import("@meteora-ag/dlmm")>();
+  class FakeDLMM {
+    static async create() {
+      if (!dlmmState.current) throw new Error("fake DLMM instance not set");
+      return dlmmState.current;
+    }
+  }
+  return { ...actual, default: FakeDLMM };
+});
+
+function mockFetchImpl(handler: (url: string) => Promise<Response>) {
+  return vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL | Request) => handler(String(url as unknown))),
+  );
+}
+
+function makeAdapterLayer(): Layer.Layer<AdapterService, never, never> {
+  const configLayer = Layer.succeed(
+    ConfigService,
+    defaultAppConfig({
+      walletPrivateKey,
+      solanaRpcUrl: "https://example.com",
+      solanaRpcFallbackUrl: "",
+      sqliteDbPath: ":memory:",
+      autoUpdate: false,
+      paperTrading: false,
+      solPriceUsd: 150,
+    }),
+  );
+  const auditLayer = Layer.provide(AuditLive, DbLive(":memory:"));
+  return Layer.provide(AdapterLive, Layer.merge(configLayer, auditLayer)) as Layer.Layer<
+    AdapterService,
+    never,
+    never
+  >;
+}
+
+beforeEach(() => {
+  dlmmState.current = makeFakeDlmm();
+  // RPC surface: reserve balances for the heuristic, mint metadata, wallet.
+  vi.spyOn(Connection.prototype, "getTokenAccountBalance").mockImplementation(() =>
+    Promise.resolve({
+      context: { slot: 1 },
+      value: { amount: "1000000000", decimals: 9, uiAmount: 1, uiAmountString: "1" },
+    } as unknown as never),
+  );
+  vi.spyOn(Connection.prototype, "getParsedAccountInfo").mockImplementation(() =>
+    Promise.resolve({
+      value: {
+        data: { parsed: { info: { decimals: 9, symbol: "SOL" } } },
+      },
+    } as unknown as never),
+  );
+  vi.spyOn(Connection.prototype, "getBalance").mockResolvedValue(0);
+  mockFetchImpl(async (url: string) => {
+    if (url.includes("api.jup.ag/price/v3")) {
+      return new Response(
+        JSON.stringify({
+          [TOKEN_X.toBase58()]: { usdPrice: 150 },
+          [TOKEN_Y.toBase58()]: { usdPrice: 1 },
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response("unexpected", { status: 500 });
+  });
+});
+
+describe("active-bin memoization (RPC dedup)", () => {
+  it("fetches the active bin and bin array ONCE across getPoolState + getBinArray", async () => {
+    await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          yield* adapter.getPoolState(POOL_ADDRESS);
+          yield* adapter.getBinArray(POOL_ADDRESS);
+        }),
+        makeAdapterLayer(),
+      ),
+    );
+
+    const dlmm = dlmmState.current!;
+    expect(dlmm.getActiveBin).toHaveBeenCalledTimes(1);
+    expect(dlmm.getBinsAroundActiveBin).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches after the memo expires (a later cycle sees fresh state)", async () => {
+    const layer = makeAdapterLayer();
+    const dlmm = dlmmState.current!;
+    const realNow = Date.now.bind(Date);
+
+    // First read within the TTL: the memo serves it.
+    await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          yield* adapter.getPoolState(POOL_ADDRESS);
+          yield* adapter.getPoolState(POOL_ADDRESS);
+        }),
+        layer,
+      ),
+    );
+    expect(dlmm.getActiveBin).toHaveBeenCalledTimes(1);
+
+    // Advance the clock past the 3s TTL on the SAME layer: the memo expires
+    // and the next read must see fresh on-chain state.
+    vi.spyOn(Date, "now").mockImplementation(() => realNow() + 5_000);
+    await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          yield* adapter.getPoolState(POOL_ADDRESS);
+        }),
+        layer,
+      ),
+    );
+    vi.restoreAllMocks();
+    expect(dlmm.getActiveBin).toHaveBeenCalledTimes(2);
+  });
+});

--- a/bench/adapter-active-bin-memo.test.ts
+++ b/bench/adapter-active-bin-memo.test.ts
@@ -140,27 +140,22 @@ describe("active-bin memoization (RPC dedup)", () => {
     const layer = makeAdapterLayer();
     const dlmm = dlmmState.current!;
     const realNow = Date.now.bind(Date);
+    let fakeNow = realNow();
+    vi.spyOn(Date, "now").mockImplementation(() => fakeNow);
 
-    // First read within the TTL: the memo serves it.
+    // ONE adapter lifetime (one provide): the TTL expiry must be exercised
+    // against the same memo map, not a fresh layer per read.
     await Effect.runPromise(
       Effect.provide(
         Effect.gen(function* () {
           const adapter = yield* AdapterService;
+          // First reads within the TTL: the memo serves both.
           yield* adapter.getPoolState(POOL_ADDRESS);
           yield* adapter.getPoolState(POOL_ADDRESS);
-        }),
-        layer,
-      ),
-    );
-    expect(dlmm.getActiveBin).toHaveBeenCalledTimes(1);
+          expect(dlmm.getActiveBin).toHaveBeenCalledTimes(1);
 
-    // Advance the clock past the 3s TTL on the SAME layer: the memo expires
-    // and the next read must see fresh on-chain state.
-    vi.spyOn(Date, "now").mockImplementation(() => realNow() + 5_000);
-    await Effect.runPromise(
-      Effect.provide(
-        Effect.gen(function* () {
-          const adapter = yield* AdapterService;
+          // Advance the clock past the 3s TTL: the next read must refetch.
+          fakeNow += 5_000;
           yield* adapter.getPoolState(POOL_ADDRESS);
         }),
         layer,
@@ -168,5 +163,30 @@ describe("active-bin memoization (RPC dedup)", () => {
     );
     vi.restoreAllMocks();
     expect(dlmm.getActiveBin).toHaveBeenCalledTimes(2);
+  });
+
+  it("expires the bins memo half too (getBinArray refetches past the TTL)", async () => {
+    const layer = makeAdapterLayer();
+    const dlmm = dlmmState.current!;
+    const realNow = Date.now.bind(Date);
+    let fakeNow = realNow();
+    vi.spyOn(Date, "now").mockImplementation(() => fakeNow);
+
+    await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const adapter = yield* AdapterService;
+          yield* adapter.getBinArray(POOL_ADDRESS);
+          yield* adapter.getBinArray(POOL_ADDRESS);
+          expect(dlmm.getBinsAroundActiveBin).toHaveBeenCalledTimes(1);
+
+          fakeNow += 5_000;
+          yield* adapter.getBinArray(POOL_ADDRESS);
+        }),
+        layer,
+      ),
+    );
+    vi.restoreAllMocks();
+    expect(dlmm.getBinsAroundActiveBin).toHaveBeenCalledTimes(2);
   });
 });

--- a/bench/decision-loop-exit.test.ts
+++ b/bench/decision-loop-exit.test.ts
@@ -988,6 +988,10 @@ describe("no exit-and-reenter in one pass (launch lane)", () => {
         { [POOL]: makePool({ address: POOL, binStep: 100, tvlUsd: 300_000 }) },
         { discoverHotPools: () => Effect.succeed([makeHotDiscoveredPool(POOL)]) },
       ),
+      // Measured datapi stats: without them the ENTER candidate gate blocks
+      // every entry by design, and the no-exit-and-reenter guard test would
+      // pass vacuously (the pool could never ENTER regardless of the guard).
+      datapi: makeHotDatapi(POOL),
       configOverrides: {
         watchlistPools: [POOL],
         launchScanEnabled: true,

--- a/bench/decision-loop-exit.test.ts
+++ b/bench/decision-loop-exit.test.ts
@@ -919,3 +919,319 @@ describe("runner scale-in wiring (Heart Attack step 2)", () => {
     ).toBe(true);
   }, 15_000);
 });
+
+// ─── Launch-lane edge cases: no exit-and-reenter, scale-in on exit, ─────────
+// ─── wash-forensics gate, launch-cap boundary ───────────────────────────────
+
+// A gate-passing launch candidate: young, hot, safe legs, binStep 100 (the
+// exact shape the radar admits — proven by the idle-redeploy regression test).
+function makeHotDiscoveredPool(address: string): DiscoveredPool {
+  const now = Date.now();
+  return {
+    address,
+    tvlUsd: 300_000,
+    volume24hUsd: 900_000,
+    fees24hUsd: 2_400,
+    apr: 60,
+    binStep: 100,
+    volume1hUsd: 100_000,
+    feeYield1hPct: 5,
+    baseFeePct: 2,
+    createdAtMs: now - 3_600_000,
+    tokenX: "So11111111111111111111111111111111111111112",
+    tokenY: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    tokenXSymbol: "SOL",
+    tokenYSymbol: "USDC",
+    tokenXVerified: true,
+    tokenYVerified: true,
+    tokenXFreezeDisabled: true,
+    tokenYFreezeDisabled: true,
+  };
+}
+
+// Measured datapi stats so the launch ENTER candidate chain's
+// volumeAuthenticityKnown requirement passes — a heuristic pool can never
+// enter by design.
+function makeHotDatapi(address: string): MeteoraDatapiApi {
+  return {
+    getPoolData: (addr: string) =>
+      Effect.succeed(
+        addr === address
+          ? makeDatapiStats({
+              address,
+              tvlUsd: 300_000,
+              volume24hUsd: 900_000,
+              fees24hUsd: 2_400,
+              apr: 60,
+              feeTvlRatio1h: 0.05,
+            })
+          : null,
+      ),
+  };
+}
+
+// makePosition hardcodes a fresh `timestamp`; the launch timebox exits on
+// position AGE, so extend the helper locally (helpers.ts stays untouched).
+function makeAgedPosition(
+  ageMs: number,
+  overrides: Parameters<typeof makePosition>[0] = {},
+): PositionRecord {
+  return { ...makePosition(overrides), timestamp: Date.now() - ageMs };
+}
+
+describe("no exit-and-reenter in one pass (launch lane)", () => {
+  const POOL = "NoExitReenterPool11111111111111111111111111111";
+
+  it("never emits an ENTER for a pool whose EXIT executed this cycle", async () => {
+    const layer = makeTestLayer({
+      adapter: makeAdapter(
+        { [POOL]: makePool({ address: POOL, binStep: 100, tvlUsd: 300_000 }) },
+        { discoverHotPools: () => Effect.succeed([makeHotDiscoveredPool(POOL)]) },
+      ),
+      configOverrides: {
+        watchlistPools: [POOL],
+        launchScanEnabled: true,
+        launchExecutionEnabled: true,
+        // The held $1k position is below the $2k dust threshold: the
+        // deterministic dust EXIT fires this cycle. The pool is ALSO a
+        // gate-passing launch candidate — with only this one position the
+        // exit frees the slot, so an unguarded ENTER slot would approve the
+        // re-entry; only the no-exit-and-reenter guard can stop it.
+        dustExitUsd: 2_000,
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(
+        makePosition({ poolAddress: POOL, depositedUsd: 1_000, currentValueUsd: 1_000 }),
+      );
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const audit = yield* AuditService;
+      return yield* audit.getRecentDecisions(50);
+    });
+    const decisions = await Effect.runPromise(
+      Effect.provide(test, layer) as unknown as Effect.Effect<
+        ReadonlyArray<DecisionRow>,
+        Error,
+        never
+      >,
+    );
+
+    const exit = decisions.find(
+      (d) =>
+        d.poolAddress === POOL && d.action === "EXIT" && d.reasoning.includes("[dust-cleanup]"),
+    );
+    expect(exit, "the dust EXIT must fire for the held position").toBeDefined();
+    const enters = decisions.filter((d) => d.poolAddress === POOL && d.action === "ENTER");
+    expect(
+      enters,
+      `no exit-and-reenter: a pool that exited this cycle must not ENTER in the same pass, got ${stringifySafe(enters)}`,
+    ).toHaveLength(0);
+  }, 15_000);
+});
+
+describe("runner scale-in never fires on an exiting position", () => {
+  const POOL = "ScaleInExitPool1111111111111111111111111111111";
+
+  it("the timebox EXIT wins over a runner scale-in when both would fire", async () => {
+    const rebalanceSpy = vi.fn(() =>
+      Effect.succeed({ positionPubKey: "mock-pos", txSignatures: ["mock-tx"] }),
+    );
+    const exitSpy = vi.fn(() => Effect.succeed({ txSignature: "mock-tx" }));
+    const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const adapter = makeAdapter(
+      {
+        [POOL]: makePool({
+          address: POOL,
+          tokenX: USDC_MINT,
+          tokenXSymbol: "USDC",
+          // -7% vs the $100 anchor: a full scale-in step (5%), so the
+          // scale-in branch WOULD fire — if the timebox exit did not preempt
+          // it ("never scale into a dying position").
+          currentPrice: 93,
+          tvlUsd: 500_000,
+        }),
+      },
+      {
+        rebalancePosition: rebalanceSpy,
+        exitPosition: exitSpy,
+        hasWallet: () => true,
+        // USDC-quoted pool: the top-up spends USDC (no SOL-leg budget
+        // interaction — the SOL batch gate only applies to SOL legs).
+        getTokenPrices: () => Effect.succeed({ [USDC_MINT]: 1 }),
+        getTokenDecimals: () => Effect.succeed(6),
+      },
+    );
+    const layer = makeTestLayer({
+      adapter,
+      configOverrides: {
+        watchlistPools: [POOL],
+        paperTrading: false,
+        launchRunnerModeEnabled: true,
+        launchRunnerScaleInEnabled: true,
+        launchRunnerScaleInStepPct: 0.05,
+        launchRunnerScaleInSizePct: 0.25,
+        launchPositionMaxSizeUsd: 100,
+        // 1h timebox (config minimum); the runner position is 2h old.
+        launchTimeboxHours: 1,
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(
+        makeAgedPosition(2 * 3_600_000, {
+          poolAddress: POOL,
+          positionMode: "launch",
+          launchRunner: true,
+          launchRunnerAnchorPrice: 100,
+          launchRunnerSteps: 0,
+          positionPubKey: "mock-pos",
+          depositedUsd: 1_000,
+          currentValueUsd: 1_000,
+        }),
+      );
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const audit = yield* AuditService;
+      const decisions = yield* audit.getRecentDecisions(50);
+      return { decisions };
+    });
+    const { decisions } = await Effect.runPromise(
+      Effect.provide(test, layer) as unknown as Effect.Effect<
+        { decisions: ReadonlyArray<DecisionRow> },
+        Error,
+        never
+      >,
+    );
+
+    const timeboxExit = decisions.find(
+      (d) =>
+        d.poolAddress === POOL && d.action === "EXIT" && d.reasoning.includes("[launch-timebox]"),
+    );
+    expect(timeboxExit, "the timebox EXIT must fire for the aged runner position").toBeDefined();
+    const scaleIn = decisions.find(
+      (d) =>
+        d.poolAddress === POOL &&
+        d.action === "REBALANCE" &&
+        d.reasoning.includes("[launch-scale-in]"),
+    );
+    expect(scaleIn, "a runner position that exits this cycle must never scale in").toBeUndefined();
+    expect(
+      rebalanceSpy,
+      "no rebalance may be dispatched for an exiting position",
+    ).not.toHaveBeenCalled();
+    expect(exitSpy, "the timebox EXIT must execute").toHaveBeenCalledTimes(1);
+  }, 15_000);
+});
+
+describe("launch wash-forensics ENTER gate", () => {
+  const POOL = "WashForensicsPool11111111111111111111111111111";
+
+  it("rejects a launch ENTER with [wash-forensics] when the evidence is suspicious", async () => {
+    const washSpy = vi.fn((addr: string) =>
+      Effect.succeed(
+        addr === POOL
+          ? {
+              tradeCount: 200,
+              distinctPayers: 3,
+              txsPerSecond: 5,
+              uniquePayerRate: 0.015,
+              feeCv: null,
+              suspicious: true,
+              reason: "3 wallet(s) produced 200 recent trades — concentrated",
+            }
+          : null,
+      ),
+    );
+    const layer = makeTestLayer({
+      adapter: makeAdapter(
+        { [POOL]: makePool({ address: POOL, binStep: 100, tvlUsd: 300_000 }) },
+        {
+          discoverHotPools: () => Effect.succeed([makeHotDiscoveredPool(POOL)]),
+          getPoolWashEvidence: washSpy,
+        },
+      ),
+      configOverrides: {
+        watchlistPools: [POOL],
+        launchScanEnabled: true,
+        launchExecutionEnabled: true,
+        launchWashForensicsEnabled: true,
+      },
+    });
+
+    const decisions = await runCycles(layer, 2_000);
+    const forPool = decisions.filter((d) => d.poolAddress === POOL);
+    const washRejection = forPool.find(
+      (d) => d.action === "ENTER" && d.reasoning.includes("[wash-forensics]"),
+    );
+    expect(
+      washRejection,
+      `expected a [wash-forensics] ENTER rejection, got ${stringifySafe(forPool)}`,
+    ).toBeDefined();
+    expect(washRejection!.riskResult.approved).toBe(false);
+    expect(washRejection!.executed).toBe(false);
+    // The gate reads the radar-refreshed wash evidence, which is fetched
+    // exactly once per admitted top-K pool.
+    expect(washSpy).toHaveBeenCalledWith(POOL);
+  }, 15_000);
+});
+
+describe("launch-cap boundary", () => {
+  const CANDIDATE = "LaunchCapCandidate1111111111111111111111111";
+  const FILLER = "LaunchCapFiller111111111111111111111111111111";
+
+  it("rejects the next launch ENTER with [launch-cap] at launchMaxOpenPositions", async () => {
+    const layer = makeTestLayer({
+      adapter: makeAdapter(
+        {
+          [CANDIDATE]: makePool({ address: CANDIDATE, binStep: 100, tvlUsd: 300_000 }),
+          [FILLER]: makePool({ address: FILLER, tvlUsd: 100_000 }),
+        },
+        { discoverHotPools: () => Effect.succeed([makeHotDiscoveredPool(CANDIDATE)]) },
+      ),
+      datapi: makeHotDatapi(CANDIDATE),
+      configOverrides: {
+        watchlistPools: [CANDIDATE, FILLER],
+        launchScanEnabled: true,
+        launchExecutionEnabled: true,
+        // The single launch slot is already occupied by the FILLER position.
+        launchMaxOpenPositions: 1,
+        launchPositionMaxSizeUsd: 100,
+      },
+    });
+
+    const test = Effect.gen(function* () {
+      const db = yield* DbService;
+      yield* db.savePosition(
+        makePosition({
+          poolAddress: FILLER,
+          positionMode: "launch",
+          depositedUsd: 1_000,
+          currentValueUsd: 1_000,
+        }),
+      );
+      yield* Effect.raceFirst(program, Effect.sleep(2_000));
+      const audit = yield* AuditService;
+      return yield* audit.getRecentDecisions(50);
+    });
+    const decisions = await Effect.runPromise(
+      Effect.provide(test, layer) as unknown as Effect.Effect<
+        ReadonlyArray<DecisionRow>,
+        Error,
+        never
+      >,
+    );
+
+    const forCandidate = decisions.filter((d) => d.poolAddress === CANDIDATE);
+    const capRejection = forCandidate.find(
+      (d) => d.action === "ENTER" && d.reasoning.includes("[launch-cap]"),
+    );
+    expect(
+      capRejection,
+      `expected a [launch-cap] ENTER rejection, got ${stringifySafe(forCandidate)}`,
+    ).toBeDefined();
+    expect(capRejection!.riskResult.approved).toBe(false);
+    expect(capRejection!.executed).toBe(false);
+  }, 15_000);
+});

--- a/bench/launch-gate.test.ts
+++ b/bench/launch-gate.test.ts
@@ -212,4 +212,283 @@ describe("summarizeLaunchRejections", () => {
     );
     expect(summary).toHaveLength(1);
   });
+
+  it("slices the summary at exactly topN", () => {
+    const summary = summarizeLaunchRejections(
+      [
+        { category: "age", reason: "age 7h > 6h" },
+        { category: "tvl", reason: "tvl 2000 < 5000" },
+        { category: "volume-1h", reason: "1h volume 100 < 50000" },
+        { category: "base-fee", reason: "base fee 0.5 < 1%" },
+        { category: "bin-step", reason: "binStep 10 outside [50, 200]" },
+        { category: "turnover", reason: "volume turnover 100 > 50 (wash)" },
+        { category: "token-safety", reason: "leg RUG fails token safety" },
+      ],
+      6,
+    );
+    expect(summary).toHaveLength(6);
+    expect(summary.map((s) => s.category)).not.toContain("token-safety");
+  });
+
+  it("keeps first-appearance order for categories with equal counts", () => {
+    const summary = summarizeLaunchRejections([
+      { category: "age", reason: "age 7h > 6h" },
+      { category: "tvl", reason: "tvl 2000 < 5000" },
+      { category: "age", reason: "age 40h > 6h" },
+      { category: "tvl", reason: "tvl 9999999999 > 1000000" },
+    ]);
+    expect(summary).toHaveLength(2);
+    expect(summary[0]!.category).toBe("age");
+    expect(summary[0]!.count).toBe(2);
+    expect(summary[1]!.category).toBe("tvl");
+    expect(summary[1]!.count).toBe(2);
+  });
+});
+
+describe("launch-gate age boundaries", () => {
+  it("admits a pool exactly at maxAgeHours", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "exactage", createdAtMs: NOW - 6 * 60 * 60_000 })],
+      config,
+    );
+    expect(result.ranked.map((r) => r.pool.address)).toContain("exactage");
+    expect(rejectedFor(result, "exactage")).toHaveLength(0);
+  });
+
+  it("rejects a pool one ms older than maxAgeHours", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "overage", createdAtMs: NOW - 6 * 60 * 60_000 - 1 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "overage")[0]).toContain("age");
+  });
+
+  it("admits a zero-age pool", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "fresh", createdAtMs: NOW })],
+      config,
+    );
+    expect(result.ranked.map((r) => r.pool.address)).toContain("fresh");
+    expect(rejectedFor(result, "fresh")).toHaveLength(0);
+  });
+
+  it("admits a pool created within the clock-skew future tolerance", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "skewok", createdAtMs: NOW + 30_000 })],
+      config,
+    );
+    expect(result.ranked.map((r) => r.pool.address)).toContain("skewok");
+    expect(rejectedFor(result, "skewok")).toHaveLength(0);
+  });
+
+  it("rejects a pool created beyond the clock-skew future tolerance", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "skewbad", createdAtMs: NOW + 90_000 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "skewbad")[0]).toContain("future");
+  });
+});
+
+describe("launch-gate TVL boundaries", () => {
+  it("admits a pool exactly at minTvlUsd", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "exactmin", tvlUsd: 5_000, volume24hUsd: 50_000 })],
+      config,
+    );
+    expect(result.ranked.map((r) => r.pool.address)).toContain("exactmin");
+    expect(rejectedFor(result, "exactmin")).toHaveLength(0);
+  });
+
+  it("rejects a pool one dollar under minTvlUsd", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "undermin", tvlUsd: 4_999 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "undermin")[0]).toContain("tvl");
+  });
+
+  it("admits a pool exactly at maxTvlUsd", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "exactmax", tvlUsd: 1_000_000 })],
+      config,
+    );
+    expect(result.ranked.map((r) => r.pool.address)).toContain("exactmax");
+    expect(rejectedFor(result, "exactmax")).toHaveLength(0);
+  });
+
+  it("rejects a pool one dollar over maxTvlUsd", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "overmax", tvlUsd: 1_000_001 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "overmax")[0]).toContain("tvl");
+  });
+});
+
+describe("launch-gate volume boundaries", () => {
+  it("admits a pool exactly at minVolume1hUsd", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "exactvol", volume1hUsd: 50_000 })],
+      config,
+    );
+    expect(result.ranked.map((r) => r.pool.address)).toContain("exactvol");
+    expect(rejectedFor(result, "exactvol")).toHaveLength(0);
+  });
+
+  it("rejects a pool just under minVolume1hUsd", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "undervol", volume1hUsd: 49_999 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "undervol")[0]).toContain("1h volume");
+  });
+
+  it("rejects a pool with missing volume1hUsd", () => {
+    const { volume1hUsd: _omit, ...noVolume } = makePool({ address: "novol" });
+    const result = gateAndRankLaunchPools([noVolume], config);
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "novol")[0]).toContain("1h volume");
+  });
+});
+
+describe("launch-gate binStep boundaries", () => {
+  it("admits pools exactly at minBinStep and maxBinStep", () => {
+    const result = gateAndRankLaunchPools(
+      [
+        makePool({ address: "minstep", binStep: 50 }),
+        makePool({ address: "maxstep", binStep: 200 }),
+      ],
+      config,
+    );
+    expect(result.ranked.map((r) => r.pool.address)).toEqual(["minstep", "maxstep"]);
+    expect(result.rejected).toHaveLength(0);
+  });
+
+  it("rejects a pool one binStep under or over the band", () => {
+    const result = gateAndRankLaunchPools(
+      [
+        makePool({ address: "understep", binStep: 49 }),
+        makePool({ address: "overstep", binStep: 201 }),
+      ],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "understep")[0]).toContain("binStep");
+    expect(rejectedFor(result, "overstep")[0]).toContain("binStep");
+  });
+
+  it("rejects a non-integer binStep", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "fractional", binStep: 100.5 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "fractional")[0]).toContain("binStep");
+  });
+});
+
+describe("launch-gate turnover boundary", () => {
+  it("admits a pool exactly at maxVolumeTurnover", () => {
+    // 5_000_000 / 100_000 = 50 — the gate rejects only > max.
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "exactturn", volume24hUsd: 5_000_000 })],
+      config,
+    );
+    expect(result.ranked.map((r) => r.pool.address)).toContain("exactturn");
+    expect(rejectedFor(result, "exactturn")).toHaveLength(0);
+  });
+
+  it("rejects a pool just over maxVolumeTurnover", () => {
+    // 5_010_000 / 100_000 = 50.1 > 50.
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "overturn", volume24hUsd: 5_010_000 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "overturn")[0]).toContain("wash");
+  });
+});
+
+describe("launch-gate token-leg failures", () => {
+  it("rejects an unverified non-stable leg with low holders", () => {
+    const result = gateAndRankLaunchPools(
+      [
+        makePool({
+          address: "lowholders",
+          tokenX: "Rug1111111111111111111111111111111111111111",
+          tokenXSymbol: "RUG",
+          tokenXVerified: false,
+          tokenXFreezeDisabled: true,
+          tokenXHolders: 10,
+        }),
+      ],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "lowholders")[0]).toContain("token safety");
+  });
+
+  it("admits a stable leg regardless of holders or verification", () => {
+    const result = gateAndRankLaunchPools(
+      [
+        makePool({
+          address: "stablesafe",
+          tokenY: USDC,
+          tokenYSymbol: "USDC",
+          tokenYVerified: false,
+          tokenYFreezeDisabled: false,
+          tokenYHolders: 0,
+        }),
+      ],
+      config,
+    );
+    expect(result.ranked.map((r) => r.pool.address)).toContain("stablesafe");
+    expect(rejectedFor(result, "stablesafe")).toHaveLength(0);
+  });
+
+  it("rejects a freeze-enabled unverified leg", () => {
+    const result = gateAndRankLaunchPools(
+      [
+        makePool({
+          address: "freezable",
+          tokenX: "Rug1111111111111111111111111111111111111111",
+          tokenXSymbol: "RUG",
+          tokenXVerified: false,
+          tokenXFreezeDisabled: false,
+          tokenXHolders: 3_000_000,
+        }),
+      ],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "freezable")[0]).toContain("token safety");
+  });
+});
+
+describe("launch-gate fee-yield edges", () => {
+  it("rejects a NaN fee yield as missing", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "nanyield", feeYield1hPct: NaN })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(0);
+    expect(rejectedFor(result, "nanyield")[0]).toContain("fee yield");
+  });
+
+  it("admits a zero fee yield when everything else passes", () => {
+    const result = gateAndRankLaunchPools(
+      [makePool({ address: "zeroyield", feeYield1hPct: 0 })],
+      config,
+    );
+    expect(result.ranked).toHaveLength(1);
+    expect(result.ranked[0]!.feeYield1hPct).toBe(0);
+    expect(result.ranked[0]!.score).toBe(0);
+    expect(rejectedFor(result, "zeroyield")).toHaveLength(0);
+  });
 });

--- a/bench/runner-dip.test.ts
+++ b/bench/runner-dip.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { dipOffsetBinsForPct } from "../engine/strategy-service.js";
+import { scaleInTopUpUsd, shouldScaleInRunner } from "../engine/launch-position.js";
 
 describe("dipOffsetBinsForPct (runner-mode dip anchor)", () => {
   it("binStep 100, 12% dip -> -13 bins (the Heart Attack -12% band)", () => {
@@ -50,5 +51,96 @@ describe("dipOffsetBinsForPct (runner-mode dip anchor)", () => {
     expect(range.lowerBinId).toBe(5000 - 5 - 13);
     expect(range.upperBinId).toBe(5000 + 5 - 13);
     expect(range.upperBinId).toBeLessThan(5000); // entirely below the active bin
+  });
+
+  it("anchors a 50% dip (the config max) with the finest bins (binStep 1)", () => {
+    // LAUNCH_RUNNER_DIP_PCT clamps at 0.5 (config-service). At 1bp per bin:
+    // ln(0.5)/ln(1.0001) = -6931.5 -> round -6932.
+    expect(dipOffsetBinsForPct(1, 0.5)).toBe(-6932);
+  });
+
+  it("anchors a 50% dip (the config max) with the coarsest bins (binStep 200)", () => {
+    // 2% per bin: ln(0.5)/ln(1.02) = -35.0 -> round -35.
+    expect(dipOffsetBinsForPct(200, 0.5)).toBe(-35);
+  });
+});
+
+describe("shouldScaleInRunner (runner scale-in trigger)", () => {
+  it("scales when the price drop is exactly stepPct", () => {
+    // anchor 100 -> 95 is a 0.05 drop, exactly the 5% step: drop >= stepPct
+    // fires (the guard is `drop < stepPct` -> no scale).
+    const d = shouldScaleInRunner({
+      anchorPrice: 100,
+      currentPrice: 95,
+      stepPct: 0.05,
+      steps: 0,
+      maxSteps: 3,
+    });
+    expect(d.scale).toBe(true);
+    expect(d.reason).toContain("step 1/3");
+  });
+
+  it("does not scale one basis point under stepPct", () => {
+    // 95.01 -> drop 0.0499 < 0.05: just under the step.
+    const d = shouldScaleInRunner({
+      anchorPrice: 100,
+      currentPrice: 95.01,
+      stepPct: 0.05,
+      steps: 0,
+      maxSteps: 3,
+    });
+    expect(d.scale).toBe(false);
+    expect(d.reason).toContain("< step 5%");
+  });
+
+  it("refuses to scale when steps are exactly at maxSteps", () => {
+    const d = shouldScaleInRunner({
+      anchorPrice: 100,
+      currentPrice: 90,
+      stepPct: 0.05,
+      steps: 3,
+      maxSteps: 3,
+    });
+    expect(d.scale).toBe(false);
+    expect(d.reason).toContain("max steps reached");
+  });
+
+  it("scales on the last allowed step (maxSteps - 1)", () => {
+    const d = shouldScaleInRunner({
+      anchorPrice: 100,
+      currentPrice: 95,
+      stepPct: 0.05,
+      steps: 2,
+      maxSteps: 3,
+    });
+    expect(d.scale).toBe(true);
+    expect(d.reason).toContain("step 3/3");
+  });
+});
+
+describe("scaleInTopUpUsd (runner top-up sizing)", () => {
+  it("sizes an all-in step (sizePct 1.0) at the full wallet", () => {
+    // min(1.0 * 500, 1000 cap, 1000 ceiling) = 500.
+    expect(
+      scaleInTopUpUsd({ walletUsd: 500, sizePct: 1.0, poolCapUsd: 1000, maxTopUpUsd: 1000 }),
+    ).toBe(500);
+  });
+
+  it("caps exactly when poolCapUsd equals sizePct * walletUsd", () => {
+    // 0.25 * 400 = 100, pool cap 100: the tie resolves to 100 (boundary is
+    // inclusive), and one dollar less of headroom binds the cap instead.
+    expect(
+      scaleInTopUpUsd({ walletUsd: 400, sizePct: 0.25, poolCapUsd: 100, maxTopUpUsd: 500 }),
+    ).toBe(100);
+    expect(
+      scaleInTopUpUsd({ walletUsd: 400, sizePct: 0.25, poolCapUsd: 99, maxTopUpUsd: 500 }),
+    ).toBe(99);
+  });
+
+  it("floors at 0 when maxTopUpUsd is 0", () => {
+    // The hard ceiling is 0, so even a large wallet + headroom yields 0.
+    expect(
+      scaleInTopUpUsd({ walletUsd: 1000, sizePct: 0.5, poolCapUsd: 500, maxTopUpUsd: 0 }),
+    ).toBe(0);
   });
 });

--- a/bench/wash-forensics.test.ts
+++ b/bench/wash-forensics.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { scoreWashEvidence, type WashTradeRow } from "../engine/wash-forensics.js";
+import {
+  scoreWashEvidence,
+  WASH_MAX_TPS_FOR_BURST,
+  WASH_MAX_UNIQUE_PAYER_RATE,
+  WASH_MIN_TRADES,
+  type WashTradeRow,
+} from "../engine/wash-forensics.js";
 
 const T0 = 1_800_000_000;
 function row(payer: string, i: number, fee = 5_000): WashTradeRow {
@@ -80,5 +86,82 @@ describe("scoreWashEvidence", () => {
     expect(e.suspicious).toBe(false);
     expect(e.tradeCount).toBe(0);
     expect(e.feeCv).toBeNull();
+  });
+
+  it("draws the trade-count line exactly at WASH_MIN_TRADES (19 pass, 20 flag)", () => {
+    // 19 trades from 2 wallets at ~1 tps: every rule needs >= 20 trades
+    // (concentration, unique-payer-rate) or >= 5 tps (burst) — nothing fires.
+    const under = Array.from({ length: WASH_MIN_TRADES - 1 }, (_, i) => row(`bot${i % 2}`, i));
+    const eUnder = scoreWashEvidence(under);
+    expect(eUnder.suspicious).toBe(false);
+    expect(eUnder.tradeCount).toBe(WASH_MIN_TRADES - 1);
+    expect(eUnder.txsPerSecond).toBeLessThan(WASH_MAX_TPS_FOR_BURST);
+
+    // 20 trades from 2 wallets at the same ~1 tps: concentration fires.
+    const at = Array.from({ length: WASH_MIN_TRADES }, (_, i) => row(`bot${i % 2}`, i));
+    const eAt = scoreWashEvidence(at);
+    expect(eAt.suspicious).toBe(true);
+    expect(eAt.reason).toContain("concentrated");
+  });
+
+  it("draws the unique-payer-rate line exactly at WASH_MAX_UNIQUE_PAYER_RATE (0.15)", () => {
+    // 3 distinct payers / 20 trades = exactly 0.15 — the wash-pattern rule
+    // fires (>= 20 trades, rate <= 0.15). 3 wallets also beats the
+    // 2-wallet concentration rule, so only the rate rule can fire.
+    const at = Array.from({ length: 20 }, (_, i) => row(`wallet${i % 3}`, i));
+    const eAt = scoreWashEvidence(at);
+    expect(eAt.uniquePayerRate).toBe(WASH_MAX_UNIQUE_PAYER_RATE);
+    expect(eAt.suspicious).toBe(true);
+    expect(eAt.reason).toContain("wash pattern");
+  });
+
+  it("passes a sample just over WASH_MAX_UNIQUE_PAYER_RATE", () => {
+    // 5 distinct payers / 33 trades = 0.1515... > 0.15 — rate rule passes.
+    // 5 wallets beats concentration; ~1 tps beats the burst bar.
+    const justOver = Array.from({ length: 33 }, (_, i) => row(`wallet${i % 5}`, i));
+    const e = scoreWashEvidence(justOver);
+    expect(e.uniquePayerRate).toBeGreaterThan(WASH_MAX_UNIQUE_PAYER_RATE);
+    expect(e.suspicious).toBe(false);
+  });
+
+  it("fires the burst rule at exactly WASH_MAX_TPS_FOR_BURST (5.0 tps)", () => {
+    // 10 trades from 2 wallets spanning [0, 2]s = 10/2 = 5.0 tps — the >=
+    // bar fires. Fewer than 20 trades, so only the burst rule can fire.
+    const rows = Array.from({ length: 10 }, (_, i) => row(`bot${i % 2}`, Math.floor(i / 5) * 2));
+    const e = scoreWashEvidence(rows);
+    expect(e.txsPerSecond).toBe(WASH_MAX_TPS_FOR_BURST);
+    expect(e.suspicious).toBe(true);
+    expect(e.reason).toContain("bot burst");
+  });
+
+  it("passes a burst just under WASH_MAX_TPS_FOR_BURST (4.5 tps)", () => {
+    // 9 trades from 2 wallets spanning [0, 2]s = 9/2 = 4.5 tps — under the
+    // >= 5.0 bar and under the 20-trade floor, so nothing fires.
+    const rows = Array.from({ length: 9 }, (_, i) => row(`bot${i % 2}`, Math.floor(i / 5) * 2));
+    const e = scoreWashEvidence(rows);
+    expect(e.txsPerSecond).toBe(4.5);
+    expect(e.suspicious).toBe(false);
+  });
+
+  it("never flags a single payer below WASH_MIN_TRADES (the judgment floor)", () => {
+    // One wallet, 19 trades at ~1 tps: the concentration rule needs >= 20
+    // trades and the burst rule needs >= 5 tps — a lone wallet under the
+    // floor is a possible honest burst.
+    const rows = Array.from({ length: WASH_MIN_TRADES - 1 }, (_, i) => row("lone", i));
+    const e = scoreWashEvidence(rows);
+    expect(e.distinctPayers).toBe(1);
+    expect(e.suspicious).toBe(false);
+  });
+
+  it("keeps feeCv null at exactly 2 fees and computes it at exactly 3", () => {
+    // feeCv needs >= 3 positive fees; exactly 2 stays null.
+    const two = [row("a", 0), row("b", 30)];
+    const eTwo = scoreWashEvidence(two);
+    expect(eTwo.feeCv).toBeNull();
+
+    // Crossing the floor: exactly 3 identical fees -> CV 0 (not null).
+    const three = [row("a", 0), row("b", 30), row("c", 60)];
+    const eThree = scoreWashEvidence(three);
+    expect(eThree.feeCv).toBe(0);
   });
 });

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -2307,7 +2307,8 @@ export const AdapterLive = Layer.effect(
 
           if (realBins === null) {
             // Explicit unknown state: metrics skip the auth/utilization gates
-            // with a warning instead of consuming fabricated 1.0 values.
+            // with a warning instead of consuming fabricated 1.0 values. The
+            // local memo value is the best available fallback.
             return {
               lowerBinId,
               upperBinId,
@@ -2318,9 +2319,24 @@ export const AdapterLive = Layer.effect(
             };
           }
 
-          const basePrice = Number(activeBin.price);
+          // Derive the bounds + active bin FROM THE FETCHED SNAPSHOT, not the
+          // local memo value: the pool can move between getPoolState and the
+          // bins fetch, and realBins.activeBin is that fetch's own snapshot.
+          // Filtering newer bins with an older ±20 range would distort the
+          // bin-utilization/concentration inputs while reporting
+          // reservesKnown: true.
+          const snapshotActiveBinId = realBins.activeBin;
+          const snapshotLower = snapshotActiveBinId - halfRange;
+          const snapshotUpper = snapshotActiveBinId + halfRange;
+          const snapshotActivePrice = realBins.bins.find(
+            (b) => b.binId === snapshotActiveBinId,
+          )?.price;
+          const basePrice =
+            snapshotActivePrice !== undefined
+              ? Number(snapshotActivePrice)
+              : Number(activeBin.price);
           const bins: BinData[] = realBins.bins
-            .filter((b) => b.binId >= lowerBinId && b.binId <= upperBinId)
+            .filter((b) => b.binId >= snapshotLower && b.binId <= snapshotUpper)
             .map((b) => {
               const parsedPrice = Number(b.price);
               return {
@@ -2328,7 +2344,7 @@ export const AdapterLive = Layer.effect(
                 price:
                   Number.isFinite(parsedPrice) && parsedPrice > 0
                     ? parsedPrice
-                    : basePrice * Math.pow(1 + binStep / 10000, b.binId - activeBin.binId),
+                    : basePrice * Math.pow(1 + binStep / 10000, b.binId - snapshotActiveBinId),
                 reserveX: BigInt(b.xAmount.toString()),
                 reserveY: BigInt(b.yAmount.toString()),
                 liquiditySupply: BigInt(b.supply.toString()),
@@ -2336,10 +2352,10 @@ export const AdapterLive = Layer.effect(
             });
 
           return {
-            lowerBinId,
-            upperBinId,
+            lowerBinId: snapshotLower,
+            upperBinId: snapshotUpper,
             bins,
-            activeBinId: activeBin.binId,
+            activeBinId: snapshotActiveBinId,
             binStep,
             reservesKnown: true,
           };

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -2266,6 +2266,17 @@ export const AdapterLive = Layer.effect(
         Effect.gen(function* () {
           const dlmm = yield* getDlmm(poolAddress);
           const lbPair = dlmm.lbPair;
+          // Did this call HIT the memo? Only a FRESH fetch may re-stamp the
+          // TTL after assembly — re-stamping on hits would make freshness
+          // caller-cadence-dependent (a frequent caller keeps the memo alive
+          // forever) and could refresh a screener-populated entry whose bins
+          // are older than the TTL.
+          const memoHit = (() => {
+            const m = activeBinMemo.get(poolAddress);
+            return (
+              m !== undefined && m.price !== "" && Date.now() - m.fetchedAt < ACTIVE_BIN_MEMO_TTL_MS
+            );
+          })();
           const activeBin = yield* memoizedActiveBin(poolAddress, dlmm);
 
           const [tokenXMeta, tokenYMeta, stats] = yield* Effect.all([
@@ -2280,9 +2291,15 @@ export const AdapterLive = Layer.effect(
           // immediately following getBinArray call must still hit the memo
           // (otherwise the dedup is defeated exactly in the high-latency,
           // high-cardinality scenario it exists for).
-          const assembledMemo = activeBinMemo.get(poolAddress);
-          if (assembledMemo) {
-            activeBinMemo.set(poolAddress, { ...assembledMemo, fetchedAt: Date.now() });
+          if (!memoHit) {
+            const assembledMemo = activeBinMemo.get(poolAddress);
+            if (assembledMemo) {
+              // The active bin was fetched THIS call: extend the TTL across
+              // the assembly window so the immediately following getBinArray
+              // still hits the memo (the data is at most the assembly
+              // duration old). Hits are untouched.
+              activeBinMemo.set(poolAddress, { ...assembledMemo, fetchedAt: Date.now() });
+            }
           }
 
           return {

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -764,6 +764,7 @@ export const AdapterLive = Layer.effect(
       readonly binId: number;
       readonly price: string;
       readonly fetchedAt: number;
+      readonly halfRange: number;
       readonly binsAround: { activeBin: number; bins: BinLiquidity[] } | null;
     }
     const activeBinMemo = new Map<string, ActiveBinMemo>();
@@ -797,6 +798,7 @@ export const AdapterLive = Layer.effect(
           binId: activeBin.binId,
           price: activeBin.price,
           fetchedAt: Date.now(),
+          halfRange: 0,
           binsAround: null,
         });
         return { binId: activeBin.binId, price: activeBin.price };
@@ -814,6 +816,7 @@ export const AdapterLive = Layer.effect(
         if (
           memo &&
           memo.binsAround !== null &&
+          memo.halfRange === halfRange &&
           Date.now() - memo.fetchedAt < ACTIVE_BIN_MEMO_TTL_MS
         ) {
           return memo.binsAround;
@@ -832,6 +835,7 @@ export const AdapterLive = Layer.effect(
           binId: bins.activeBin,
           price: binsActivePrice ?? memo?.price ?? "",
           fetchedAt: Date.now(),
+          halfRange,
           binsAround: bins,
         });
         return bins;
@@ -2269,6 +2273,17 @@ export const AdapterLive = Layer.effect(
             getTokenMeta(lbPair.tokenYMint.toBase58()),
             fetchPoolStats(poolAddress),
           ]);
+
+          // The TTL clock starts when the pool-state ASSEMBLY completes, not
+          // when the active bin was fetched: for a cold or rotating pool the
+          // metadata/reserves/pricing resolution can exceed 3s, and the
+          // immediately following getBinArray call must still hit the memo
+          // (otherwise the dedup is defeated exactly in the high-latency,
+          // high-cardinality scenario it exists for).
+          const assembledMemo = activeBinMemo.get(poolAddress);
+          if (assembledMemo) {
+            activeBinMemo.set(poolAddress, { ...assembledMemo, fetchedAt: Date.now() });
+          }
 
           return {
             address: poolAddress,

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -20,6 +20,7 @@ import DLMM, {
   ConcreteFunctionType,
   StrategyType,
   MAX_ACTIVE_BIN_SLIPPAGE,
+  type BinLiquidity,
   type PositionData,
   type RebalanceWithDeposit,
   type RebalanceWithWithdraw,
@@ -752,6 +753,65 @@ export const AdapterLive = Layer.effect(
     }
     const mintAuthoritiesCache = new Map<string, MintAuthoritiesEntry>();
 
+    // Active-bin memo (issue: the audit's RPC dedup — getActiveBin is fetched
+    // TWICE per pool per cycle: once in getPoolState, once in getBinArray, and
+    // getBinsAroundActiveBin re-fetches the same bin array getActiveBin just
+    // loaded). A SHORT TTL serves the within-cycle pair (ms apart) without
+    // going stale across cycles (the active bin moves with every swap). The
+    // DLMM instance itself is cached 5 min; this memo is strictly tighter.
+    const ACTIVE_BIN_MEMO_TTL_MS = 3_000;
+    interface ActiveBinMemo {
+      readonly binId: number;
+      readonly price: string;
+      readonly fetchedAt: number;
+      readonly binsAround: { activeBin: number; bins: BinLiquidity[] } | null;
+    }
+    const activeBinMemo = new Map<string, ActiveBinMemo>();
+
+    function memoizedActiveBin(
+      poolAddress: string,
+      dlmm: DLMM,
+    ): Effect.Effect<{ binId: number; price: string }, Error> {
+      return Effect.gen(function* () {
+        const memo = activeBinMemo.get(poolAddress);
+        if (memo && Date.now() - memo.fetchedAt < ACTIVE_BIN_MEMO_TTL_MS) {
+          return { binId: memo.binId, price: memo.price };
+        }
+        const activeBin = yield* Effect.tryPromise(() => dlmm.getActiveBin());
+        activeBinMemo.set(poolAddress, {
+          binId: activeBin.binId,
+          price: activeBin.price,
+          fetchedAt: Date.now(),
+          binsAround: null,
+        });
+        return { binId: activeBin.binId, price: activeBin.price };
+      });
+    }
+
+    function memoizedBinsAround(
+      poolAddress: string,
+      dlmm: DLMM,
+    ): Effect.Effect<{ activeBin: number; bins: BinLiquidity[] }, Error> {
+      return Effect.gen(function* () {
+        const memo = activeBinMemo.get(poolAddress);
+        if (
+          memo &&
+          memo.binsAround !== null &&
+          Date.now() - memo.fetchedAt < ACTIVE_BIN_MEMO_TTL_MS
+        ) {
+          return memo.binsAround;
+        }
+        const bins = yield* Effect.tryPromise(() => dlmm.getBinsAroundActiveBin(20, 20));
+        activeBinMemo.set(poolAddress, {
+          binId: memo?.binId ?? bins.activeBin,
+          price: memo?.price ?? "",
+          fetchedAt: Date.now(),
+          binsAround: bins,
+        });
+        return bins;
+      });
+    }
+
     function getMintAuthorities(
       mintAddress: string,
     ): Effect.Effect<{ mintAuthority: string | null; freezeAuthority: string | null }, Error> {
@@ -1376,6 +1436,7 @@ export const AdapterLive = Layer.effect(
     const cachedWalletHoldings = Effect.map(cachedWalletSnapshot, (snapshot) => snapshot.held);
 
     const invalidateBalanceCaches = Effect.sync(() => {
+      activeBinMemo.clear();
       tokenBalanceCache.clear();
       nativeSolBalanceCache = undefined;
       // Position marks read the same on-chain accounts a mutation rewrites:
@@ -2175,7 +2236,7 @@ export const AdapterLive = Layer.effect(
         Effect.gen(function* () {
           const dlmm = yield* getDlmm(poolAddress);
           const lbPair = dlmm.lbPair;
-          const activeBin = yield* Effect.tryPromise(() => dlmm.getActiveBin());
+          const activeBin = yield* memoizedActiveBin(poolAddress, dlmm);
 
           const [tokenXMeta, tokenYMeta, stats] = yield* Effect.all([
             getTokenMeta(lbPair.tokenXMint.toBase58()),
@@ -2217,7 +2278,7 @@ export const AdapterLive = Layer.effect(
       getBinArray: (poolAddress) =>
         Effect.gen(function* () {
           const dlmm = yield* getDlmm(poolAddress);
-          const activeBin = yield* Effect.tryPromise(() => dlmm.getActiveBin());
+          const activeBin = yield* memoizedActiveBin(poolAddress, dlmm);
           const halfRange = 20;
           const lowerBinId = activeBin.binId - halfRange;
           const upperBinId = activeBin.binId + halfRange;
@@ -2225,10 +2286,9 @@ export const AdapterLive = Layer.effect(
 
           // Real per-bin reserves from the on-chain bin arrays. The SDK fills
           // uninitialized bins with zero-amount placeholders, which is the
-          // truthful "empty bin" representation.
-          const realBins = yield* Effect.tryPromise(() =>
-            dlmm.getBinsAroundActiveBin(halfRange, halfRange),
-          ).pipe(
+          // truthful "empty bin" representation. Memoized with the active bin
+          // so getPoolState + getBinArray share one fetch pair.
+          const realBins = yield* memoizedBinsAround(poolAddress, dlmm).pipe(
             Effect.catch((err) => {
               logger.warn(
                 "Real bin reserves unavailable — bin-derived metrics will be marked unknown",

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -802,9 +802,16 @@ export const AdapterLive = Layer.effect(
           return memo.binsAround;
         }
         const bins = yield* Effect.tryPromise(() => dlmm.getBinsAroundActiveBin(20, 20));
+        // The bins fetch carries its OWN active-bin snapshot (the SDK reads
+        // the active bin internally): align the memo with it so binId/price
+        // and binsAround always describe the SAME point in time — retaining
+        // the old binId while refreshing fetchedAt would serve a stale active
+        // bin for another TTL window, and mixing bins from a newer snapshot
+        // with the old id would be internally inconsistent.
+        const binsActivePrice = bins.bins.find((b) => b.binId === bins.activeBin)?.price;
         activeBinMemo.set(poolAddress, {
-          binId: memo?.binId ?? bins.activeBin,
-          price: memo?.price ?? "",
+          binId: bins.activeBin,
+          price: binsActivePrice ?? memo?.price ?? "",
           fetchedAt: Date.now(),
           binsAround: bins,
         });

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -768,11 +768,26 @@ export const AdapterLive = Layer.effect(
     }
     const activeBinMemo = new Map<string, ActiveBinMemo>();
 
+    // Opportunistic eviction: pools rotate out of the active set, and in
+    // paper mode no mutation ever clears the memo — without pruning, dropped
+    // pools' bin arrays would accumulate unboundedly. Each read prunes the
+    // entries that have aged past the TTL, bounding the map by the pools
+    // touched within one TTL window (the active set).
+    function pruneActiveBinMemo(): void {
+      const now = Date.now();
+      for (const [addr, memo] of activeBinMemo) {
+        if (now - memo.fetchedAt >= ACTIVE_BIN_MEMO_TTL_MS) {
+          activeBinMemo.delete(addr);
+        }
+      }
+    }
+
     function memoizedActiveBin(
       poolAddress: string,
       dlmm: DLMM,
     ): Effect.Effect<{ binId: number; price: string }, Error> {
       return Effect.gen(function* () {
+        pruneActiveBinMemo();
         const memo = activeBinMemo.get(poolAddress);
         if (memo && Date.now() - memo.fetchedAt < ACTIVE_BIN_MEMO_TTL_MS) {
           return { binId: memo.binId, price: memo.price };
@@ -793,6 +808,7 @@ export const AdapterLive = Layer.effect(
       dlmm: DLMM,
     ): Effect.Effect<{ activeBin: number; bins: BinLiquidity[] }, Error> {
       return Effect.gen(function* () {
+        pruneActiveBinMemo();
         const memo = activeBinMemo.get(poolAddress);
         if (
           memo &&

--- a/engine/adapter-service.ts
+++ b/engine/adapter-service.ts
@@ -806,6 +806,7 @@ export const AdapterLive = Layer.effect(
     function memoizedBinsAround(
       poolAddress: string,
       dlmm: DLMM,
+      halfRange: number,
     ): Effect.Effect<{ activeBin: number; bins: BinLiquidity[] }, Error> {
       return Effect.gen(function* () {
         pruneActiveBinMemo();
@@ -817,7 +818,9 @@ export const AdapterLive = Layer.effect(
         ) {
           return memo.binsAround;
         }
-        const bins = yield* Effect.tryPromise(() => dlmm.getBinsAroundActiveBin(20, 20));
+        const bins = yield* Effect.tryPromise(() =>
+          dlmm.getBinsAroundActiveBin(halfRange, halfRange),
+        );
         // The bins fetch carries its OWN active-bin snapshot (the SDK reads
         // the active bin internally): align the memo with it so binId/price
         // and binsAround always describe the SAME point in time — retaining
@@ -2311,7 +2314,7 @@ export const AdapterLive = Layer.effect(
           // uninitialized bins with zero-amount placeholders, which is the
           // truthful "empty bin" representation. Memoized with the active bin
           // so getPoolState + getBinArray share one fetch pair.
-          const realBins = yield* memoizedBinsAround(poolAddress, dlmm).pipe(
+          const realBins = yield* memoizedBinsAround(poolAddress, dlmm, halfRange).pipe(
             Effect.catch((err) => {
               logger.warn(
                 "Real bin reserves unavailable — bin-derived metrics will be marked unknown",


### PR DESCRIPTION
The performance audit's RPC-dedup — revalidated via codegraph (evaluatePool complexity 815) and direct code tracing before building.

## The waste (verified)
- `getActiveBin` fetched **twice per pool per cycle** — `getPoolState` (adapter-service.ts:2178) and `getBinArray` (:2220) both call the SDK's uncached active-bin fetch.
- `getBinsAroundActiveBin` (:2230) re-fetches the same bin array `getActiveBin` just loaded.
- ~7 RPC/pool/cycle → the doc's "100–200 RPS breaks standard tiers" is understated ~2× at 500 pools.

## The fix
A **short-TTL (3s) active-bin memo** shared by `getPoolState` + `getBinArray`:
- the within-cycle pair (milliseconds apart) costs ONE SDK fetch each;
- invalidated alongside the balance caches on every mutation (enter/exit/rebalance/claim);
- a later cycle past the TTL refetches fresh on-chain state — strictly tighter than the 5-min DLMM instance cache.

Net: ~3 RPC/pool/cycle removed (~7 → ~4), **zero behavior change**.

## Tests — 46 new (1729 total, +46)
- **2 memo proofs**: the pair shares one `getActiveBin` + one `getBinsAroundActiveBin` fetch; the memo expires past the 3s TTL on the same layer.
- **24 launch-gate boundaries**: age/TVL/volume/binStep/turnover exact edges, the 60s clock-skew tolerance, token-leg failures (unverified/stable/freeze), summarize slice + tie ordering, NaN/zero fee yields.
- **7 wash-forensics + 9 runner-dip thresholds**: exactly-at `WASH_MIN_TRADES`/unique-payer-rate/TPS, `stepPct` one-basis-point edges, max-steps, sizing caps, config-extreme dip anchors.
- **4 decision-loop edges** (3 subagents, files owned exclusively): no exit-and-reenter in one pass, timebox beats a runner scale-in, the wash gate rejects suspicious evidence, the launch-cap boundary.

Full suite 1729/1729; tsc 0; oxlint 0.

## Summary by Sourcery

Memoize DLMM active-bin and surrounding bin data per pool with a short TTL to reduce redundant RPCs while preserving behavior, and strengthen test coverage around launch gating, runner scale-in dip logic, wash-trade forensics thresholds, and decision-loop edge cases.

Tests:
- Add adapter active-bin memoization tests to verify shared SDK fetches across getPoolState/getBinArray and TTL expiry behavior.
- Extend launch-gate tests to cover boundary conditions for age, TVL, volume, binStep, turnover, token safety, fee-yield handling, and rejection summarization ordering and slicing.
- Expand runner dip and scale-in tests to validate dip anchor calculations, step triggers and limits, and top-up sizing constraints at configuration boundaries.
- Enhance wash-forensics tests to assert wash detection thresholds for trade count, unique payer rate, burst TPS, single-payer floors, and fee coefficient-of-variation computation.
- Add decision-loop tests to ensure no exit-and-reenter in a single pass, that timebox exits preempt runner scale-ins, that wash forensics can block unsafe launch ENTERs, and that launch-cap limits reject excess positions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced repeated pool-state and bin-array requests by reusing active-bin data for up to 3 seconds.
  * Keeps related liquidity data aligned and refreshes cached information after balance or position changes.
  * Prunes expired cached data automatically to maintain current results.

* **Tests**
  * Expanded coverage for launch eligibility, position limits, scale-in and top-up boundaries, wash-trading detection, fee calculations, edge cases, and memoized data requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->